### PR TITLE
Fix elf32 linker

### DIFF
--- a/Source/Mosa.Compiler.Linker/Elf32/CodeSection.cs
+++ b/Source/Mosa.Compiler.Linker/Elf32/CodeSection.cs
@@ -17,8 +17,8 @@ namespace Mosa.Compiler.Linker.Elf32
 		/// <summary>
 		/// Initializes a new instance of the <see cref="CodeSection"/> class.
 		/// </summary>
-		public CodeSection()
-			: base(SectionKind.Text, @".text", 0)
+		public CodeSection(long virtualAddress)
+			: base(SectionKind.Text, @".text", virtualAddress)
 		{
 			header.Type = SectionType.ProgBits;
 			header.Flags = SectionAttribute.AllocExecute;

--- a/Source/Mosa.Compiler.Linker/Elf32/Elf32LinkerSection.cs
+++ b/Source/Mosa.Compiler.Linker/Elf32/Elf32LinkerSection.cs
@@ -55,6 +55,7 @@ namespace Mosa.Compiler.Linker.Elf32
 		public virtual void Write(BinaryWriter writer)
 		{
 			Header.Offset = (uint)writer.BaseStream.Position;
+			stream.Seek(0, SeekOrigin.Begin);
 			stream.WriteTo(writer.BaseStream);
 		}
 
@@ -65,6 +66,7 @@ namespace Mosa.Compiler.Linker.Elf32
 		public virtual void WriteHeader(BinaryWriter writer)
 		{
 			Header.Size = (uint)Length;
+			Header.Address = (uint)VirtualAddress;
 			Header.Write(writer);
 		}
 	}

--- a/Source/Mosa.Compiler.Linker/Elf32/SectionHeader.cs
+++ b/Source/Mosa.Compiler.Linker/Elf32/SectionHeader.cs
@@ -89,7 +89,6 @@ namespace Mosa.Compiler.Linker.Elf32
 		/// <param name="writer">The writer.</param>
 		public void Write(BinaryWriter writer)
 		{
-			Address = (uint)writer.BaseStream.Position;
 			writer.Write(Name);
 			writer.Write((uint)Type);
 			writer.Write((uint)Flags);


### PR DESCRIPTION
This commit fixes ELF32 linker target enough to make it usable with syslinux's multiboot loader, qemu's -kernel multiboot loader and objdump/elfutils
