### PR TITLE
Add Object.Equals tests for boxed primitive types

### DIFF
--- a/Source/Mosa.Test.Collection.x86.xUnit/BoxingFixture.cs
+++ b/Source/Mosa.Test.Collection.x86.xUnit/BoxingFixture.cs
@@ -100,5 +100,82 @@ namespace Mosa.Test.Collection.x86.xUnit
 		{
 			Assert.Equal(BoxingTests.BoxC(value), Run<char>("Mosa.Test.Collection.BoxingTests.BoxC", value));
 		}
+
+		[Theory]
+		[PropertyData("U1")]
+		public void EqualsU1(byte value)
+		{
+			Assert.Equal(true, Run<bool>("Mosa.Test.Collection.BoxingTests.EqualsU1", value));
+		}
+
+		[Theory]
+		[PropertyData("U2")]
+		public void EqualsU2(ushort value)
+		{
+			Assert.Equal(true, Run<bool>("Mosa.Test.Collection.BoxingTests.EqualsU2", value));
+		}
+
+		[Theory]
+		[PropertyData("U4")]
+		public void EqualsU4(uint value)
+		{
+			Assert.Equal(true, Run<bool>("Mosa.Test.Collection.BoxingTests.EqualsU4", value));
+		}
+
+		[Theory]
+		[PropertyData("U8")]
+		public void EqualsU8(ulong value)
+		{
+			Assert.Equal(true, Run<bool>("Mosa.Test.Collection.BoxingTests.EqualsU8", value));
+		}
+
+		[Theory]
+		[PropertyData("I1")]
+		public void EqualsI1(sbyte value)
+		{
+			Assert.Equal(true, Run<bool>("Mosa.Test.Collection.BoxingTests.EqualsI1", value));
+		}
+
+		[Theory]
+		[PropertyData("I2")]
+		public void EqualsI2(short value)
+		{
+			Assert.Equal(true, Run<bool>("Mosa.Test.Collection.BoxingTests.EqualsI2", value));
+		}
+
+		[Theory]
+		[PropertyData("I4")]
+		public void EqualsI4(int value)
+		{
+			Assert.Equal(true, Run<bool>("Mosa.Test.Collection.BoxingTests.EqualsI4", value));
+		}
+
+		[Theory]
+		[PropertyData("I8")]
+		public void EqualsI8(long value)
+		{
+			Assert.Equal(true, Run<bool>("Mosa.Test.Collection.BoxingTests.EqualsI8", value));
+		}
+
+		[Theory]
+		[PropertyData("R4NotNaN")]
+		public void EqualsR4(float value)
+		{
+			Assert.Equal(true, Run<bool>("Mosa.Test.Collection.BoxingTests.EqualsR4", value));
+		}
+
+		[Theory]
+		[PropertyData("R8NotNaN")]
+		public void EqualsR8(double value)
+		{
+			Assert.Equal(true, Run<bool>("Mosa.Test.Collection.BoxingTests.EqualsR8", value));
+		}
+
+		[Theory]
+		[PropertyData("C")]
+		public void EqualsC(char value)
+		{
+			Assert.Equal(true, Run<bool>("Mosa.Test.Collection.BoxingTests.EqualsC", value));
+		}
 	}
 }

--- a/Source/Mosa.Test.Collection/BoxingTests.cs
+++ b/Source/Mosa.Test.Collection/BoxingTests.cs
@@ -5,83 +5,149 @@ namespace Mosa.Test.Collection
 
 	public static class BoxingTests 
 	{
-			
+		
+	
 		public static byte BoxU1(byte value) 
 		{
 			object o = value;
 			return (byte)o;
 		}
 
-		
+		public static bool EqualsU1(byte value)
+		{
+			object o = value;
+			return o.Equals(value);
+		}
+	
+	
 		public static ushort BoxU2(ushort value) 
 		{
 			object o = value;
 			return (ushort)o;
 		}
 
-		
+		public static bool EqualsU2(ushort value)
+		{
+			object o = value;
+			return o.Equals(value);
+		}
+	
+	
 		public static uint BoxU4(uint value) 
 		{
 			object o = value;
 			return (uint)o;
 		}
 
-		
+		public static bool EqualsU4(uint value)
+		{
+			object o = value;
+			return o.Equals(value);
+		}
+	
+	
 		public static ulong BoxU8(ulong value) 
 		{
 			object o = value;
 			return (ulong)o;
 		}
 
-		
+		public static bool EqualsU8(ulong value)
+		{
+			object o = value;
+			return o.Equals(value);
+		}
+	
+	
 		public static sbyte BoxI1(sbyte value) 
 		{
 			object o = value;
 			return (sbyte)o;
 		}
 
-		
+		public static bool EqualsI1(sbyte value)
+		{
+			object o = value;
+			return o.Equals(value);
+		}
+	
+	
 		public static short BoxI2(short value) 
 		{
 			object o = value;
 			return (short)o;
 		}
 
-		
+		public static bool EqualsI2(short value)
+		{
+			object o = value;
+			return o.Equals(value);
+		}
+	
+	
 		public static int BoxI4(int value) 
 		{
 			object o = value;
 			return (int)o;
 		}
 
-		
+		public static bool EqualsI4(int value)
+		{
+			object o = value;
+			return o.Equals(value);
+		}
+	
+	
 		public static long BoxI8(long value) 
 		{
 			object o = value;
 			return (long)o;
 		}
 
-		
+		public static bool EqualsI8(long value)
+		{
+			object o = value;
+			return o.Equals(value);
+		}
+	
+	
 		public static float BoxR4(float value) 
 		{
 			object o = value;
 			return (float)o;
 		}
 
-		
+		public static bool EqualsR4(float value)
+		{
+			object o = value;
+			return o.Equals(value);
+		}
+	
+	
 		public static double BoxR8(double value) 
 		{
 			object o = value;
 			return (double)o;
 		}
 
-		
+		public static bool EqualsR8(double value)
+		{
+			object o = value;
+			return o.Equals(value);
+		}
+	
+	
 		public static char BoxC(char value) 
 		{
 			object o = value;
 			return (char)o;
 		}
 
+		public static bool EqualsC(char value)
+		{
+			object o = value;
+			return o.Equals(value);
 		}
+	
+	}
 }
-			

--- a/Source/Mosa.Test.Collection/BoxingTests.tt
+++ b/Source/Mosa.Test.Collection/BoxingTests.tt
@@ -14,7 +14,11 @@ namespace Mosa.Test.Collection
 			return (<#= number.Key #>)o;
 		}
 
+		public static bool Equals<#= number.Value #>(<#= number.Key #> value)
+		{
+			object o = value;
+			return o.Equals(value);
+		}
 	<# } #>
 	}
 }
-			

--- a/Source/Mosa.Test.Numbers/Combinations.cs
+++ b/Source/Mosa.Test.Numbers/Combinations.cs
@@ -656,6 +656,15 @@ namespace Mosa.Test.Numbers
 			}
 		}
 
+		public static IEnumerable<object[]> R4NotNaN
+		{
+			get
+			{
+				foreach (var i1 in Series.R4NotNaN)
+					yield return new object[] { i1 };
+			}
+		}
+
 		public static IEnumerable<object[]> R4R4
 		{
 			get
@@ -682,6 +691,15 @@ namespace Mosa.Test.Numbers
 			get
 			{
 				foreach (var i1 in Mosa.Test.Numbers.R8.Series)
+					yield return new object[] { i1 };
+			}
+		}
+
+		public static IEnumerable<object[]> R8NotNaN
+		{
+			get
+			{
+				foreach (var i1 in Series.R8NotNaN)
 					yield return new object[] { i1 };
 			}
 		}

--- a/Source/Mosa.TinyCPUSimulator.TestSystem/TestFixture.cs
+++ b/Source/Mosa.TinyCPUSimulator.TestSystem/TestFixture.cs
@@ -165,11 +165,15 @@ namespace Mosa.TinyCPUSimulator.TestSystem
 
 		public static IEnumerable<object[]> R4 { get { return Combinations.R4; } }
 
+		public static IEnumerable<object[]> R4NotNaN { get { return Combinations.R4NotNaN; } }
+
 		public static IEnumerable<object[]> R4R4 { get { return Combinations.R4R4; } }
 
 		public static IEnumerable<object[]> R4MiniR4MiniR4Mini { get { return Combinations.R4MiniR4MiniR4Mini; } }
 
 		public static IEnumerable<object[]> R8 { get { return Combinations.R8; } }
+
+		public static IEnumerable<object[]> R8NotNaN { get { return Combinations.R8NotNaN; } }
 
 		public static IEnumerable<object[]> R8R8 { get { return Combinations.R8R8; } }
 


### PR DESCRIPTION
This was supposed to showcase an issue with I1/I2 comparisons (which was fixed some time ago). Instead it shows a problem with boxing - virtual methods called from boxed value types work incorrectly because they expect a "self" pointer to a valuetype layout but they get a reference type layout with some extra fields prepended to the expected layout. So basically method table should point to some sort of thunks to fixup the pointer before passing control to actual methods; I don't know how to do that so here are just the tests to highlight this issue.
