### PR TITLE
Separation of concerns

### DIFF
--- a/Source/Korlib/System.Runtime.CompilerServices/RuntimeHelpers.cs
+++ b/Source/Korlib/System.Runtime.CompilerServices/RuntimeHelpers.cs
@@ -11,7 +11,7 @@ namespace System.Runtime.CompilerServices
 {
 	public static class RuntimeHelpers
 	{
-		[DllImport("Mosa.Compiler.Framework.Intrinsics.InternalInitializeArray, Mosa.Compiler.Framework")]
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		public static extern void InitializeArray(Array array, RuntimeFieldHandle fldHandle);
 	}
 }

--- a/Source/Korlib/System/String.cs
+++ b/Source/Korlib/System/String.cs
@@ -113,7 +113,7 @@ namespace System
 		////[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		////public unsafe extern String(char* value, int startIndex, int length);
 
-		[DllImportAttribute(@"Mosa.Compiler.Framework.Intrinsics.InternalAllocateString, Mosa.Compiler.Framework")]
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		internal static extern string InternalAllocateString(int length);
 
 		private static unsafe string CreateString(char c, int count)

--- a/Source/Korlib/System/Type.cs
+++ b/Source/Korlib/System/Type.cs
@@ -9,6 +9,7 @@
 
 using System.Runtime.InteropServices;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace System
 {
@@ -58,7 +59,7 @@ namespace System
 			return new Type(handle);
 		}
 
-		[DllImport("Mosa.Compiler.Framework.Intrinsics.InternalGetType, Mosa.Compiler.Framework")]
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		public static extern RuntimeTypeHandle GetTypeHandle(object obj);
 
 		public override string ToString()

--- a/Source/Mosa.Compiler.Common/Mosa.Compiler.Common.csproj
+++ b/Source/Mosa.Compiler.Common/Mosa.Compiler.Common.csproj
@@ -41,6 +41,7 @@
     <Compile Include="InvalidCompilerException.cs" />
     <Compile Include="NotImplementCompilerException.cs" />
     <Compile Include="CompilerException.cs" />
+    <Compile Include="ReplacementTargetAttribute.cs" />
     <Compile Include="SimplePriorityQueue.cs" />
     <Compile Include="Endianness .cs" />
     <Compile Include="ListExtension.cs" />

--- a/Source/Mosa.Compiler.Common/ReplacementTargetAttribute.cs
+++ b/Source/Mosa.Compiler.Common/ReplacementTargetAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Mosa.Compiler.Common
+{
+	/// <summary>
+	/// Used for defining targets when using intrinsic replacements
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Class)]
+	public class ReplacementTargetAttribute : Attribute
+	{
+		public string Target
+		{
+			get;
+			private set;
+		}
+
+		public ReplacementTargetAttribute(string target)
+		{
+			this.Target = target;
+		}
+	}
+}

--- a/Source/Mosa.Compiler.Framework/Intrinsics/InternalAllocateString.cs
+++ b/Source/Mosa.Compiler.Framework/Intrinsics/InternalAllocateString.cs
@@ -7,12 +7,14 @@
  *  Michael Ruck (grover) <sharpos@michaelruck.de>
  */
 
+using Mosa.Compiler.Common;
 using Mosa.Compiler.Framework.IR;
 using Mosa.Compiler.MosaTypeSystem;
 using System.Diagnostics;
 
 namespace Mosa.Compiler.Framework.Intrinsics
 {
+	[ReplacementTarget("System.String::InternalAllocateString")]
 	public sealed class InternalAllocateString : IIntrinsicInternalMethod
 	{
 		private const string StringClassMethodTableSymbolName = @"System.String$mtable";

--- a/Source/Mosa.Compiler.Framework/Intrinsics/InternalGetType.cs
+++ b/Source/Mosa.Compiler.Framework/Intrinsics/InternalGetType.cs
@@ -5,11 +5,13 @@
  *
  */
 
+using Mosa.Compiler.Common;
 using Mosa.Compiler.Framework.IR;
 using System.Diagnostics;
 
 namespace Mosa.Compiler.Framework.Intrinsics
 {
+	[ReplacementTarget("System.Type::GetTypeHandle")]
 	public sealed class InternalGetType : IIntrinsicInternalMethod
 	{
 		/// <summary>

--- a/Source/Mosa.Compiler.Framework/Intrinsics/InternalInitializeArray.cs
+++ b/Source/Mosa.Compiler.Framework/Intrinsics/InternalInitializeArray.cs
@@ -5,12 +5,14 @@
  *
  */
 
+using Mosa.Compiler.Common;
 using Mosa.Compiler.Framework.IR;
 using Mosa.Compiler.MosaTypeSystem;
 using System.Diagnostics;
 
 namespace Mosa.Compiler.Framework.Intrinsics
 {
+	[ReplacementTarget("System.Runtime.CompilerServices.RuntimeHelpers::InitializeArray")]
 	public sealed class InternalInitializeArray : IIntrinsicInternalMethod
 	{
 		/// <summary>

--- a/Source/Mosa.Compiler.Framework/Stages/CILTransformationStage.cs
+++ b/Source/Mosa.Compiler.Framework/Stages/CILTransformationStage.cs
@@ -18,6 +18,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Reflection;
+using System.Linq;
 
 namespace Mosa.Compiler.Framework.Stages
 {
@@ -29,6 +31,30 @@ namespace Mosa.Compiler.Framework.Stages
 	/// </remarks>
 	public sealed class CILTransformationStage : BaseCodeTransformationStage, CIL.ICILVisitor, IPipelineStage
 	{
+		private Dictionary<string, Type> intrinsicTypes = new Dictionary<string, Type>();
+
+		protected override void Run()
+		{
+			// Get all the classes that implement the IIntrinsicInternalMethod interface
+			IEnumerable<Type> types = AppDomain.CurrentDomain.GetAssemblies()
+				.SelectMany(s => s.GetTypes())
+				.Where(p => typeof(IIntrinsicInternalMethod).IsAssignableFrom(p) && p.IsClass);
+
+			// Iterate through all the found types
+			foreach (Type t in types)
+			{
+				// Now get all the ReplacementTarget attributes
+				ReplacementTargetAttribute[] attributes = (ReplacementTargetAttribute[])t.GetCustomAttributes(typeof(ReplacementTargetAttribute), true);
+				for (int i = 0; i < attributes.Length; i++)
+				{
+					// Finally add the dictionary entry mapping the target string and the type
+					intrinsicTypes.Add(attributes[i].Target, t);
+				}
+			}
+			
+			base.Run();
+		}
+
 		#region ICILVisitor
 
 		/// <summary>
@@ -1693,13 +1719,16 @@ namespace Mosa.Compiler.Framework.Stages
 		private bool ProcessExternalCall(Context context)
 		{
 			string external = context.MosaMethod.ExternMethod;
+			bool isInternal = context.MosaMethod.IsInternal;
 
-			if (external == null)
-				return false;
+			Type intrinsicType = null;
 
-			//TODO: Verify!
-
-			Type intrinsicType = Type.GetType(external);
+			if (external != null)
+				intrinsicType = Type.GetType(external);
+			else if (isInternal)
+				intrinsicTypes.TryGetValue(context.MosaMethod.FullName, out intrinsicType);
+				if (intrinsicType == null)
+					intrinsicTypes.TryGetValue(context.MosaMethod.DeclaringType.FullName + "::" + context.MosaMethod.Name, out intrinsicType);
 
 			if (intrinsicType == null)
 				return false;


### PR DESCRIPTION
Korlib should not be burdened with knowing how we are going to modify
its internal calls during compilation.

This fixes that by sticking to standard MethodImpl attributes and then
having the compiler dictate the modification of internal calls.
