### PR TITLE
Lower page table mapping

### DIFF
--- a/Source/Mosa.Kernel.x86/PageTable.cs
+++ b/Source/Mosa.Kernel.x86/PageTable.cs
@@ -31,8 +31,8 @@ namespace Mosa.Kernel.x86
 			for (int index = 0; index < 1024; index++)
 				Native.Set32((uint)(pageDirectory + (index * 4)), (uint)(pageTable + (index * 4096) | 0x04 | 0x02 | 0x01));
 
-			// Map the first 32MB of memory (8192 4K pages)
-			for (int index = 0; index < 8192 * 16; index++) // FIXME: It's not 32MB
+			// Map the first 128MB of memory (32786 4K pages)
+			for (int index = 0; index < 1024 * 32; index++)
 				Native.Set32((uint)(pageTable + (index * 4)), (uint)(index * 4096) | 0x04 | 0x02 | 0x01);
 
 			// Set CR3 register on processor - sets page directory


### PR DESCRIPTION
Page table was mapping 512MB worth of memory.
In TinySimulator that can take a long time to process.
I've lowered it down to 128MB to speed things up.
