### PR TITLE
Allow Metadata to know about Generics

### DIFF
--- a/Source/Mosa.Compiler.Framework/CompilationScheduler.cs
+++ b/Source/Mosa.Compiler.Framework/CompilationScheduler.cs
@@ -53,7 +53,7 @@ namespace Mosa.Compiler.Framework.Stages
 
 		void ICompilationScheduler.TrackTypeAllocated(MosaType type)
 		{
-			Debug.Assert(!type.HasOpenGenericParams);
+			//Debug.Assert(!type.HasOpenGenericParams);
 
 			if (type.IsModule)
 				return;
@@ -68,7 +68,7 @@ namespace Mosa.Compiler.Framework.Stages
 
 		void ICompilationScheduler.TrackMethodInvoked(MosaMethod method)
 		{
-			Debug.Assert(!method.HasOpenGenericParams);
+			//Debug.Assert(!method.HasOpenGenericParams);
 
 			methodsInvoked.AddIfNew(method);
 
@@ -77,7 +77,7 @@ namespace Mosa.Compiler.Framework.Stages
 
 		void ICompilationScheduler.TrackFieldReferenced(MosaField field)
 		{
-			Debug.Assert(!field.FieldType.HasOpenGenericParams);
+			//Debug.Assert(!field.FieldType.HasOpenGenericParams);
 
 			(this as ICompilationScheduler).TrackTypeAllocated(field.DeclaringType);
 		}
@@ -104,9 +104,6 @@ namespace Mosa.Compiler.Framework.Stages
 			if (type.IsInterface)
 				return;
 
-			if (type.HasOpenGenericParams)
-				return;
-
 			if (type.IsInterface || type.IsPointer)
 				return;
 
@@ -123,7 +120,7 @@ namespace Mosa.Compiler.Framework.Stages
 
 		private void CompileMethod(MosaMethod method)
 		{
-			if (method.HasOpenGenericParams || method.IsAbstract)
+			if (method.IsAbstract)
 				return;
 
 			if (methodScheduled.Contains(method))

--- a/Source/Mosa.Compiler.Framework/MosaTypeLayout.cs
+++ b/Source/Mosa.Compiler.Framework/MosaTypeLayout.cs
@@ -209,9 +209,6 @@ namespace Mosa.Compiler.Framework
 			if (type.IsModule)
 				return null;
 
-			if (type.HasOpenGenericParams)
-				return null;
-
 			if (type.BaseType == null && !type.IsInterface && type.FullName != "System.Object")   // ghost types like generic params, function ptr, etc.
 				return null;
 
@@ -280,7 +277,7 @@ namespace Mosa.Compiler.Framework
 			}
 		}
 
-		private void ResolveType(MosaType type)
+		public void ResolveType(MosaType type)
 		{
 			if (type.IsModule)
 				return;
@@ -336,9 +333,6 @@ namespace Mosa.Compiler.Framework
 			Debug.Assert(type.IsInterface);
 
 			if (type.IsModule)
-				return;
-
-			if (type.HasOpenGenericParams)
 				return;
 
 			if (interfaces.Contains(type))
@@ -545,15 +539,6 @@ namespace Mosa.Compiler.Framework
 
 			foreach (var method in type.Methods)
 			{
-				/*if (method.HasOpenGenericParams)
-					continue;
-
-				if (method.IsAbstract)
-				{
-					if (!method.IsNewSlot)
-						continue;
-				}*/
-
 				if (method.IsVirtual)
 				{
 					if (method.IsNewSlot)

--- a/Source/Mosa.Compiler.Framework/Stages/MetadataStage.cs
+++ b/Source/Mosa.Compiler.Framework/Stages/MetadataStage.cs
@@ -56,10 +56,6 @@ namespace Mosa.Compiler.Framework.Stages
 			// Create the definitions along the way
 			foreach (var module in TypeSystem.Modules)
 			{
-				// Exclude Linker generated stuff for now since it's causing issues
-				if (module.IsLinkerGenerated)
-					continue;
-
 				var assemblyTableSymbol = CreateAssemblyDefinitionTable(module);
 
 				// Link
@@ -98,8 +94,9 @@ namespace Mosa.Compiler.Framework.Stages
 			uint count = 0;
 			foreach (var type in module.Types.Values)
 			{
-				if (type.IsModule/* || (type.BaseType == null && !type.IsInterface && type.FullName != "System.Object")*/)   // ghost types like generic params, function ptr, etc.
+				if (type.IsModule)
 					continue;
+
 				count++;
 			}
 			writer1.Write(count);
@@ -111,8 +108,8 @@ namespace Mosa.Compiler.Framework.Stages
 				if (type.IsModule)
 					continue;
 
-				/*if (type.BaseType == null && !type.IsInterface && type.FullName != "System.Object")   // ghost types like generic params, function ptr, etc.
-					continue;*/
+				// Run the type through the TypeLayout system
+				TypeLayout.ResolveType(type);
 
 				var typeTableSymbol = CreateTypeDefinitionTable(type, assemblyTableSymbol);
 
@@ -150,8 +147,11 @@ namespace Mosa.Compiler.Framework.Stages
 			}
 			writer1.WriteZeroBytes(TypeLayout.NativePointerSize);
 
-			// 3. Flags: IsInterface
-			writer1.Write((uint)(type.IsInterface ? 1 : 0));
+			// 3. Flags: IsInterface, HasGenericParams (32bit length)
+			uint flags = 0x0;
+			if (type.IsInterface) flags |= 0x1;
+			if (type.HasOpenGenericParams) flags |= 0x2;
+			writer1.Write(flags);
 
 			// 4. Size
 			writer1.Write((uint)TypeLayout.GetTypeSize(type));
@@ -365,13 +365,12 @@ namespace Mosa.Compiler.Framework.Stages
 
 
 			// 5. Pointer to Method
-			if (!method.IsAbstract && !method.HasOpenGenericParams)
+			if (!method.IsAbstract)
 				Linker.Link(LinkType.AbsoluteAddress, BuiltInPatch.I4, methodTableSymbol, (int)writer1.Position, 0, method.FullName, SectionKind.Text, 0);
 			writer1.WriteZeroBytes(TypeLayout.NativePointerSize);
 
 			// 6. Pointer to return Type
-			if (!method.IsAbstract && !method.HasOpenGenericParams)
-				Linker.Link(LinkType.AbsoluteAddress, BuiltInPatch.I4, methodTableSymbol, (int)writer1.Position, 0, method.Signature.ReturnType.FullName + Metadata.TypeDefinition, SectionKind.ROData, 0);
+			Linker.Link(LinkType.AbsoluteAddress, BuiltInPatch.I4, methodTableSymbol, (int)writer1.Position, 0, method.Signature.ReturnType.FullName + Metadata.TypeDefinition, SectionKind.ROData, 0);
 			writer1.WriteZeroBytes(TypeLayout.NativePointerSize);
 
 			// 7. Pointer to Exception Hanlder Table

--- a/Source/Mosa.Compiler.MosaTypeSystem/Metadata/MetadataLoader.cs
+++ b/Source/Mosa.Compiler.MosaTypeSystem/Metadata/MetadataLoader.cs
@@ -11,6 +11,7 @@ using dnlib.DotNet;
 using Mosa.Compiler.Common;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Mosa.Compiler.MosaTypeSystem.Metadata
 {
@@ -273,6 +274,7 @@ namespace Mosa.Compiler.MosaTypeSystem.Metadata
 
 		private MosaType LoadGenericParam(GenericSig sig)
 		{
+			//Debug.Assert(false, sig.FullName);
 			MosaType[] pars = sig.IsTypeVar ? var : mvar;
 			MosaType type = pars[sig.Number];
 
@@ -290,6 +292,7 @@ namespace Mosa.Compiler.MosaTypeSystem.Metadata
 					genericParam.UnderlyingObject = new UnitDesc<TypeDef, TypeSig>(null, null, sig);
 				}
 				pars[sig.Number] = type;
+				metadata.Controller.AddType(type);
 			}
 
 			return type;
@@ -297,6 +300,7 @@ namespace Mosa.Compiler.MosaTypeSystem.Metadata
 
 		private MosaType LoadGenericTypeInstanceSig(GenericInstSig typeSig)
 		{
+			//Debug.Assert(false, typeSig.FullName);
 			MosaType origin = GetType(typeSig.GenericType);
 			MosaType result = metadata.Controller.CreateType(origin);
 			var desc = result.GetUnderlyingObject<UnitDesc<TypeDef, TypeSig>>();

--- a/Source/Mosa.HelloWorld.x86/Boot.cs
+++ b/Source/Mosa.HelloWorld.x86/Boot.cs
@@ -33,6 +33,18 @@ namespace Mosa.HelloWorld.x86
 
 			IDT.SetInterruptHandler(ProcessInterrupt);
 
+			Console.Goto(24, 0);
+			Console.Color = Colors.White;
+
+			System.Threading.SpinLock splk = new System.Threading.SpinLock();
+			bool @lock = false;
+
+			if (@lock) Console.Write("This won't output!");
+			splk.Enter(ref @lock);
+			if (@lock) Console.Write("Entered!");
+			splk.Enter(ref @lock);
+			if (@lock) Console.Write("Can't get here!");
+
 			Console.Color = Colors.Yellow;
 			Console.BackgroundColor = Colors.Black;
 
@@ -281,17 +293,6 @@ namespace Mosa.HelloWorld.x86
 				else
 					Console.Write((char)186);
 			}
-
-			Console.Goto(24, 0);
-
-			System.Threading.SpinLock splk = new System.Threading.SpinLock();
-			bool @lock = false;
-
-			if (@lock) Console.Write("This won't output!");
-			splk.Enter(ref @lock);
-			if (@lock) Console.Write("Entered!");
-			splk.Enter(ref @lock);
-			if (@lock) Console.Write("Can't get here!");
 
 			Console.Goto(24, 29);
 			Console.Color = Colors.Yellow;


### PR DESCRIPTION
By allowing Metadata to know about Generics we can allow all known types
to have their metadata emitted.
