### PR TITLE
Improve TypeSystemTree

### DIFF
--- a/Source/Mosa.Compiler.MosaTypeSystem/Metadata/MetadataResolver.cs
+++ b/Source/Mosa.Compiler.MosaTypeSystem/Metadata/MetadataResolver.cs
@@ -174,7 +174,10 @@ namespace Mosa.Compiler.MosaTypeSystem.Metadata
 					mosaType.BaseType = metadata.Loader.GetType(resolver.Resolve(type.BaseType.GetTypeSig()));
 
 				if (type.DeclaringType != null)
+				{
 					mosaType.DeclaringType = metadata.Loader.GetType(resolver.Resolve(type.DeclaringType.GetTypeSig()));
+					mosaType.Namespace = type.DeclaringType.Namespace;
+				}
 
 				for (int i = 0; i < type.Interfaces.Count; i++)
 					mosaType.Interfaces[i] = metadata.Loader.GetType(resolver.Resolve(type.Interfaces[i].GetTypeSig()));

--- a/Source/Mosa.Compiler.MosaTypeSystem/Units/MosaType.cs
+++ b/Source/Mosa.Compiler.MosaTypeSystem/Units/MosaType.cs
@@ -287,14 +287,14 @@ namespace Mosa.Compiler.MosaTypeSystem
 			{
 				SignatureName.UpdateType(type);
 				StringBuilder fName = new StringBuilder();
-				if (!string.IsNullOrEmpty(type.Namespace))
-				{
-					fName.Append(type.Namespace);
-					fName.Append(".");
-				}
-				else if (type.DeclaringType != null)
+				if (type.DeclaringType != null && type.DeclaringType != type.ElementType)
 				{
 					fName.Append(type.DeclaringType.FullName);
+					fName.Append("+");
+				}
+				else if (!string.IsNullOrEmpty(type.Namespace))
+				{
+					fName.Append(type.Namespace);
 					fName.Append(".");
 				}
 				fName.Append(type.Name);

--- a/Source/Mosa.Utility.GUI.Common/TypeSystemTree.cs
+++ b/Source/Mosa.Utility.GUI.Common/TypeSystemTree.cs
@@ -9,6 +9,8 @@
 
 using Mosa.Compiler.Framework;
 using Mosa.Compiler.MosaTypeSystem;
+using System.Linq;
+using System.Collections.Generic;
 using System.Windows.Forms;
 
 namespace Mosa.Utility.GUI.Common
@@ -22,13 +24,35 @@ namespace Mosa.Utility.GUI.Common
 
 			foreach (var module in typeSystem.Modules)
 			{
+				List<TreeNode> namespaces = new List<TreeNode>();
+
 				TreeNode moduleNode = new TreeNode(module.Name);
 				treeView.Nodes.Add(moduleNode);
 
-				foreach (MosaType type in module.Types.Values)
+				List<MosaType> typeList = (new List<MosaType>(module.Types.Values)).OrderBy(o=>o.FullName).ToList();
+
+				foreach (MosaType type in typeList)
 				{
+					TreeNode namespaceNode = null;
+					string @namespace = (string.IsNullOrWhiteSpace(type.Namespace)) ? "[No Namespace]" : type.Namespace;
+					foreach (TreeNode node in namespaces)
+					{
+						if (node.Text.Equals(@namespace))
+						{
+							namespaceNode = node;
+							break;
+						}
+					}
+
+					if (namespaceNode == null)
+					{
+						namespaceNode = new TreeNode(@namespace);
+						moduleNode.Nodes.Add(namespaceNode);
+						namespaces.Add(namespaceNode);
+					}
+
 					TreeNode typeNode = new TreeNode(type.FullName);
-					moduleNode.Nodes.Add(typeNode);
+					namespaceNode.Nodes.Add(typeNode);
 
 					if (type.BaseType != null)
 					{


### PR DESCRIPTION
Types are now segmented by namespace within their modules
Types are now sorted by name so they are easy to find
Nested types have the proper "+" qualifier instead of "."
Nested types are now placed into the same namespace as their declaring
type
