### PR TITLE
Corrected order in Kernel.Setup

### DIFF
--- a/Source/Mosa.ClassLib/FlechtersChecksum.cs
+++ b/Source/Mosa.ClassLib/FlechtersChecksum.cs
@@ -11,6 +11,11 @@ namespace Mosa.ClassLib
 	/// <remarks>Usefull to track memory changes for debugging purposes</remarks>
 	public static class FlechterChecksum
 	{
+		unsafe public static ushort Fletcher16(uint startAddress, uint bytes)
+		{
+			return Fletcher16((byte*)startAddress, bytes);
+		}
+
 		unsafe public static ushort Fletcher16(byte* data, uint bytes)
 		{
 			ushort sum1 = 0xff, sum2 = 0xff;

--- a/Source/Mosa.ClassLib/FlechtersChecksum.cs
+++ b/Source/Mosa.ClassLib/FlechtersChecksum.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Mosa.ClassLib
+{
+	/// <summary>
+	/// Fast checksum algorithm.
+	/// </summary>
+	/// <remarks>Usefull to track memory changes for debugging purposes</remarks>
+	public static class FlechterChecksum
+	{
+		unsafe public static ushort Fletcher16(byte* data, uint bytes)
+		{
+			ushort sum1 = 0xff, sum2 = 0xff;
+
+			while (bytes > 0)
+			{
+				uint tlen = bytes > 20 ? 20 : bytes;
+				bytes -= tlen;
+				do
+				{
+					sum2 += sum1 += *data++;
+				} while (--tlen > 0);
+				sum1 = (ushort)((sum1 & 0xff) + (sum1 >> 8));
+				sum2 = (ushort)((sum2 & 0xff) + (sum2 >> 8));
+			}
+			/* Second reduction step to reduce sums to 8 bits */
+			sum1 = (ushort)((sum1 & 0xff) + (sum1 >> 8));
+			sum2 = (ushort)((sum2 & 0xff) + (sum2 >> 8));
+			return (ushort)(sum2 << 8 | sum1);
+		}
+	}
+}

--- a/Source/Mosa.ClassLib/Mosa.ClassLib.csproj
+++ b/Source/Mosa.ClassLib/Mosa.ClassLib.csproj
@@ -40,6 +40,7 @@
     <WarningLevel>4</WarningLevel>
     <DebugType>full</DebugType>
     <NoStdLib>false</NoStdLib>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <BaseAddress>285212672</BaseAddress>
@@ -60,10 +61,14 @@
     <Compile Include="BinaryFormat.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="FlechtersChecksum.cs" />
     <Compile Include="Math.cs">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="RedBlackTree.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
   <PropertyGroup>

--- a/Source/Mosa.Kernel.x86/Debug.cs
+++ b/Source/Mosa.Kernel.x86/Debug.cs
@@ -40,8 +40,17 @@ namespace Mosa.Kernel.x86
 
 		private static MemoryChangedItem memoyChangedItem;
 
+		/// <summary>
+		/// Helps to track memroy changes. Checks if memroy has changed between two calls.
+		/// </summary>
+		/// <param name="startAddress"></param>
+		/// <param name="bytes"></param>
+		/// <param name="panic">Halt the kernel</param>
+		/// <param name="message">Display a custom message</param>
+		/// <returns></returns>
 		public static bool MemoryChanged(uint startAddress, uint bytes, bool panic = false, string message = null)
 		{
+			//Improvement: Allocate memory for multiple items and check for different input values.
 			var checksum = ClassLib.FlechterChecksum.Fletcher16(startAddress, bytes);
 			memoyChangedItem.bevoreLastCheckum = memoyChangedItem.lastChecksum;
 			memoyChangedItem.lastChecksum = checksum;

--- a/Source/Mosa.Kernel.x86/Debug.cs
+++ b/Source/Mosa.Kernel.x86/Debug.cs
@@ -12,7 +12,7 @@ namespace Mosa.Kernel.x86
 	/// <summary>
 	///
 	/// </summary>
-	public static class DebugTrace
+	public static class DebugUtil
 	{
 		private static uint Count = 0;
 
@@ -29,6 +29,38 @@ namespace Mosa.Kernel.x86
 			Console.Write(" - Trace: ");
 			Console.Write(location);
 			Console.WriteLine();
+		}
+
+		private struct MemoryChangedItem
+		{
+			public uint checks;
+			public ushort lastChecksum;
+			public ushort bevoreLastCheckum;
+		}
+
+		private static MemoryChangedItem memoyChangedItem;
+
+		public static bool MemoryChanged(uint startAddress, uint bytes, bool panic = false, string message = null)
+		{
+			var checksum = ClassLib.FlechterChecksum.Fletcher16(startAddress, bytes);
+			memoyChangedItem.bevoreLastCheckum = memoyChangedItem.lastChecksum;
+			memoyChangedItem.lastChecksum = checksum;
+			memoyChangedItem.checks++;
+
+			if (memoyChangedItem.checks > 1 && memoyChangedItem.bevoreLastCheckum != memoyChangedItem.lastChecksum)
+			{
+				if (panic)
+					if (message == null)
+						Panic.Error("Memory Changed Exception");
+					else
+						Panic.Error(message);
+
+				return true;
+			}
+			else
+			{
+				return false;
+			}
 		}
 	}
 }

--- a/Source/Mosa.Kernel.x86/Kernel.cs
+++ b/Source/Mosa.Kernel.x86/Kernel.cs
@@ -35,10 +35,10 @@ namespace Mosa.Kernel.x86
 			PageFrameAllocator.Setup();
 			PageTable.Setup();
 			VirtualPageAllocator.Setup();
+			ProcessManager.Setup();
 
 			//At this point we can use objects, that allocates memory
 			Runtime.Setup();
-			ProcessManager.Setup();
 			TaskManager.Setup();
 			SmbiosManager.Setup();
 			ConsoleManager.Setup();

--- a/Source/Mosa.Kernel.x86/Mosa.Kernel.x86.csproj
+++ b/Source/Mosa.Kernel.x86/Mosa.Kernel.x86.csproj
@@ -102,6 +102,10 @@
       <Project>{631bc4f3-e2d8-4319-814c-13904caa17ce}</Project>
       <Name>Korlib</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Mosa.ClassLib\Mosa.ClassLib.csproj">
+      <Project>{27a3c89c-1967-45ff-a77e-94f44995c42c}</Project>
+      <Name>Mosa.ClassLib</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Mosa.Internal\Mosa.Internal.csproj">
       <Project>{77961864-DB33-4189-804F-D774022C96E2}</Project>
       <Name>Mosa.Internal</Name>

--- a/Source/Mosa.Kernel.x86/PageTable.cs
+++ b/Source/Mosa.Kernel.x86/PageTable.cs
@@ -17,7 +17,7 @@ namespace Mosa.Kernel.x86
 	/// <summary>
 	///
 	/// </summary>
-	public static class PageTable_
+	public static class PageTable
 	{
 		// Location for page directory starts at 20MB
 		private static uint pageDirectory = 1024 * 1024 * 20; // 0x1400000
@@ -30,6 +30,8 @@ namespace Mosa.Kernel.x86
 		/// </summary>
 		public static void Setup()
 		{
+			Memory.Clear(pageTable, 1024 * 1024 * 4);
+
 			// Setup Page Directory
 			for (int index = 0; index < 1024; index++)
 			{
@@ -77,7 +79,7 @@ namespace Mosa.Kernel.x86
 		}
 	}
 
-	unsafe public static class PageTable
+	unsafe public static class PageTable_
 	{
 		// Location for page directory starts at 20MB
 		private static uint pageDirectoryAddress = 1024 * 1024 * 20; // 0x1400000

--- a/Source/Mosa.Kernel.x86/PageTable.cs
+++ b/Source/Mosa.Kernel.x86/PageTable.cs
@@ -7,14 +7,17 @@
  *  Phil Garcia (tgiphil) <phil@thinkedge.com>
  */
 
+using Mosa.Kernel.Helpers;
+using Mosa.Kernel.x86.Helpers;
 using Mosa.Platform.Internal.x86;
+using System.Runtime.InteropServices;
 
 namespace Mosa.Kernel.x86
 {
 	/// <summary>
 	///
 	/// </summary>
-	public static class PageTable
+	public static class PageTable_
 	{
 		// Location for page directory starts at 20MB
 		private static uint pageDirectory = 1024 * 1024 * 20; // 0x1400000
@@ -44,6 +47,11 @@ namespace Mosa.Kernel.x86
 
 			// Set CR0 register on processor - turns on virtual memory
 			Native.SetCR0(Native.GetCR0() | 0x80000000);
+
+			unsafe
+			{
+				//Panic.Error(Mosa.ClassLib.FlechterChecksum.Fletcher16((byte*)pageDirectory, PageTable_.PageDirectorySize));
+			}
 		}
 
 		/// <summary>
@@ -66,6 +74,322 @@ namespace Mosa.Kernel.x86
 		{
 			//FUTURE: traverse page directory from CR3 --- do not assume page table is linearly allocated
 			return Native.Get32(pageTable + ((virtualAddress & 0xFFFFF000) >> 10)) + (virtualAddress & 0xFFF);
+		}
+	}
+
+	unsafe public static class PageTable
+	{
+		// Location for page directory starts at 20MB
+		private static uint pageDirectoryAddress = 1024 * 1024 * 20; // 0x1400000
+
+		// Location for page tables start at 16MB
+		private static uint pageTableAddress = 1024 * 1024 * 16;	// 0x1000000
+
+		internal static PageDirectoryEntry* pageDirectoryEntries;
+		internal static PageTableEntry* pageTableEntries;
+
+		//We can have up to 1024 PageDirectories
+		public const uint PageDirectoryCount = 1024;
+
+		public const uint PageDirectorySize = PageDirectoryCount * PageDirectoryEntry.EntrySize;
+
+		//For each PageDirectory, we can have up to 1024 PageTables
+		public const uint PageTableCount = 1024;
+
+		public const uint PageTableSize = PageTableCount * PageTableEntry.EntrySize; //Size of 1024 PageTables
+
+		public const uint PageTablesMaxCount = PageDirectoryCount * PageTableCount; //The sum of 1024 PageTables in 1024 PageDirectories
+		public const uint PageTablesMaxSize = PageTablesMaxCount * PageTableEntry.EntrySize;  //Size of 1024 PageTables in 1024 PageDirectories
+
+		/// <summary>
+		/// Sets up the PageTable
+		/// </summary>
+		public static void Setup()
+		{
+			pageDirectoryEntries = (PageDirectoryEntry*)pageDirectoryAddress;
+			pageTableEntries = (PageTableEntry*)pageTableAddress;
+
+			ClearPageDirectory();
+			ClearPageTable();
+
+			// Map the first 256MB of memory (65536 4K pages) (why 256MB?)
+			for (uint index = 0; index < 1024 * 64; index++)
+				AllocatePage();
+
+			//Panic.DumpMemory(pageDirectoryAddress);
+
+			// Set CR3 register on processor - sets page directory
+			Native.SetCR3(pageDirectoryAddress);
+
+			// Set CR0 register on processor - turns on virtual memory
+			Native.SetCR0(Native.GetCR0() | BitMask.Bit31);
+
+			unsafe
+			{
+				//Panic.Error(Mosa.ClassLib.FlechterChecksum.Fletcher16((byte*)pageDirectoryAddress, PageDirectorySize));
+			}
+		}
+
+		public static void ClearPageDirectory()
+		{
+			Memory.Clear(pageDirectoryAddress, PageDirectorySize);
+		}
+
+		public static void ClearPageTable()
+		{
+			Memory.Clear(pageTableAddress, PageTablesMaxSize);
+		}
+
+		internal static PageDirectoryEntry* GetPageDirectoryEntry(uint index)
+		{
+			Assert.InRange(index, PageDirectoryCount);
+			return pageDirectoryEntries + index;
+		}
+
+		public static PageTableEntry* GetPageTableEntry(uint index)
+		{
+			Assert.InRange(index, PageTablesMaxCount);
+			return pageTableEntries + index;
+		}
+
+		private static uint currentDictionaryEntryCount;
+		private static uint currentTableEntryCount;
+		private static uint allTableEntryCount;
+
+		private static PageDirectoryEntry* RegisterPage(PageTableEntry* page)
+		{
+			if (currentDictionaryEntryCount == 0 || currentTableEntryCount == 1024)
+			{
+				currentDictionaryEntryCount++;
+				var dicEntry = GetPageDirectoryEntry(currentDictionaryEntryCount - 1);
+				dicEntry->PageTableEntry = page;
+				dicEntry->Present = true;
+				dicEntry->Writable = true;
+				dicEntry->User = true;
+				currentTableEntryCount = 0;
+			}
+			return GetPageDirectoryEntry(currentDictionaryEntryCount - 1);
+		}
+
+		public static void AllocatePage()
+		{
+			currentTableEntryCount++;
+			allTableEntryCount++;
+
+			var tabEntry = GetPageTableEntry(allTableEntryCount - 1);
+			tabEntry->PhysicalAddress = (allTableEntryCount - 1) * 4096;
+			tabEntry->Present = true;
+			tabEntry->Writable = true;
+			tabEntry->User = true;
+
+			RegisterPage(tabEntry);
+		}
+
+		/// <summary>
+		/// Maps the virtual address to physical.
+		/// </summary>
+		/// <param name="virtualAddress">The virtual address.</param>
+		/// <param name="physicalAddress">The physical address.</param>
+		public static void MapVirtualAddressToPhysical(uint virtualAddress, uint physicalAddress)
+		{
+			//FUTURE: traverse page directory from CR3 --- do not assume page table is linearly allocated
+			Native.Set32(pageTableAddress + ((virtualAddress & 0xFFC00000) >> 10), (uint)(physicalAddress & 0xFFC00000 | 0x04 | 0x02 | 0x01));
+		}
+
+		/// <summary>
+		/// Gets the physical memory.
+		/// </summary>
+		/// <param name="virtualAddress">The virtual address.</param>
+		/// <returns></returns>
+		public static uint GetPhysicalAddressFromVirtual(uint virtualAddress)
+		{
+			//FUTURE: traverse page directory from CR3 --- do not assume page table is linearly allocated
+			return Native.Get32(pageTableAddress + ((virtualAddress & 0xFFFFF000) >> 10)) + (virtualAddress & 0xFFF);
+		}
+	}
+
+	[StructLayout(LayoutKind.Explicit, Size = 4)]
+	unsafe public struct PageDirectoryEntry
+	{
+		[FieldOffset(0)]
+		private uint data;
+
+		public const byte EntrySize = 4;
+
+		private class Offset
+		{
+			public const byte Present = 0;
+			public const byte Readonly = 1;
+			public const byte User = 2;
+			public const byte WriteThrough = 3;
+			public const byte DisableCache = 4;
+			public const byte Accessed = 5;
+			private const byte UNKNOWN6 = 6;
+			public const byte PageSize4Mib = 7;
+			private const byte IGNORED8 = 8;
+			public const byte Custom = 9;
+			public const byte Address = 12;
+		}
+
+		private const byte AddressBitSize = 20;
+		private const uint AddressMask = 0xFFFFF000;
+
+		private uint PageTableAddress
+		{
+			get { return data & AddressMask; }
+			set
+			{
+				Assert.True(value << AddressBitSize == 0, "PageDirectoryEntry.Address needs to be 4k aligned");
+				data = data.SetBits(Offset.Address, AddressBitSize, value, Offset.Address);
+			}
+		}
+
+		internal PageTableEntry* PageTableEntry
+		{
+			get { return (PageTableEntry*)PageTableAddress; }
+			set { PageTableAddress = (uint)value; }
+		}
+
+		public bool Present
+		{
+			get { return data.IsBitSet(Offset.Present); }
+			set { data = data.SetBit(Offset.Present, value); }
+		}
+
+		public bool Writable
+		{
+			get { return data.IsBitSet(Offset.Readonly); }
+			set { data = data.SetBit(Offset.Readonly, value); }
+		}
+
+		public bool User
+		{
+			get { return data.IsBitSet(Offset.User); }
+			set { data = data.SetBit(Offset.User, value); }
+		}
+
+		public bool WriteThrough
+		{
+			get { return data.IsBitSet(Offset.WriteThrough); }
+			set { data = data.SetBit(Offset.WriteThrough, value); }
+		}
+
+		public bool DisableCache
+		{
+			get { return data.IsBitSet(Offset.DisableCache); }
+			set { data = data.SetBit(Offset.DisableCache, value); }
+		}
+
+		public bool Accessed
+		{
+			get { return data.IsBitSet(Offset.Accessed); }
+			set { data = data.SetBit(Offset.Accessed, value); }
+		}
+
+		public bool PageSize4Mib
+		{
+			get { return data.IsBitSet(Offset.PageSize4Mib); }
+			set { data = data.SetBit(Offset.PageSize4Mib, value); }
+		}
+
+		public byte Custom
+		{
+			get { return (byte)data.GetBits(Offset.Custom, 2); }
+			set { data = data.SetBits(Offset.Custom, 2, value); }
+		}
+	}
+
+	[StructLayout(LayoutKind.Explicit, Size = 4)]
+	public struct PageTableEntry
+	{
+		[FieldOffset(0)]
+		private uint Value;
+
+		public const byte EntrySize = 4;
+
+		private class Offset
+		{
+			public const byte Present = 0;
+			public const byte Readonly = 1;
+			public const byte User = 2;
+			public const byte WriteThrough = 3;
+			public const byte DisableCache = 4;
+			public const byte Accessed = 5;
+			public const byte Dirty = 6;
+			private const byte SIZE0 = 7;
+			public const byte Global = 8;
+			public const byte Custom = 9;
+			public const byte Address = 12;
+		}
+
+		private const byte AddressBitSize = 20;
+		private const uint AddressMask = 0xFFFFF000;
+
+		/// <summary>
+		/// 4k aligned physical address
+		/// </summary>
+		public uint PhysicalAddress
+		{
+			get { return Value & AddressMask; }
+			set
+			{
+				Assert.True(value << AddressBitSize == 0, "PageTableEntry.PhysicalAddress needs to be 4k aligned");
+				Value = Value.SetBits(Offset.Address, AddressBitSize, value, Offset.Address);
+			}
+		}
+
+		public bool Present
+		{
+			get { return Value.IsBitSet(Offset.Present); }
+			set { Value = Value.SetBit(Offset.Present, value); }
+		}
+
+		public bool Writable
+		{
+			get { return Value.IsBitSet(Offset.Readonly); }
+			set { Value = Value.SetBit(Offset.Readonly, value); }
+		}
+
+		public bool User
+		{
+			get { return Value.IsBitSet(Offset.User); }
+			set { Value = Value.SetBit(Offset.User, value); }
+		}
+
+		public bool WriteThrough
+		{
+			get { return Value.IsBitSet(Offset.WriteThrough); }
+			set { Value = Value.SetBit(Offset.WriteThrough, value); }
+		}
+
+		public bool DisableCache
+		{
+			get { return Value.IsBitSet(Offset.DisableCache); }
+			set { Value = Value.SetBit(Offset.DisableCache, value); }
+		}
+
+		public bool Accessed
+		{
+			get { return Value.IsBitSet(Offset.Accessed); }
+			set { Value = Value.SetBit(Offset.Accessed, value); }
+		}
+
+		public bool Global
+		{
+			get { return Value.IsBitSet(Offset.Global); }
+			set { Value = Value.SetBit(Offset.Global, value); }
+		}
+
+		public bool Dirty
+		{
+			get { return Value.IsBitSet(Offset.Dirty); }
+			set { Value = Value.SetBit(Offset.Dirty, value); }
+		}
+
+		public byte Custom
+		{
+			get { return (byte)Value.GetBits(Offset.Custom, 2); }
+			set { Value = Value.SetBits(Offset.Custom, 2, value); }
 		}
 	}
 }

--- a/Source/Mosa.Kernel.x86/PageTable.cs
+++ b/Source/Mosa.Kernel.x86/PageTable.cs
@@ -14,72 +14,7 @@ using System.Runtime.InteropServices;
 
 namespace Mosa.Kernel.x86
 {
-	/// <summary>
-	///
-	/// </summary>
-	public static class PageTable
-	{
-		// Location for page directory starts at 20MB
-		private static uint pageDirectory = 1024 * 1024 * 20; // 0x1400000
-
-		// Location for page tables start at 16MB
-		private static uint pageTable = 1024 * 1024 * 16;	// 0x1000000
-
-		/// <summary>
-		/// Sets up the PageTable
-		/// </summary>
-		public static void Setup()
-		{
-			Memory.Clear(pageTable, 1024 * 1024 * 4);
-
-			// Setup Page Directory
-			for (int index = 0; index < 1024; index++)
-			{
-				Native.Set32((uint)(pageDirectory + (index << 2)), (uint)(pageTable + (index * 4096) | 0x04 | 0x02 | 0x01));
-			}
-
-			// Map the first 128MB of memory (32786 4K pages) (why 128MB?)
-			for (int index = 0; index < 1024 * 32; index++)
-			{
-				Native.Set32((uint)(pageTable + (index << 2)), (uint)(index * 4096) | 0x04 | 0x02 | 0x01);
-			}
-
-			// Set CR3 register on processor - sets page directory
-			Native.SetCR3(pageDirectory);
-
-			// Set CR0 register on processor - turns on virtual memory
-			Native.SetCR0(Native.GetCR0() | 0x80000000);
-
-			unsafe
-			{
-				//Panic.Error(Mosa.ClassLib.FlechterChecksum.Fletcher16((byte*)pageDirectory, PageTable_.PageDirectorySize));
-			}
-		}
-
-		/// <summary>
-		/// Maps the virtual address to physical.
-		/// </summary>
-		/// <param name="virtualAddress">The virtual address.</param>
-		/// <param name="physicalAddress">The physical address.</param>
-		public static void MapVirtualAddressToPhysical(uint virtualAddress, uint physicalAddress)
-		{
-			//FUTURE: traverse page directory from CR3 --- do not assume page table is linearly allocated
-			Native.Set32(pageTable + ((virtualAddress & 0xFFC00000) >> 10), (uint)(physicalAddress & 0xFFC00000 | 0x04 | 0x02 | 0x01));
-		}
-
-		/// <summary>
-		/// Gets the physical memory.
-		/// </summary>
-		/// <param name="virtualAddress">The virtual address.</param>
-		/// <returns></returns>
-		public static uint GetPhysicalAddressFromVirtual(uint virtualAddress)
-		{
-			//FUTURE: traverse page directory from CR3 --- do not assume page table is linearly allocated
-			return Native.Get32(pageTable + ((virtualAddress & 0xFFFFF000) >> 10)) + (virtualAddress & 0xFFF);
-		}
-	}
-
-	unsafe public static class PageTable_
+	unsafe public static class PageTable
 	{
 		// Location for page directory starts at 20MB
 		private static uint pageDirectoryAddress = 1024 * 1024 * 20; // 0x1400000
@@ -114,8 +49,8 @@ namespace Mosa.Kernel.x86
 			ClearPageDirectory();
 			ClearPageTable();
 
-			// Map the first 256MB of memory (65536 4K pages) (why 256MB?)
-			for (uint index = 0; index < 1024 * 64; index++)
+			// Map the first 128MB of memory (32768 4K pages) (why 128MB?)
+			for (uint index = 0; index < 1024 * 32; index++)
 				AllocatePage();
 
 			//Panic.DumpMemory(pageDirectoryAddress);


### PR DESCRIPTION
- Yesterday, i tweaked a little bit the order of the instructions in Kernel.Setup, but one of them caused the crash of HelloWorld. It's now corrected.
- Added debug method, to track memory changes. Useful, when you find out, when memory ares has changes, that should not changed (using wrong pointers, but in memory management, buffer overflow).