### PR TITLE
Updated MultiBoot

### DIFF
--- a/Source/Mosa.CoolWorld.x86/Boot.cs
+++ b/Source/Mosa.CoolWorld.x86/Boot.cs
@@ -22,9 +22,14 @@ namespace Mosa.CoolWorld.x86
 		/// <summary>
 		/// Main
 		/// </summary>
-		public static void Main()
+		unsafe public static void Main()
 		{
 			Mosa.Kernel.x86.Kernel.Setup();
+			//Panic.DumpMemory((uint)Multiboot.info->ElfSectionHeaderTable);
+			//Panic.Error(StringBuffer.CreateFromNullTerminatedString(0x66d0c8 + 1));
+			//Panic.DumpMemory((Multiboot.info->ElfSectionHeaderTable->Sections + 4)->sh_addr);
+			//Panic.DumpMemory(Multiboot.info->ElfSectionHeaderTable->shndx);
+			Panic.Error(Multiboot.MultiBootInfo->ElfSectionHeaderTable->GetSectionName(4));
 
 			Console = ConsoleManager.Controller.Boot;
 			Console.Clear();

--- a/Source/Mosa.CoolWorld.x86/Boot.cs
+++ b/Source/Mosa.CoolWorld.x86/Boot.cs
@@ -25,11 +25,6 @@ namespace Mosa.CoolWorld.x86
 		unsafe public static void Main()
 		{
 			Mosa.Kernel.x86.Kernel.Setup();
-			//Panic.DumpMemory((uint)Multiboot.info->ElfSectionHeaderTable);
-			//Panic.Error(StringBuffer.CreateFromNullTerminatedString(0x66d0c8 + 1));
-			//Panic.DumpMemory((Multiboot.info->ElfSectionHeaderTable->Sections + 4)->sh_addr);
-			//Panic.DumpMemory(Multiboot.info->ElfSectionHeaderTable->shndx);
-			Panic.Error(Multiboot.MultiBootInfo->ElfSectionHeaderTable->GetSectionName(4));
 
 			Console = ConsoleManager.Controller.Boot;
 			Console.Clear();

--- a/Source/Mosa.HelloWorld.x86/Boot.cs
+++ b/Source/Mosa.HelloWorld.x86/Boot.cs
@@ -55,7 +55,10 @@ namespace Mosa.HelloWorld.x86
 			Console.Color = Colors.Green;
 			Console.Write("Multibootaddress: ");
 			Console.Color = Colors.Gray;
-			Console.Write(Multiboot.MultibootStructure, 16, 8);
+			unsafe
+			{
+				Console.Write((uint)Multiboot.MultiBootInfo, 16, 8);
+			}
 
 			Console.WriteLine();
 			Console.Color = Colors.Green;

--- a/Source/Mosa.Internal/Extensions.cs
+++ b/Source/Mosa.Internal/Extensions.cs
@@ -1,7 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿/*
+ * (c) 2008 MOSA - The Managed Operating System Alliance
+ *
+ * Licensed under the terms of the New BSD License.
+ *
+ * Authors:
+ *  Sebastian Loncar (Arakis) <sebastian.loncar@gmail.com>
+ */
+
+using System;
 
 namespace Mosa.Kernel.Helpers
 {

--- a/Source/Mosa.Kernel.x86/Debug.cs
+++ b/Source/Mosa.Kernel.x86/Debug.cs
@@ -37,7 +37,7 @@ namespace Mosa.Kernel.x86
 		{
 			public uint checks;
 			public ushort lastChecksum;
-			public ushort bevoreLastCheckum;
+			public ushort beforeLastCheckum;
 		}
 
 		private static MemoryChangedItem memoyChangedItem;
@@ -54,11 +54,11 @@ namespace Mosa.Kernel.x86
 		{
 			//Improvement: Allocate memory for multiple items and check for different input values.
 			var checksum = FlechterChecksum.Fletcher16(startAddress, bytes);
-			memoyChangedItem.bevoreLastCheckum = memoyChangedItem.lastChecksum;
+			memoyChangedItem.beforeLastCheckum = memoyChangedItem.lastChecksum;
 			memoyChangedItem.lastChecksum = checksum;
 			memoyChangedItem.checks++;
 
-			if (memoyChangedItem.checks > 1 && memoyChangedItem.bevoreLastCheckum != memoyChangedItem.lastChecksum)
+			if (memoyChangedItem.checks > 1 && memoyChangedItem.beforeLastCheckum != memoyChangedItem.lastChecksum)
 			{
 				if (panic)
 					if (message == null)

--- a/Source/Mosa.Kernel.x86/ELFHeader.cs
+++ b/Source/Mosa.Kernel.x86/ELFHeader.cs
@@ -4,7 +4,7 @@
  * Licensed under the terms of the New BSD License.
  *
  * Authors:
- *  Sebastion Loncar (Arakis) <sebastion.loncar@gmail.com>
+ *  Sebastian Loncar (Arakis) <sebastian.loncar@gmail.com>
  */
 
 using Mosa.Kernel.x86.Helpers;

--- a/Source/Mosa.Kernel.x86/GDT.cs
+++ b/Source/Mosa.Kernel.x86/GDT.cs
@@ -6,7 +6,7 @@
  * Authors:
  *  Phil Garcia (tgiphil) <phil@thinkedge.com>
  *  Stefan Andres Charsley (charsleysa) <charsleysa@gmail.com>
- *  Sebastion Loncar (Arakis) <sebastion.loncar@gmail.com>
+ *  Sebastian Loncar (Arakis) <sebastian.loncar@gmail.com>
  */
 
 using Mosa.Kernel.Helpers;

--- a/Source/Mosa.Kernel.x86/Multiboot.cs
+++ b/Source/Mosa.Kernel.x86/Multiboot.cs
@@ -448,10 +448,10 @@ namespace Mosa.Kernel.x86
 	{
 		public uint Num;
 		public uint Size;
-		unsafe public ElfSectionHeader* Sections;
+		unsafe public MultiBootElfSectionHeader* Sections;
 		public uint Shndx;
 
-		unsafe public ElfSectionHeader* StringTableSection
+		unsafe public MultiBootElfSectionHeader* StringTableSection
 		{
 			get
 			{
@@ -467,7 +467,7 @@ namespace Mosa.Kernel.x86
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
-	public struct ElfSectionHeader
+	public struct MultiBootElfSectionHeader
 	{
 		public uint Name;                /* Section name (string tbl index) */
 		public uint Type;                /* Section type */

--- a/Source/Mosa.Kernel.x86/Multiboot.cs
+++ b/Source/Mosa.Kernel.x86/Multiboot.cs
@@ -5,6 +5,7 @@
  *
  * Authors:
  *  Phil Garcia (tgiphil) <phil@thinkedge.com>
+ *  Sebastian Loncar (Arakis) <sebastian.loncar@gmail.com>
  */
 
 using Mosa.Internal;

--- a/Source/Mosa.Kernel.x86/Multiboot.cs
+++ b/Source/Mosa.Kernel.x86/Multiboot.cs
@@ -92,7 +92,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->flags;
+				return MultiBootInfo->Flags;
 			}
 		}
 
@@ -104,7 +104,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->memLower;
+				return MultiBootInfo->MemLower;
 			}
 		}
 
@@ -116,7 +116,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->memUpper;
+				return MultiBootInfo->MemUpper;
 			}
 		}
 
@@ -128,7 +128,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->bootDevice;
+				return MultiBootInfo->BootDevice;
 			}
 		}
 
@@ -140,7 +140,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->commandLine;
+				return MultiBootInfo->CommandLine;
 			}
 		}
 
@@ -152,7 +152,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->moduleAddress;
+				return MultiBootInfo->ModuleAddress;
 			}
 		}
 
@@ -164,7 +164,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->moduleCount;
+				return MultiBootInfo->ModuleCount;
 			}
 		}
 
@@ -176,7 +176,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->memMapLength;
+				return MultiBootInfo->MemMapLength;
 			}
 		}
 
@@ -188,7 +188,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->memMapAddress;
+				return MultiBootInfo->MemMapAddress;
 			}
 		}
 
@@ -231,7 +231,7 @@ namespace Mosa.Kernel.x86
 		/// <returns></returns>
 		public static uint GetMemoryMapBase(uint index)
 		{
-			return (uint)GetMemoryMapIndexLocation(index)->base_addr;
+			return (uint)GetMemoryMapIndexLocation(index)->BaseAddr;
 		}
 
 		/// <summary>
@@ -241,7 +241,7 @@ namespace Mosa.Kernel.x86
 		/// <returns></returns>
 		public static uint GetMemoryMapLength(uint index)
 		{
-			return (uint)GetMemoryMapIndexLocation(index)->length;
+			return (uint)GetMemoryMapIndexLocation(index)->Length;
 		}
 
 		/// <summary>
@@ -251,7 +251,7 @@ namespace Mosa.Kernel.x86
 		/// <returns></returns>
 		public static byte GetMemoryMapType(uint index)
 		{
-			return (byte)GetMemoryMapIndexLocation(index)->type;
+			return (byte)GetMemoryMapIndexLocation(index)->Type;
 		}
 
 		/// <summary>
@@ -262,7 +262,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->drivesLength;
+				return MultiBootInfo->DrivesLength;
 			}
 		}
 
@@ -274,7 +274,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->drivesAddress;
+				return MultiBootInfo->DrivesAddress;
 			}
 		}
 
@@ -286,7 +286,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->configTable;
+				return MultiBootInfo->ConfigTable;
 			}
 		}
 
@@ -310,7 +310,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->apmTable;
+				return MultiBootInfo->ApmTable;
 			}
 		}
 
@@ -322,7 +322,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->vbeControlInfo;
+				return MultiBootInfo->VbeControlInfo;
 			}
 		}
 
@@ -334,7 +334,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->vbeModeInfo;
+				return MultiBootInfo->VbeModeInfo;
 			}
 		}
 
@@ -346,7 +346,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->vbeMode;
+				return MultiBootInfo->VbeMode;
 			}
 		}
 
@@ -358,7 +358,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->vbeInterfaceSeg;
+				return MultiBootInfo->VbeInterfaceSeg;
 			}
 		}
 
@@ -370,7 +370,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->vbeInterfaceOff;
+				return MultiBootInfo->VbeInterfaceOff;
 			}
 		}
 
@@ -382,7 +382,7 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return MultiBootInfo->vbeInterfaceLength;
+				return MultiBootInfo->VbeInterfaceLength;
 			}
 		}
 	}
@@ -390,26 +390,26 @@ namespace Mosa.Kernel.x86
 	[StructLayout(LayoutKind.Sequential)]
 	unsafe public struct MultiBootInfo
 	{
-		public uint flags;			//required
-		public uint memLower;		//if bit 0 in flags are set
-		public uint memUpper;		//if bit 0 in flags are set
-		public uint bootDevice;		//if bit 1 in flags are set
-		public uint commandLine;		//if bit 2 in flags are set
-		public uint moduleCount;		//if bit 3 in flags are set
-		public uint moduleAddress;		//if bit 3 in flags are set
-		public MultiBootElfSectionHeaderTable syms;		//if bits 4 or 5 in flags are set
-		public uint memMapLength;		//if bit 6 in flags is set
-		public uint memMapAddress;		//if bit 6 in flags is set
-		public uint drivesLength;		//if bit 7 in flags is set
-		public uint drivesAddress;		//if bit 7 in flags is set
-		public uint configTable;		//if bit 8 in flags is set
-		public uint apmTable;		//if bit 9 in flags is set
-		public uint vbeControlInfo;	//if bit 10 in flags is set
-		public uint vbeModeInfo;		//if bit 11 in flags is set
-		public uint vbeMode;		// all vbe_* set if bit 12 in flags are set
-		public uint vbeInterfaceSeg;
-		public uint vbeInterfaceOff;
-		public uint vbeInterfaceLength;
+		public uint Flags;			    //required
+		public uint MemLower;		    //if bit 0 in flags are set
+		public uint MemUpper;		    //if bit 0 in flags are set
+		public uint BootDevice;		  //if bit 1 in flags are set
+		public uint CommandLine;		//if bit 2 in flags are set
+		public uint ModuleCount;		//if bit 3 in flags are set
+		public uint ModuleAddress;	//if bit 3 in flags are set
+		public MultiBootElfSectionHeaderTable Syms;	//if bits 4 or 5 in flags are set
+		public uint MemMapLength;		//if bit 6 in flags is set
+		public uint MemMapAddress;	//if bit 6 in flags is set
+		public uint DrivesLength;		//if bit 7 in flags is set
+		public uint DrivesAddress;	//if bit 7 in flags is set
+		public uint ConfigTable;		//if bit 8 in flags is set
+		public uint ApmTable;				//if bit 9 in flags is set
+		public uint VbeControlInfo;	//if bit 10 in flags is set
+		public uint VbeModeInfo;		//if bit 11 in flags is set
+		public uint VbeMode;				// all vbe_* set if bit 12 in flags are set
+		public uint VbeInterfaceSeg;
+		public uint VbeInterfaceOff;
+		public uint VbeInterfaceLength;
 
 		private static class FlagsOffset
 		{
@@ -420,17 +420,9 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				return flags.IsBitSet(5);
+				return Flags.IsBitSet(5);
 			}
 		}
-
-		//unsafe public uint MemoryMapCount
-		//{
-		//	get
-		//	{
-		//		return (uint)(memMapLength / MultiBootMemoryMap.EntrySize);
-		//	}
-		//}
 
 		unsafe public MultiBootElfSectionHeaderTable* ElfSectionHeaderTable
 		{
@@ -443,7 +435,7 @@ namespace Mosa.Kernel.x86
 				//	return (MultiBootElfSectionHeaderTable*)ptr;
 
 				uint ui;
-				fixed (void* ptr = &syms)
+				fixed (void* ptr = &Syms)
 					ui = (uint)ptr;
 				return (MultiBootElfSectionHeaderTable*)ui;
 			}
@@ -453,51 +445,48 @@ namespace Mosa.Kernel.x86
 	[StructLayout(LayoutKind.Sequential)]
 	public struct MultiBootElfSectionHeaderTable
 	{
-		public uint num;
-		public uint size;
+		public uint Num;
+		public uint Size;
 		unsafe public ElfSectionHeader* Sections;
-		public uint shndx;
+		public uint Shndx;
 
 		unsafe public ElfSectionHeader* StringTableSection
 		{
 			get
 			{
-				return Sections + shndx;
+				return Sections + Shndx;
 			}
 		}
 
 		unsafe public StringBuffer GetSectionName(int idx)
 		{
-			//return StringBuffer.CreateFromNullTerminatedString((byte*)(StringTableSection->sh_addr + (Sections + idx)->sh_name));
-
-			//TODO: Why name idx -1?
-			return StringBuffer.CreateFromNullTerminatedString((byte*)(StringTableSection->sh_addr + (Sections + idx)->sh_name - 1));
+			//TODO / confirm: Why name idx -1?
+			return StringBuffer.CreateFromNullTerminatedString((byte*)(StringTableSection->Addr + (Sections + idx)->Name - 1));
 		}
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct ElfSectionHeader
 	{
-		public uint sh_name;                /* Section name (string tbl index) */
-		public uint sh_type;                /* Section type */
-		public uint sh_flags;               /* Section flags */
-		public uint sh_addr;                /* Section virtual addr at execution */
-		public uint sh_offset;              /* Section file offset */
-		public uint sh_size;                /* Section size in bytes */
-		public uint sh_link;                /* Link to another section */
-		public uint sh_info;                /* Additional section information */
-		public uint sh_addralign;           /* Section alignment */
-		public uint sh_entsize;             /* Entry size if section holds table */
+		public uint Name;                /* Section name (string tbl index) */
+		public uint Type;                /* Section type */
+		public uint Flags;               /* Section flags */
+		public uint Addr;                /* Section virtual addr at execution */
+		public uint Offset;              /* Section file offset */
+		public uint Size;                /* Section size in bytes */
+		public uint Link;                /* Link to another section */
+		public uint Info;                /* Additional section information */
+		public uint AddrAlign;           /* Section alignment */
+		public uint EntSize;             /* Entry size if section holds table */
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	public struct MultiBootMemoryMap
 	{
-		public uint size;
-		public ulong base_addr;
-		public ulong length;
-		public uint type;
-		public const uint EntrySize = 16;
+		public uint Size;
+		public ulong BaseAddr;
+		public ulong Length;
+		public uint Type;
 
 		//public bool IsLast
 		//{
@@ -523,7 +512,7 @@ namespace Mosa.Kernel.x86
 			get
 			{
 				//Assert.False(IsLast);
-				return (MultiBootMemoryMap*)(((uint)thisPtr) + size + 4);
+				return (MultiBootMemoryMap*)(((uint)thisPtr) + Size + 4);
 			}
 		}
 	}

--- a/Source/Mosa.Kernel.x86/PageTable.cs
+++ b/Source/Mosa.Kernel.x86/PageTable.cs
@@ -5,6 +5,7 @@
  *
  * Authors:
  *  Phil Garcia (tgiphil) <phil@thinkedge.com>
+ *  Sebastian Loncar (Arakis) <sebastian.loncar@gmail.com>
  */
 
 using Mosa.Kernel.Helpers;

--- a/Source/Mosa.Kernel.x86/Panic.cs
+++ b/Source/Mosa.Kernel.x86/Panic.cs
@@ -5,6 +5,7 @@
  *
  * Authors:
  *  Phil Garcia (tgiphil) <phil@thinkedge.com>
+ *  Sebastian Loncar (Arakis) <sebastian.loncar@gmail.com>
  */
 
 using Mosa.Platform.Internal.x86;

--- a/Source/Mosa.Platform.Internal.x86/StringBuffer.cs
+++ b/Source/Mosa.Platform.Internal.x86/StringBuffer.cs
@@ -30,6 +30,21 @@ namespace Mosa.Platform.Internal.x86
 		//[FieldOffset(4)]
 		//unsafe private char* chars;
 
+		unsafe public static StringBuffer CreateFromNullTerminatedString(uint start)
+		{
+			return CreateFromNullTerminatedString((byte*)start);
+		}
+
+		unsafe public static StringBuffer CreateFromNullTerminatedString(byte* start)
+		{
+			var buf = new StringBuffer();
+			while (*start != 0)
+			{
+				buf.Append((char)*start++);
+			}
+			return buf;
+		}
+
 		private unsafe char* firstChar()
 		{
 			//Does not work!


### PR DESCRIPTION
- Before, only a very small part was accessible via the MultiBoot class, and it was hardcoded via offsets. Now we have access to most of the MultiBoot informations using structs, including the ELF sections.
- We are now able to get the exact position and size of .text and .data segment in the physical memory.