### PR TITLE
Fix multiboot, linker, and machine code emitter

### DIFF
--- a/Source/Mosa.Compiler.Linker/BaseLinker.cs
+++ b/Source/Mosa.Compiler.Linker/BaseLinker.cs
@@ -109,6 +109,23 @@ namespace Mosa.Compiler.Linker
 			return CreateSymbol(name, kind, 0);
 		}
 
+		public LinkerSymbol FindSymbol(string name)
+		{
+			var list = new [] { SectionKind.BSS, SectionKind.Data, SectionKind.ROData, SectionKind.Text };
+			foreach (var kind in list)
+			{
+				var section = Sections[(int)kind];
+
+				Debug.Assert(section != null);
+
+				var symbol = section.GetSymbol(name);
+
+				if (symbol != null)
+					return symbol;
+			}
+			return null;
+		}
+
 		protected LinkerSymbol CreateSymbol(string name, SectionKind kind, uint alignment)
 		{
 			lock (mylock)

--- a/Source/Mosa.Kernel.x86/Multiboot.cs
+++ b/Source/Mosa.Kernel.x86/Multiboot.cs
@@ -431,14 +431,8 @@ namespace Mosa.Kernel.x86
 			{
 				Assert.True(SymIsELF, "MultiBoot info does not contain ELF sections");
 
-				//FIXME: COMPILER BUG
-				//fixed (void* ptr = &this)
-				//	return (MultiBootElfSectionHeaderTable*)ptr;
-
-				uint ui;
-				fixed (void* ptr = &Syms)
-					ui = (uint)ptr;
-				return (MultiBootElfSectionHeaderTable*)ui;
+				fixed (void* ptr = &this)
+					return (MultiBootElfSectionHeaderTable*)ptr;
 			}
 		}
 	}
@@ -498,13 +492,8 @@ namespace Mosa.Kernel.x86
 		{
 			get
 			{
-				//fixed (MultiBootMemoryMap* ptr = &this)
-				//	return ptr;
-
-				uint addr;
-				fixed (void* ptr = &this)
-					addr = (uint)ptr;
-				return (MultiBootMemoryMap*)addr;
+				fixed (MultiBootMemoryMap* ptr = &this)
+					return ptr;
 			}
 		}
 

--- a/Source/Mosa.Platform.x86/Intrinsic/GetMultibootEAX.cs
+++ b/Source/Mosa.Platform.x86/Intrinsic/GetMultibootEAX.cs
@@ -27,7 +27,10 @@ namespace Mosa.Platform.x86.Intrinsic
 		/// <param name="typeSystem">The type system.</param>
 		void IIntrinsicPlatformMethod.ReplaceIntrinsicCall(Context context, BaseMethodCompiler methodCompiler)
 		{
-			context.SetInstruction(IRInstruction.Move, context.Result, Operand.CreateUnmanagedSymbolPointer(methodCompiler.TypeSystem, Multiboot0695Stage.MultibootEAX));
+			var result = context.Result;
+			var address = methodCompiler.CreateVirtualRegister(methodCompiler.TypeSystem.BuiltIn.I4);
+			context.SetInstruction(IRInstruction.Move, address, Operand.CreateUnmanagedSymbolPointer(methodCompiler.TypeSystem, Multiboot0695Stage.MultibootEAX));
+			context.AppendInstruction(IRInstruction.Move, result, Operand.CreateMemoryAddress(methodCompiler.TypeSystem.BuiltIn.I4, address, 0));
 		}
 
 		#endregion Methods

--- a/Source/Mosa.Platform.x86/Intrinsic/GetMultibootEBX.cs
+++ b/Source/Mosa.Platform.x86/Intrinsic/GetMultibootEBX.cs
@@ -27,7 +27,10 @@ namespace Mosa.Platform.x86.Intrinsic
 		/// <param name="typeSystem">The type system.</param>
 		void IIntrinsicPlatformMethod.ReplaceIntrinsicCall(Context context, BaseMethodCompiler methodCompiler)
 		{
-			context.SetInstruction(IRInstruction.Move, context.Result, Operand.CreateUnmanagedSymbolPointer(methodCompiler.TypeSystem, Multiboot0695Stage.MultibootEBX));
+			var result = context.Result;
+			var address = methodCompiler.CreateVirtualRegister(methodCompiler.TypeSystem.BuiltIn.I4);
+			context.SetInstruction(IRInstruction.Move, address, Operand.CreateUnmanagedSymbolPointer(methodCompiler.TypeSystem, Multiboot0695Stage.MultibootEBX));
+			context.AppendInstruction(IRInstruction.Move, result, Operand.CreateMemoryAddress(methodCompiler.TypeSystem.BuiltIn.I4, address, 0));
 		}
 
 		#endregion Methods

--- a/Source/Mosa.Platform.x86/MachineCodeEmitter.cs
+++ b/Source/Mosa.Platform.x86/MachineCodeEmitter.cs
@@ -188,7 +188,11 @@ namespace Mosa.Platform.x86
 
 				SectionKind section = (displacement.Method != null) ? SectionKind.Text : SectionKind.ROData;
 
-				linker.Link(LinkType.AbsoluteAddress, BuiltInPatch.I4, MethodName, SectionKind.Text, (int)codeStream.Position, 0, displacement.Name, section, 0);
+				var symbol = linker.FindSymbol(displacement.Name);
+				if (symbol == null)
+					symbol = linker.GetSymbol(displacement.Name, section);
+				
+				linker.Link(LinkType.AbsoluteAddress, BuiltInPatch.I4, MethodName, SectionKind.Text, (int)codeStream.Position, 0, symbol.Name, symbol.SectionKind, 0);
 				codeStream.WriteZeroBytes(4);
 			}
 			else if (displacement.IsMemoryAddress && displacement.OffsetBase != null && displacement.OffsetBase.IsConstant)


### PR DESCRIPTION
- Fix multiboot, many uses of its address were straight copies instead
of copy from address
- Fix multiboot asking for more memory than it used
- Added ability to find symbols in linker
- Fixed issue in machine code emitter where it wasn't able to determine
which section a symbol used