### PR TITLE
Fix issue with R8 alignment during calls

### DIFF
--- a/Source/Mosa.Platform.x86/Architecture.cs
+++ b/Source/Mosa.Platform.x86/Architecture.cs
@@ -257,7 +257,7 @@ namespace Mosa.Platform.x86
 		/// <param name="alignment">Receives alignment requirements of the type.</param>
 		public override void GetTypeRequirements(MosaTypeLayout typeLayout, MosaType type, out int size, out int alignment)
 		{
-			alignment = type.IsR8 ? 8 : 4;
+			alignment = 4;
 
 			size = type.IsValueType ? typeLayout.GetTypeSize(type) : 4;
 		}

--- a/Source/Mosa.Tool.Debugger/MemoryView.cs
+++ b/Source/Mosa.Tool.Debugger/MemoryView.cs
@@ -128,6 +128,7 @@ namespace Mosa.Tool.Debugger
 			catch
 			{
 				Status = "ERROR: Invalid memory location";
+				cbSelect.Enabled = Enabled;
 			}
 		}
 

--- a/Source/Mosa.UnitTest.Engine/UnitTestEngine.cs
+++ b/Source/Mosa.UnitTest.Engine/UnitTestEngine.cs
@@ -88,7 +88,8 @@ namespace Mosa.UnitTest.Engine
 				DebugConnectionOption = DebugConnectionOption.TCPServer,
 				DebugConnectionPort = 9999,
 				ExitOnLaunch = true,
-				GenerateASMFile = true
+				GenerateASMFile = true,
+				GenerateMapFile = true
 			};
 
 			AppLocations = new AppLocations();


### PR DESCRIPTION
- Fixed issue with R8 alignment during calls
- Fixed debugger MemoryView where entering an invalid address would
cause the view to stop working
- Added map output to unit test engine