### PR TITLE
Renaming the Microsoft.Sharp.targets file to its correct name-casing.

### DIFF
--- a/Source/Mosa.ClassLib/Mosa.ClassLib.csproj
+++ b/Source/Mosa.ClassLib/Mosa.ClassLib.csproj
@@ -77,7 +77,7 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>

--- a/Source/Mosa.Compiler.Framework.xUnit/Mosa.Compiler.Framework.xUnit.csproj
+++ b/Source/Mosa.Compiler.Framework.xUnit/Mosa.Compiler.Framework.xUnit.csproj
@@ -122,7 +122,7 @@
   <ItemGroup>
     <Analyzer Include="..\packages\xunit.analyzers.0.10.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>

--- a/Source/Mosa.DeviceDriver/Mosa.DeviceDriver.csproj
+++ b/Source/Mosa.DeviceDriver/Mosa.DeviceDriver.csproj
@@ -104,7 +104,7 @@
     <Folder Include="PCI\Network\" />
     <Folder Include="PCI\VideoCard\" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>

--- a/Source/Mosa.DeviceSystem/Mosa.DeviceSystem.csproj
+++ b/Source/Mosa.DeviceSystem/Mosa.DeviceSystem.csproj
@@ -209,7 +209,7 @@
       <SubType>Code</SubType>
     </Compile>
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>

--- a/Source/Mosa.FileSystem/Mosa.FileSystem.csproj
+++ b/Source/Mosa.FileSystem/Mosa.FileSystem.csproj
@@ -158,7 +158,7 @@
       <SubType>Code</SubType>
     </Compile>
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>

--- a/Source/Mosa.Kernel.ARMv6/Mosa.Kernel.ARMv6.csproj
+++ b/Source/Mosa.Kernel.ARMv6/Mosa.Kernel.ARMv6.csproj
@@ -78,7 +78,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup />
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>

--- a/Source/Mosa.Kernel.x86/Mosa.Kernel.x86.csproj
+++ b/Source/Mosa.Kernel.x86/Mosa.Kernel.x86.csproj
@@ -123,7 +123,7 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>

--- a/Source/Mosa.Korlib/Mosa.Korlib.csproj
+++ b/Source/Mosa.Korlib/Mosa.Korlib.csproj
@@ -203,7 +203,7 @@
   <ItemGroup>
     <Folder Include="System.Reflection.Emit\" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <CompileDependsOn>GenerateCompilerResponseFile;$(CompileDependsOn)</CompileDependsOn>
   </PropertyGroup>

--- a/Source/Mosa.Platform.ARMv6/Mosa.Platform.ARMv6.csproj
+++ b/Source/Mosa.Platform.ARMv6/Mosa.Platform.ARMv6.csproj
@@ -156,7 +156,7 @@
   <ItemGroup>
     <Folder Include="Intrinsic\" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>

--- a/Source/Mosa.Platform.x64/Mosa.Platform.x64.csproj
+++ b/Source/Mosa.Platform.x64/Mosa.Platform.x64.csproj
@@ -308,7 +308,7 @@
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>

--- a/Source/Mosa.Platform.x86/Mosa.Platform.x86.csproj
+++ b/Source/Mosa.Platform.x86/Mosa.Platform.x86.csproj
@@ -399,7 +399,7 @@
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>

--- a/Source/Mosa.Runtime.ARMv6/Mosa.Runtime.ARMv6.csproj
+++ b/Source/Mosa.Runtime.ARMv6/Mosa.Runtime.ARMv6.csproj
@@ -76,7 +76,7 @@
       <Name>Mosa.Korlib</Name>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>

--- a/Source/Mosa.Runtime.x86/Mosa.Runtime.x86.csproj
+++ b/Source/Mosa.Runtime.x86/Mosa.Runtime.x86.csproj
@@ -89,7 +89,7 @@
     </None>
   </ItemGroup>
   <ItemGroup />
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>

--- a/Source/Mosa.Runtime/Mosa.Runtime.csproj
+++ b/Source/Mosa.Runtime/Mosa.Runtime.csproj
@@ -105,7 +105,7 @@
       <Name>Mosa.Korlib</Name>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>

--- a/Source/Mosa.Tool.Bootstrap/Mosa.Tool.Bootstrap.csproj
+++ b/Source/Mosa.Tool.Bootstrap/Mosa.Tool.Bootstrap.csproj
@@ -113,7 +113,7 @@
       <DependentUpon>StatusForm.cs</DependentUpon>
     </EmbeddedResource>
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>

--- a/Source/Mosa.Tool.Compiler/Mosa.Tool.Compiler.csproj
+++ b/Source/Mosa.Tool.Compiler/Mosa.Tool.Compiler.csproj
@@ -109,7 +109,7 @@
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>

--- a/Source/Mosa.Utility.CodeCompiler/Mosa.Utility.CodeCompiler.csproj
+++ b/Source/Mosa.Utility.CodeCompiler/Mosa.Utility.CodeCompiler.csproj
@@ -57,7 +57,7 @@
     <WarningLevel>2</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>


### PR DESCRIPTION
File names on Unix are case-sensitive.