### PR TITLE
IDT race condition with GDT

### DIFF
--- a/Source/Mosa.Kernel.x86/Kernel.cs
+++ b/Source/Mosa.Kernel.x86/Kernel.cs
@@ -12,6 +12,12 @@ namespace Mosa.Kernel.x86
 	{
 		public static void Setup()
 		{
+			// Initialize GDT before IDT, because IDT Entries requies a valid Segment Selector
+			// This never happend before, because on fast computers GDT.Setup() was called
+			// before a Interrupt,for example clock, got triggered.
+			Multiboot.Setup();
+			GDT.Setup();
+
 			// At this stage, allocating memory does not work, so you are only allowed to use ValueTypes or static classes.
 			IDT.SetInterruptHandler(null);
 			Panic.Setup();
@@ -22,8 +28,6 @@ namespace Mosa.Kernel.x86
 			IDT.Setup();
 
 			// Initializing the memory management
-			Multiboot.Setup();
-			GDT.Setup();
 			PageFrameAllocator.Setup();
 			PageTable.Setup();
 			VirtualPageAllocator.Setup();

--- a/Source/Mosa.TestWorld.x86/Boot.cs
+++ b/Source/Mosa.TestWorld.x86/Boot.cs
@@ -38,17 +38,19 @@ namespace Mosa.TestWorld.x86
 			Screen.Write("!");
 			Screen.Write(" ");
 
-			IDT.SetInterruptHandler(null);
-			Screen.Write('0');
-			Debugger.Setup(Serial.COM1);
-			Screen.Write('1');
-			PIC.Setup();
-			Screen.Write('2');
-			IDT.Setup();
-			Screen.Write('3');
 			Multiboot.Setup();
-			Screen.Write('4');
+			Screen.Write('0');
 			GDT.Setup();
+			Screen.Write('1');
+
+			IDT.SetInterruptHandler(null);
+			Screen.Write('2');
+			Debugger.Setup(Serial.COM1);
+
+			Screen.Write('3');
+			PIC.Setup();
+			Screen.Write('4');
+			IDT.Setup();
 			Screen.Write('5');
 			PageFrameAllocator.Setup();
 			Screen.Write('6');


### PR DESCRIPTION
Initialize GDT before IDT, because IDT Entries requires a valid Segment Selector.
This never happend before, because on fast computers GDT.Setup() was called before a interrupt, for example clock, got triggered.

With that patch, it works with bochs, too (Bochs is generally slower then qemu).

It's only checked with HelloWorld example on Bochs and Qemu