### PR TITLE
Patch-010: Add custom sections to elf

### DIFF
--- a/Source/Mosa.Compiler.Framework/CompilerOptions.cs
+++ b/Source/Mosa.Compiler.Framework/CompilerOptions.cs
@@ -128,6 +128,11 @@ namespace Mosa.Compiler.Framework
 		public Func<BaseCompilerStage> BootStageFactory { get; set; }
 
 		/// <summary>
+		/// Adds additional sections to the Elf-File.
+		/// </summary>
+		public BaseLinker.CreateExtraSectionsDelegate CreateExtraSections { get; set; }
+
+		/// <summary>
 		/// Gets or sets a value indicating whether [emit binary].
 		/// </summary>
 		/// <value>

--- a/Source/Mosa.Compiler.Framework/Linker/BaseLinker.cs
+++ b/Source/Mosa.Compiler.Framework/Linker/BaseLinker.cs
@@ -15,6 +15,8 @@ namespace Mosa.Compiler.Framework.Linker
 	/// </summary>
 	public class BaseLinker
 	{
+		public delegate List<Section> CreateExtraSectionsDelegate();
+
 		public LinkerSection[] LinkerSections { get; }
 
 		public LinkerSymbol EntryPoint { get; set; }
@@ -56,7 +58,9 @@ namespace Mosa.Compiler.Framework.Linker
 			}
 		}
 
-		public BaseLinker(ulong baseAddress, Endianness endianness, MachineType machineType, bool emitSymbols, LinkerFormatType linkerFormatType)
+		public CreateExtraSectionsDelegate CreateExtraSections { get; set; }
+
+		public BaseLinker(ulong baseAddress, Endianness endianness, MachineType machineType, bool emitSymbols, LinkerFormatType linkerFormatType, CreateExtraSectionsDelegate createExtraSections)
 		{
 			LinkerSections = new LinkerSection[4];
 
@@ -65,6 +69,7 @@ namespace Mosa.Compiler.Framework.Linker
 			MachineType = machineType;
 			EmitSymbols = emitSymbols;
 			LinkerFormatType = linkerFormatType;
+			CreateExtraSections = createExtraSections;
 
 			elfLinker = new ElfLinker(this, LinkerFormatType);
 

--- a/Source/Mosa.Compiler.Framework/Linker/Elf/Section.cs
+++ b/Source/Mosa.Compiler.Framework/Linker/Elf/Section.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using Mosa.Compiler.Common;
 
 namespace Mosa.Compiler.Framework.Linker.Elf
 {
@@ -10,7 +11,7 @@ namespace Mosa.Compiler.Framework.Linker.Elf
 	/// </summary>
 	public class Section
 	{
-		public delegate void EmitSectionMethod(Section section);
+		public delegate void EmitSectionMethod(Section section, EndianAwareBinaryWriter writer);
 
 		public int Index { get; set; }
 

--- a/Source/Mosa.Compiler.Framework/MosaCompiler.cs
+++ b/Source/Mosa.Compiler.Framework/MosaCompiler.cs
@@ -103,7 +103,7 @@ namespace Mosa.Compiler.Framework
 
 		public void Initialize()
 		{
-			Linker = new BaseLinker(CompilerOptions.BaseAddress, CompilerOptions.Architecture.Endianness, CompilerOptions.Architecture.MachineType, CompilerOptions.EmitSymbols, CompilerOptions.LinkerFormatType);
+			Linker = new BaseLinker(CompilerOptions.BaseAddress, CompilerOptions.Architecture.Endianness, CompilerOptions.Architecture.MachineType, CompilerOptions.EmitSymbols, CompilerOptions.LinkerFormatType, CompilerOptions.CreateExtraSections);
 
 			Compiler = new Compiler(this);
 		}

--- a/Source/Mosa.Platform.x86/Intrinsic/Jmp.cs
+++ b/Source/Mosa.Platform.x86/Intrinsic/Jmp.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using Mosa.Compiler.Framework;
+using Mosa.Platform.Intel;
+
+namespace Mosa.Platform.x86.Intrinsic
+{
+	/// <summary>
+	/// Representations the x86 Jmp instruction.
+	/// </summary>
+	internal sealed class Jmp : IIntrinsicPlatformMethod
+	{
+		void IIntrinsicPlatformMethod.ReplaceIntrinsicCall(Context context, MethodCompiler methodCompiler)
+		{
+			context.SetInstruction(X86.JmpReg, null, context.Operand1);
+		}
+	}
+}

--- a/Source/Mosa.Platform.x86/Mosa.Platform.x86.csproj
+++ b/Source/Mosa.Platform.x86/Mosa.Platform.x86.csproj
@@ -13,7 +13,6 @@
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
-    <DelaySign>false</DelaySign>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
@@ -390,6 +389,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="X86Instructions.cs" />
+    <Compile Include="Intrinsic\Jmp.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />

--- a/Source/Mosa.Runtime.x86/Native.cs
+++ b/Source/Mosa.Runtime.x86/Native.cs
@@ -21,6 +21,9 @@ namespace Mosa.Runtime.x86
 		[DllImportAttribute(@"Mosa.Platform.x86.Intrinsic.Lgdt, Mosa.Platform.x86")]
 		public extern static void Lgdt(uint address);
 
+		[DllImportAttribute(@"Mosa.Platform.x86.Intrinsic.Jmp, Mosa.Platform.x86")]
+		public extern static void Jmp(uint address);
+
 		[DllImportAttribute(@"Mosa.Platform.x86.Intrinsic.Sti, Mosa.Platform.x86")]
 		public extern static void Sti();
 

--- a/Source/Mosa.Utility.Launcher/Builder.cs
+++ b/Source/Mosa.Utility.Launcher/Builder.cs
@@ -99,6 +99,8 @@ namespace Mosa.Utility.Launcher
 
 				compiler.CompilerOptions.SetCustomOption("x86.irq-methods", Options.Emitx86IRQMethods ? "true" : "false");
 
+				compiler.CompilerOptions.CreateExtraSections = Options.CreateExtraSections;
+
 				if (Options.GenerateMapFile)
 				{
 					compiler.CompilerOptions.MapFile = Path.Combine(Options.DestinationDirectory, $"{Path.GetFileNameWithoutExtension(Options.SourceFile)}.map");

--- a/Source/Mosa.Utility.Launcher/Options.cs
+++ b/Source/Mosa.Utility.Launcher/Options.cs
@@ -316,6 +316,8 @@ namespace Mosa.Utility.Launcher
 		[Option("hunt-corlib")]
 		public bool HuntForCorLib { get; set; }
 
+		public BaseLinker.CreateExtraSectionsDelegate CreateExtraSections { get; set; }
+
 		public Options()
 		{
 			IncludeFiles = new List<IncludeFile>();


### PR DESCRIPTION
This patch mak it possible to add custom sections for the generated elf file, for example binary blobs, custom code, text data, meta data, what ever you want.

Here's an example, how to use it:
```c#
var Options = new Mosa.Utility.Launcher.Options();
Options.CreateExtraSections = () =>
{
	return new List<Section>
	{
		new Section
		{
			Name = "customdata",
			Type = SectionType.ProgBits,
			AddressAlignment = 4096,
			EmitMethod = (section, writer) =>
			{
				var data = File.ReadAllBytes("data.bin");
				writer.Write(data);
				section.Size = (uint)data.Length;
			}
		}
	};
};
```

I would be glad if you would accept this patch. I followed your code convention where possible. Feel free to refactor the code.