### PR TITLE
013 Respect explicit struct size

### DIFF
--- a/Source/Mosa.Compiler.Framework/MosaTypeLayout.cs
+++ b/Source/Mosa.Compiler.Framework/MosaTypeLayout.cs
@@ -455,7 +455,7 @@ namespace Mosa.Compiler.Framework
 				}
 			}
 
-			typeSizes.Add(type, typeSize);
+			typeSizes.Add(type, (type.ClassSize == null || type.ClassSize == -1) ? typeSize : (int)type.ClassSize);
 		}
 
 		/// <summary>


### PR DESCRIPTION
The Size property of StructLayout is valid both on Explicit or Sequential.

This fix fixed also the feature of FixedBuffers (e.g. public unsafe fixed byte fieldName[100]).

UnitTests run successful.