### PR TITLE
015-extra-programheaders

### DIFF
--- a/Source/Mosa.Compiler.Framework/CompilerOptions.cs
+++ b/Source/Mosa.Compiler.Framework/CompilerOptions.cs
@@ -133,6 +133,11 @@ namespace Mosa.Compiler.Framework
 		public BaseLinker.CreateExtraSectionsDelegate CreateExtraSections { get; set; }
 
 		/// <summary>
+		/// Adds additional program headers to the Elf-File.
+		/// </summary>
+		public BaseLinker.CreateExtraProgramHeaderDelegate CreateExtraProgramHeaders { get; set; }
+
+		/// <summary>
 		/// Gets or sets a value indicating whether [emit binary].
 		/// </summary>
 		/// <value>

--- a/Source/Mosa.Compiler.Framework/Linker/BaseLinker.cs
+++ b/Source/Mosa.Compiler.Framework/Linker/BaseLinker.cs
@@ -16,6 +16,7 @@ namespace Mosa.Compiler.Framework.Linker
 	public class BaseLinker
 	{
 		public delegate List<Section> CreateExtraSectionsDelegate();
+		public delegate List<ProgramHeader> CreateExtraProgramHeaderDelegate();
 
 		public LinkerSection[] LinkerSections { get; }
 
@@ -59,8 +60,9 @@ namespace Mosa.Compiler.Framework.Linker
 		}
 
 		public CreateExtraSectionsDelegate CreateExtraSections { get; set; }
+		public CreateExtraProgramHeaderDelegate CreateExtraProgramHeaders { get; set; }
 
-		public BaseLinker(ulong baseAddress, Endianness endianness, MachineType machineType, bool emitSymbols, LinkerFormatType linkerFormatType, CreateExtraSectionsDelegate createExtraSections)
+		public BaseLinker(ulong baseAddress, Endianness endianness, MachineType machineType, bool emitSymbols, LinkerFormatType linkerFormatType, CreateExtraSectionsDelegate createExtraSections, CreateExtraProgramHeaderDelegate createExtraProgramHeaders)
 		{
 			LinkerSections = new LinkerSection[4];
 
@@ -70,6 +72,7 @@ namespace Mosa.Compiler.Framework.Linker
 			EmitSymbols = emitSymbols;
 			LinkerFormatType = linkerFormatType;
 			CreateExtraSections = createExtraSections;
+			CreateExtraProgramHeaders = createExtraProgramHeaders;
 
 			elfLinker = new ElfLinker(this, LinkerFormatType);
 

--- a/Source/Mosa.Compiler.Framework/Linker/Elf/ElfLinker.cs
+++ b/Source/Mosa.Compiler.Framework/Linker/Elf/ElfLinker.cs
@@ -229,6 +229,19 @@ namespace Mosa.Compiler.Framework.Linker.Elf
 
 				elfheader.ProgramHeaderNumber++;
 			}
+
+			if (linker.CreateExtraProgramHeaders != null)
+			{
+				foreach (var programHeader in linker.CreateExtraProgramHeaders())
+				{
+					if (programHeader.FileSize == 0)
+						continue;
+
+					programHeader.Write(linkerFormatType, writer);
+
+					elfheader.ProgramHeaderNumber++;
+				}
+			}
 		}
 
 		private void CreateSections()
@@ -382,7 +395,7 @@ namespace Mosa.Compiler.Framework.Linker.Elf
 			sectionHeaderStringSection.AddDependency(stringSection);
 		}
 
-		protected void WriteStringSection(Section section,EndianAwareBinaryWriter writer)
+		protected void WriteStringSection(Section section, EndianAwareBinaryWriter writer)
 		{
 			Debug.Assert(section == stringSection);
 

--- a/Source/Mosa.Compiler.Framework/MosaCompiler.cs
+++ b/Source/Mosa.Compiler.Framework/MosaCompiler.cs
@@ -103,7 +103,7 @@ namespace Mosa.Compiler.Framework
 
 		public void Initialize()
 		{
-			Linker = new BaseLinker(CompilerOptions.BaseAddress, CompilerOptions.Architecture.Endianness, CompilerOptions.Architecture.MachineType, CompilerOptions.EmitSymbols, CompilerOptions.LinkerFormatType, CompilerOptions.CreateExtraSections);
+			Linker = new BaseLinker(CompilerOptions.BaseAddress, CompilerOptions.Architecture.Endianness, CompilerOptions.Architecture.MachineType, CompilerOptions.EmitSymbols, CompilerOptions.LinkerFormatType, CompilerOptions.CreateExtraSections, CompilerOptions.CreateExtraProgramHeaders);
 
 			Compiler = new Compiler(this);
 		}

--- a/Source/Mosa.Utility.Launcher/Builder.cs
+++ b/Source/Mosa.Utility.Launcher/Builder.cs
@@ -100,6 +100,7 @@ namespace Mosa.Utility.Launcher
 				compiler.CompilerOptions.SetCustomOption("x86.irq-methods", Options.Emitx86IRQMethods ? "true" : "false");
 
 				compiler.CompilerOptions.CreateExtraSections = Options.CreateExtraSections;
+				compiler.CompilerOptions.CreateExtraProgramHeaders = Options.CreateExtraProgramHeaders;
 
 				if (Options.GenerateMapFile)
 				{

--- a/Source/Mosa.Utility.Launcher/Options.cs
+++ b/Source/Mosa.Utility.Launcher/Options.cs
@@ -317,6 +317,7 @@ namespace Mosa.Utility.Launcher
 		public bool HuntForCorLib { get; set; }
 
 		public BaseLinker.CreateExtraSectionsDelegate CreateExtraSections { get; set; }
+		public BaseLinker.CreateExtraProgramHeaderDelegate CreateExtraProgramHeaders { get; set; }
 
 		public Options()
 		{


### PR DESCRIPTION
This patch adds the feature to add additional program headers to a ELF file. A strict multiboot loader like `qemu --kernel`-option will only load parts of the ELF specified in the program headers. GRUB/Syslinux load all other section, too, but this is opional and you cannot specify where those sections will be loded.

