### PR TITLE
Downgrade to .NET 4.7.1 and Fixing Filename casing

### DIFF
--- a/Source/Mosa.ClassLib/Mosa.ClassLib.csproj
+++ b/Source/Mosa.ClassLib/Mosa.ClassLib.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Compiler.Common/Mosa.Compiler.Common.csproj
+++ b/Source/Mosa.Compiler.Common/Mosa.Compiler.Common.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.Compiler.Common</RootNamespace>
     <AssemblyName>Mosa.Compiler.Common</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Source/Mosa.Compiler.Framework.xUnit/Mosa.Compiler.Framework.xUnit.csproj
+++ b/Source/Mosa.Compiler.Framework.xUnit/Mosa.Compiler.Framework.xUnit.csproj
@@ -17,7 +17,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Compiler.Framework/Mosa.Compiler.Framework.csproj
+++ b/Source/Mosa.Compiler.Framework/Mosa.Compiler.Framework.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Mosa.Compiler.Framework</RootNamespace>
     <FileUpgradeFlags>

--- a/Source/Mosa.Compiler.MosaTypeSystem/Mosa.Compiler.MosaTypeSystem.csproj
+++ b/Source/Mosa.Compiler.MosaTypeSystem/Mosa.Compiler.MosaTypeSystem.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Mosa.Compiler.MosaTypeSystem</RootNamespace>
     <FileUpgradeFlags>

--- a/Source/Mosa.CoolWorld.x86/Mosa.CoolWorld.x86.csproj
+++ b/Source/Mosa.CoolWorld.x86/Mosa.CoolWorld.x86.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.DeviceDriver/Mosa.DeviceDriver.csproj
+++ b/Source/Mosa.DeviceDriver/Mosa.DeviceDriver.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.DeviceSystem/Mosa.DeviceSystem.csproj
+++ b/Source/Mosa.DeviceSystem/Mosa.DeviceSystem.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Mosa.DeviceSystem</RootNamespace>
     <FileUpgradeFlags>

--- a/Source/Mosa.FileSystem/Mosa.FileSystem.csproj
+++ b/Source/Mosa.FileSystem/Mosa.FileSystem.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.HelloWorld.x86/Mosa.HelloWorld.x86.csproj
+++ b/Source/Mosa.HelloWorld.x86/Mosa.HelloWorld.x86.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Kernel.ARMv6/Mosa.Kernel.ARMv6.csproj
+++ b/Source/Mosa.Kernel.ARMv6/Mosa.Kernel.ARMv6.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Kernel.x64/Mosa.Kernel.x64.csproj
+++ b/Source/Mosa.Kernel.x64/Mosa.Kernel.x64.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Kernel.x86/Mosa.Kernel.x86.csproj
+++ b/Source/Mosa.Kernel.x86/Mosa.Kernel.x86.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Korlib/Mosa.Korlib.csproj
+++ b/Source/Mosa.Korlib/Mosa.Korlib.csproj
@@ -9,7 +9,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <AssemblyName>mscorlib</AssemblyName>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>System</RootNamespace>
     <NoWarn>0169;0649;1685</NoWarn>

--- a/Source/Mosa.Platform.ARMv6/Mosa.Platform.ARMv6.csproj
+++ b/Source/Mosa.Platform.ARMv6/Mosa.Platform.ARMv6.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Platform.Intel/Mosa.Platform.Intel.csproj
+++ b/Source/Mosa.Platform.Intel/Mosa.Platform.Intel.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Platform.x64/Mosa.Platform.x64.csproj
+++ b/Source/Mosa.Platform.x64/Mosa.Platform.x64.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Platform.x86/Mosa.Platform.x86.csproj
+++ b/Source/Mosa.Platform.x86/Mosa.Platform.x86.csproj
@@ -13,7 +13,7 @@
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>
@@ -89,8 +89,8 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Instructions\Adc32.cs" />
     <Compile Include="Instructions\Add32.cs" />
-    <Compile Include="Instructions\Addsd.cs" />
-    <Compile Include="Instructions\Addss.cs" />
+    <Compile Include="Instructions\AddSD.cs" />
+    <Compile Include="Instructions\AddSS.cs" />
     <Compile Include="Instructions\And32.cs" />
     <Compile Include="Instructions\BochsDebug.cs" />
     <Compile Include="Instructions\BranchCarry.cs" />

--- a/Source/Mosa.Plug.Korlib.x64/Mosa.Plug.Korlib.x64.csproj
+++ b/Source/Mosa.Plug.Korlib.x64/Mosa.Plug.Korlib.x64.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Plug.Korlib.x86/Mosa.Plug.Korlib.x86.csproj
+++ b/Source/Mosa.Plug.Korlib.x86/Mosa.Plug.Korlib.x86.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Plug.Korlib/Mosa.Plug.Korlib.csproj
+++ b/Source/Mosa.Plug.Korlib/Mosa.Plug.Korlib.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Runtime.ARMv6/Mosa.Runtime.ARMv6.csproj
+++ b/Source/Mosa.Runtime.ARMv6/Mosa.Runtime.ARMv6.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Runtime.x64/Mosa.Runtime.x64.csproj
+++ b/Source/Mosa.Runtime.x64/Mosa.Runtime.x64.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Runtime.x86/Mosa.Runtime.x86.csproj
+++ b/Source/Mosa.Runtime.x86/Mosa.Runtime.x86.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Runtime/Mosa.Runtime.csproj
+++ b/Source/Mosa.Runtime/Mosa.Runtime.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.TestWorld.ARMv6/Mosa.TestWorld.ARMv6.csproj
+++ b/Source/Mosa.TestWorld.ARMv6/Mosa.TestWorld.ARMv6.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.TestWorld.x64/Mosa.TestWorld.x64.csproj
+++ b/Source/Mosa.TestWorld.x64/Mosa.TestWorld.x64.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.TestWorld.x86/Mosa.TestWorld.x86.csproj
+++ b/Source/Mosa.TestWorld.x86/Mosa.TestWorld.x86.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Tool.Bootstrap/Mosa.Tool.Bootstrap.csproj
+++ b/Source/Mosa.Tool.Bootstrap/Mosa.Tool.Bootstrap.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>WinExe</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Tool.Compiler/Mosa.Tool.Compiler.csproj
+++ b/Source/Mosa.Tool.Compiler/Mosa.Tool.Compiler.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Tool.CreateBootImage/Mosa.Tool.CreateBootImage.csproj
+++ b/Source/Mosa.Tool.CreateBootImage/Mosa.Tool.CreateBootImage.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.Tool.CreateBootImage</RootNamespace>
     <AssemblyName>Mosa.Tool.CreateBootImage</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <StartupObject>Mosa.Tool.CreateBootImage.Program</StartupObject>
     <FileUpgradeFlags>

--- a/Source/Mosa.Tool.Disassembler.Intel/Mosa.Tool.Disassembler.Intel.csproj
+++ b/Source/Mosa.Tool.Disassembler.Intel/Mosa.Tool.Disassembler.Intel.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.Tool.Disassembler.Intel</RootNamespace>
     <AssemblyName>Mosa.Tool.Disassembler.Intel</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>

--- a/Source/Mosa.Tool.Explorer/Mosa.Tool.Explorer.csproj
+++ b/Source/Mosa.Tool.Explorer/Mosa.Tool.Explorer.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.Tool.Explorer</RootNamespace>
     <AssemblyName>Mosa.Tool.Explorer</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <IsWebBootstrapper>false</IsWebBootstrapper>

--- a/Source/Mosa.Tool.GDBDebugger/Mosa.Tool.GDBDebugger.csproj
+++ b/Source/Mosa.Tool.GDBDebugger/Mosa.Tool.GDBDebugger.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.Tool.GDBDebugger</RootNamespace>
     <AssemblyName>Mosa.Tool.GDBDebugger</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/Source/Mosa.Tool.Launcher/Mosa.Tool.Launcher.csproj
+++ b/Source/Mosa.Tool.Launcher/Mosa.Tool.Launcher.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.Tool.Launcher</RootNamespace>
     <AssemblyName>Mosa.Tool.Launcher</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/Source/Mosa.Tools.Package/Mosa.Tools.Package.csproj
+++ b/Source/Mosa.Tools.Package/Mosa.Tools.Package.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.Tools.Package</RootNamespace>
     <AssemblyName>Mosa.Tools.Package</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/Source/Mosa.UnitTests.x86/Mosa.UnitTests.x86.csproj
+++ b/Source/Mosa.UnitTests.x86/Mosa.UnitTests.x86.csproj
@@ -14,7 +14,7 @@
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.UnitTests/Mosa.UnitTests.csproj
+++ b/Source/Mosa.UnitTests/Mosa.UnitTests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.UnitTests</RootNamespace>
     <AssemblyName>Mosa.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Source/Mosa.Utility.BootImage/Mosa.Utility.BootImage.csproj
+++ b/Source/Mosa.Utility.BootImage/Mosa.Utility.BootImage.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.Utility.BootImage</RootNamespace>
     <AssemblyName>Mosa.Utility.BootImage</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <StartupObject>
     </StartupObject>

--- a/Source/Mosa.Utility.CodeCompiler/Mosa.Utility.CodeCompiler.csproj
+++ b/Source/Mosa.Utility.CodeCompiler/Mosa.Utility.CodeCompiler.csproj
@@ -11,7 +11,7 @@
     </AssemblyKeyContainerName>
     <AssemblyName>Mosa.Utility.CodeCompiler</AssemblyName>
     <DelaySign>false</DelaySign>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>
     </AppDesignerFolder>

--- a/Source/Mosa.Utility.DebugEngine/Mosa.Utility.DebugEngine.csproj
+++ b/Source/Mosa.Utility.DebugEngine/Mosa.Utility.DebugEngine.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.Utility.DebugEngine</RootNamespace>
     <AssemblyName>Mosa.Utility.DebugEngine</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectGuid>{5B810793-78E2-413C-AA05-FCDD12B7DB04}</ProjectGuid>
     <TargetFrameworkProfile />

--- a/Source/Mosa.Utility.GUI.Common/Mosa.Utility.GUI.Common.csproj
+++ b/Source/Mosa.Utility.GUI.Common/Mosa.Utility.GUI.Common.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.Utility.GUI.Common</RootNamespace>
     <AssemblyName>Mosa.Utility.GUI.Common</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectGuid>{5A813793-78E2-413C-AA05-FCDD12B7DB04}</ProjectGuid>
     <TargetFrameworkProfile />

--- a/Source/Mosa.Utility.Launcher/Mosa.Utility.Launcher.csproj
+++ b/Source/Mosa.Utility.Launcher/Mosa.Utility.Launcher.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.Utility.Launcher</RootNamespace>
     <AssemblyName>Mosa.Utility.Launcher</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/Source/Mosa.Utility.RSP/Mosa.Utility.RSP.csproj
+++ b/Source/Mosa.Utility.RSP/Mosa.Utility.RSP.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.Utility.RSP</RootNamespace>
     <AssemblyName>Mosa.Utility.RSP</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectGuid>{5B810793-78E2-413C-CC05-FCDD12B7DB04}</ProjectGuid>
     <TargetFrameworkProfile />

--- a/Source/Mosa.Utility.SourceCodeGenerator/Mosa.Utility.SourceCodeGenerator.csproj
+++ b/Source/Mosa.Utility.SourceCodeGenerator/Mosa.Utility.SourceCodeGenerator.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.Utility.SourceCodeGenerator</RootNamespace>
     <AssemblyName>Mosa.Utility.SourceCodeGenerator</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Source/Mosa.Utility.UnitTests/Mosa.Utility.UnitTests.csproj
+++ b/Source/Mosa.Utility.UnitTests/Mosa.Utility.UnitTests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.Utility.UnitTests</RootNamespace>
     <AssemblyName>Mosa.Utility.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Source/Mosa.VBEWorld.x86/Mosa.VBEWorld.x86.csproj
+++ b/Source/Mosa.VBEWorld.x86/Mosa.VBEWorld.x86.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.VBEWorld.x86</RootNamespace>
     <AssemblyName>Mosa.VBEWorld.x86</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Source/Mosa.VisualStudio.Template/Mosa.VisualStudio.Template.csproj
+++ b/Source/Mosa.VisualStudio.Template/Mosa.VisualStudio.Template.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.VisualStudio.Template</RootNamespace>
     <AssemblyName>Mosa.VisualStudio.Template</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Source/Mosa.Workspace.Experiment.Debug/Mosa.Workspace.Experiment.Debug.csproj
+++ b/Source/Mosa.Workspace.Experiment.Debug/Mosa.Workspace.Experiment.Debug.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.Workspace.Experiment.Debug</RootNamespace>
     <AssemblyName>Mosa.Workspace.Experiment.Debug</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Source/Mosa.Workspace.FileSystem.Debug/Mosa.Workspace.FileSystem.Debug.csproj
+++ b/Source/Mosa.Workspace.FileSystem.Debug/Mosa.Workspace.FileSystem.Debug.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.Workspace.FileSystem.Debug</RootNamespace>
     <AssemblyName>Mosa.Workspace.FileSystem.Debug</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Source/Mosa.Workspace.GDB.Debug/Mosa.Workspace.GDB.Debug.csproj
+++ b/Source/Mosa.Workspace.GDB.Debug/Mosa.Workspace.GDB.Debug.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mosa.Workspace.GDB.Debug</RootNamespace>
     <AssemblyName>Mosa.Workspace.GDB.Debug</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>


### PR DESCRIPTION
We discussed about downgrading back to 4.6.2 because of mono incompatibility. As i found out, 4.7.1 is ok enough. 4.7.2 does not work yet.