### PR TITLE
017 Fixed Command Line Tools. Added Unix compatibility

### DIFF
--- a/Demos/Run-CoolWorld.bat
+++ b/Demos/Run-CoolWorld.bat
@@ -1,1 +1,0 @@
-start ..\bin\Mosa.Tool.Launcher.exe --q --a --output-map --output-asm --output-debuginfo ..\bin\Mosa.CoolWorld.x86.exe

--- a/Demos/Run-HelloWorld.bat
+++ b/Demos/Run-HelloWorld.bat
@@ -1,1 +1,0 @@
-start ..\bin\Mosa.Tool.Launcher.exe --q --a --qemu --output-asm ..\bin\Mosa.HelloWorld.x86.exe

--- a/Demos/Run-TestWorld.bat
+++ b/Demos/Run-TestWorld.bat
@@ -1,2 +1,0 @@
-start ..\bin\Mosa.Tool.Launcher.exe --q --a --qemu --output-map --output-asm --output-debug ..\bin\Mosa.TestWorld.x86.exe
-

--- a/Demos/unix/Run-CoolWorld.x86.sh
+++ b/Demos/unix/Run-CoolWorld.x86.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd $(dirname $0)
+
+./Run-Demo.x86.sh ../../bin/Mosa.CoolWorld.x86.exe

--- a/Demos/unix/Run-Demo.x64.sh
+++ b/Demos/unix/Run-Demo.x64.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+if [ -z $1 ]; then
+    echo "No input file specifed"
+    exit
+fi
+
+if [ ! -f $1 ]; then
+    echo "Input file does not exists ($1)"
+    exit
+fi
+
+absfile=$(realpath $1)
+
+name=$(basename -- "$absfile")
+name="${filename%.*}"
+
+cd $(dirname $0)/../../bin
+
+mono Mosa.Tool.Compiler.exe \
+	-o ${name}.bin \
+	-a x64 \
+	--mboot v1 \
+	--x86-irq-methods \
+	--base-address 0x00500000 \
+	${absfile} \
+
+if [ $? -ne 0 ]
+then
+    echo "compilation failed"
+	exit
+fi
+
+mono --debug Mosa.Tool.CreateBootImage.exe \
+	-o ${name}.img \
+	--mbr ../Tools/syslinux/3.72/mbr.bin \
+	--boot ../Tools/syslinux/3.72/ldlinux.bin \
+	--syslinux \
+	--volume-label MOSABOOT \
+	--blocks 25000 \
+	--filesystem fat16 \
+	--format img \
+	../Tools/syslinux/3.72/ldlinux.sys \
+	../Tools/syslinux/3.72/mboot.c32 \
+	../Demos/unix/syslinux.cfg \
+	${name}.bin,main.exe
+
+if [ $? -ne 0 ]
+then
+    echo "disk creation failed"
+	exit
+fi
+
+qemu-system-x86_64 -drive format=raw,file=${name}.img

--- a/Demos/unix/Run-Demo.x86.sh
+++ b/Demos/unix/Run-Demo.x86.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+if [ -z $1 ]; then
+    echo "No input file specifed"
+    exit
+fi
+
+if [ ! -f $1 ]; then
+    echo "Input file does not exists ($1)"
+    exit
+fi
+
+absfile=$(realpath $1)
+
+name=$(basename -- "$absfile")
+name="${filename%.*}"
+
+cd $(dirname $0)/../../bin
+
+mono Mosa.Tool.Compiler.exe \
+	-o ${name}.bin \
+	-a x86 \
+	--mboot v1 \
+	--x86-irq-methods \
+	--base-address 0x00500000 \
+	${absfile} \
+	mscorlib.dll \
+	Mosa.Plug.Korlib.dll \
+	Mosa.Plug.Korlib.x86.dll
+
+if [ $? -ne 0 ]
+then
+    echo "compilation failed"
+	exit
+fi
+
+mono --debug Mosa.Tool.CreateBootImage.exe \
+	-o ${name}.img \
+	--mbr ../Tools/syslinux/3.72/mbr.bin \
+	--boot ../Tools/syslinux/3.72/ldlinux.bin \
+	--syslinux \
+	--volume-label MOSABOOT \
+	--blocks 25000 \
+	--filesystem fat16 \
+	--format img \
+	../Tools/syslinux/3.72/ldlinux.sys \
+	../Tools/syslinux/3.72/mboot.c32 \
+	../Demos/unix/syslinux.cfg \
+	${name}.bin,main.exe
+
+if [ $? -ne 0 ]
+then
+    echo "disk creation failed"
+	exit
+fi
+
+qemu-system-i386 -drive format=raw,file=${name}.img

--- a/Demos/unix/Run-HelloWorld.x86.sh
+++ b/Demos/unix/Run-HelloWorld.x86.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd $(dirname $0)
+
+./Run-Demo.x86.sh ../../bin/Mosa.HelloWorld.x86.exe

--- a/Demos/unix/Run-TestWorld-x64.sh
+++ b/Demos/unix/Run-TestWorld-x64.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd $(dirname $0)
+
+./Run-Demo.x64.sh ../../bin/Mosa.TestWorld.x64.exe

--- a/Demos/unix/Run-TestWorld-x86.sh
+++ b/Demos/unix/Run-TestWorld-x86.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd $(dirname $0)
+
+./Run-Demo.x86.sh ../../bin/Mosa.TestWorld.x86.exe

--- a/Demos/unix/syslinux.cfg
+++ b/Demos/unix/syslinux.cfg
@@ -1,0 +1,5 @@
+DEFAULT MOSA
+LABEL MOSA
+  SAY Now trying to boot the MOSA kernel...
+  KERNEL mboot.c32
+  APPEND main.exe

--- a/Demos/win/Run-CoolWorld.x86.bat
+++ b/Demos/win/Run-CoolWorld.x86.bat
@@ -1,0 +1,3 @@
+cd %~dp0
+cd ..\..\bin
+start Mosa.Tool.Launcher.exe --q --a --output-map --output-asm --output-debuginfo Mosa.CoolWorld.x86.exe

--- a/Demos/win/Run-HelloWorld.x86.bat
+++ b/Demos/win/Run-HelloWorld.x86.bat
@@ -1,0 +1,3 @@
+cd %~dp0
+cd ..\..\bin
+start Mosa.Tool.Launcher.exe --q --a --qemu --output-asm Mosa.HelloWorld.x86.exe

--- a/Demos/win/Run-TestWorld.x86.bat
+++ b/Demos/win/Run-TestWorld.x86.bat
@@ -1,0 +1,4 @@
+cd %~dp0
+cd ..\..\bin
+start Mosa.Tool.Launcher.exe --q --a --qemu --output-map --output-asm --output-debug Mosa.TestWorld.x86.exe
+

--- a/Source/Mosa.Tool.Compiler/Compiler.cs
+++ b/Source/Mosa.Tool.Compiler/Compiler.cs
@@ -42,7 +42,9 @@ namespace Mosa.Tool.Compiler
 		/// </summary>
 		public Compiler()
 		{
-			usageString = "Usage: mosacl -o outputfile --Architecture=[x86|x64|ARMv6] --format=[ELF32|ELF64] {--boot=[mb0.7]} {additional options} inputfiles";
+			usageString = @"Usage: Mosa.Tool.Compiler.exe -o outputfile --achitecture=[x86|x64|ARMv6] --format=[ELF32|ELF64] {--boot=[mb0.7]} {additional options} inputfiles.
+
+Example: Mosa.Tool.Compiler.exe -o Mosa.HelloWorld.x86.bin -a x86 --mboot v1 --x86-irq-methods --base-address 0x00500000 Mosa.HelloWorld.x86.exe mscorlib.dll Mosa.Plug.Korlib.dll Mosa.Plug.Korlib.x86.dll";
 		}
 
 		#endregion Constructors
@@ -100,6 +102,7 @@ namespace Mosa.Tool.Compiler
 			catch (Exception e)
 			{
 				ShowError(e.Message);
+				Environment.Exit(1);
 				return;
 			}
 
@@ -116,6 +119,8 @@ namespace Mosa.Tool.Compiler
 			catch (CompilerException ce)
 			{
 				ShowError(ce.Message);
+				Environment.Exit(1);
+				return;
 			}
 
 			DateTime end = DateTime.Now;

--- a/Source/Mosa.Tool.Compiler/Mosa.Tool.Compiler.csproj
+++ b/Source/Mosa.Tool.Compiler/Mosa.Tool.Compiler.csproj
@@ -13,7 +13,6 @@
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
-    <DelaySign>false</DelaySign>
     <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>
@@ -103,6 +102,10 @@
     <ProjectReference Include="..\Mosa.Platform.x86\Mosa.Platform.x86.csproj">
       <Project>{de30cbe9-50f3-4a3e-bcc9-a8a36348530e}</Project>
       <Name>Mosa.Platform.x86</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Mosa.Platform.x64\Mosa.Platform.x64.csproj">
+      <Project>{F445DB8E-E25A-41EF-A158-C742F14E94E4}</Project>
+      <Name>Mosa.Platform.x64</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Source/Mosa.Tool.Compiler/Options.cs
+++ b/Source/Mosa.Tool.Compiler/Options.cs
@@ -113,6 +113,8 @@ namespace Mosa.Tool.Compiler
 			switch (architecture.ToLower())
 			{
 				case "x86": return Mosa.Platform.x86.Architecture.CreateArchitecture(Mosa.Platform.x86.ArchitectureFeatureFlags.AutoDetect);
+				case "x64": return Mosa.Platform.x64.Architecture.CreateArchitecture(Mosa.Platform.x64.ArchitectureFeatureFlags.AutoDetect);
+				case "armv6": return Mosa.Platform.ARMv6.Architecture.CreateArchitecture(Mosa.Platform.ARMv6.ArchitectureFeatureFlags.AutoDetect);
 				default: throw new NotImplementCompilerException(string.Format("Unknown or unsupported Architecture {0}.", architecture));
 			}
 		}

--- a/Source/Mosa.Tool.Compiler/Options.cs
+++ b/Source/Mosa.Tool.Compiler/Options.cs
@@ -48,6 +48,9 @@ namespace Mosa.Tool.Compiler
 		[Option('a', "architecture", HelpText = "Select one of the MOSA architectures to compile for [x86|x64|ARMv6].", Required = true)]
 		public string Architecture { set { CompilerOptions.Architecture = SelectArchitecture(value); } }
 
+		[Option("mboot", HelpText = "Select multiboot specification [v1|v2].")]
+		public string Boot { set { CompilerOptions.MultibootSpecification = GetMultibootSpecification(value); } }
+
 		[Option('f', "format", HelpText = "Select the format of the binary file to create [ELF32|ELF64].")]
 		public string LinkerFormat { set { CompilerOptions.LinkerFormatType = GetLinkerFactory(value); } }
 
@@ -64,13 +67,13 @@ namespace Mosa.Tool.Compiler
 		public bool EnableStaticAllocation { set { CompilerOptions.EnableStaticAllocations = value; } }
 
 		[Option("enable-static-alloc", HelpText = "Performs static allocations at compile time.")]
-		public bool EnableStaticAllocationTrue { set { EnableStaticAllocation = true; } }
+		public bool EnableStaticAllocationTrue { set { EnableStaticAllocation = value; } }
 
 		[Option("ssa", HelpText = "Performs single static assignments at compile time.")]
 		public bool EnableSSA { set { CompilerOptions.EnableSSA = value; } }
 
 		[Option("enable-single-static-assignment-form", HelpText = "Performs single static assignments at compile time.")]
-		public bool EnableSSATrue { set { EnableSSA = true; } }
+		public bool EnableSSATrue { set { EnableSSA = value; } }
 
 		[Option("optimize-ir", HelpText = "Performs ir-level optimizations.")]
 		public bool EnableIROptimizaion { set { CompilerOptions.EnableIROptimizations = value; } }
@@ -122,6 +125,16 @@ namespace Mosa.Tool.Compiler
 				case "elf32": return LinkerFormatType.Elf32;
 				case "elf64": return LinkerFormatType.Elf64;
 				default: return LinkerFormatType.Elf32;
+			}
+		}
+
+		private static MultibootSpecification GetMultibootSpecification(string format)
+		{
+			switch (format.ToLower())
+			{
+				case "v1": return Mosa.Compiler.Framework.MultibootSpecification.V1;
+				case "v2": return Mosa.Compiler.Framework.MultibootSpecification.V2;
+				default: throw new NotImplementCompilerException(string.Format("Unknown or unsupported MultibootSpecification {0}.", format));
 			}
 		}
 

--- a/Source/Mosa.Tool.CreateBootImage/Options.cs
+++ b/Source/Mosa.Tool.CreateBootImage/Options.cs
@@ -61,12 +61,12 @@ namespace Mosa.Tool.CreateBootImage
 			get { return options.MediaLastSnapGuid.ToString(); }
 		}
 
-		[Option("filesystem",HelpText ="FileSystem [fat12|fat16|fat32]")]
+		[Option("filesystem", HelpText = "FileSystem [fat12|fat16|fat32]")]
 		public string FileSystem
 		{
 			set
 			{
-				options.FileSystem= (FileSystem)Enum.Parse(typeof(FileSystem), value, true);
+				options.FileSystem = (FileSystem)Enum.Parse(typeof(FileSystem), value, true);
 			}
 		}
 

--- a/Source/Mosa.Tool.CreateBootImage/Options.cs
+++ b/Source/Mosa.Tool.CreateBootImage/Options.cs
@@ -13,37 +13,31 @@ namespace Mosa.Tool.CreateBootImage
 	{
 		private BootImageOptions options;
 
-		[Option('m', "mbr")]
+		[Option('m', "mbr", HelpText ="MBR file")]
 		public string MBRFile
 		{
 			set { options.MBROption = true; options.MBRCode = File.ReadAllBytes(value); }
 		}
 
-		[Option('b', "boot")]
+		[Option('b', "boot", HelpText ="FAT boot code file")]
 		public string BootCodeFile
 		{
 			set { options.FatBootCode = File.ReadAllBytes(value); }
 		}
 
-		[Option("vhd")]
-		public bool VHDImageFormat
+		[Option('o', "out", Required = true, HelpText ="Output disk file name")]
+		public string DiskImageFileName
 		{
-			set { options.ImageFormat = ImageFormat.VHD; }
-			get { return (options.ImageFormat == ImageFormat.VHD); }
+			set { options.DiskImageFileName = value; }
 		}
 
-		[Option("img")]
-		public bool IMGImageFormat
+		[Option("format", HelpText ="Disk image format [img|iso|vhd|vdi|vmdk]")]
+		public string ImageFormat
 		{
-			set { options.ImageFormat = ImageFormat.IMG; }
-			get { return (options.ImageFormat == ImageFormat.IMG); }
-		}
-
-		[Option("vdi")]
-		public bool VDIImageFormat
-		{
-			set { options.ImageFormat = ImageFormat.VDI; }
-			get { return (options.ImageFormat == ImageFormat.VDI); }
+			set
+			{
+				options.ImageFormat = (ImageFormat)Enum.Parse(typeof(ImageFormat), value, true);
+			}
 		}
 
 		[Option("syslinux")]
@@ -67,25 +61,13 @@ namespace Mosa.Tool.CreateBootImage
 			get { return options.MediaLastSnapGuid.ToString(); }
 		}
 
-		[Option("fat32")]
-		public bool Fat32FileSystem
+		[Option("filesystem",HelpText ="FileSystem [fat12|fat16|fat32]")]
+		public string FileSystem
 		{
-			set { options.FileSystem = FileSystem.FAT32; }
-			get { return (options.FileSystem == FileSystem.FAT32); }
-		}
-
-		[Option("fat16")]
-		public bool Fat16FileSystem
-		{
-			set { options.FileSystem = FileSystem.FAT16; }
-			get { return (options.FileSystem == FileSystem.FAT16); }
-		}
-
-		[Option("fat12")]
-		public bool Fat12FileSystem
-		{
-			set { options.FileSystem = FileSystem.FAT12; }
-			get { return (options.FileSystem == FileSystem.FAT12); }
+			set
+			{
+				options.FileSystem= (FileSystem)Enum.Parse(typeof(FileSystem), value, true);
+			}
 		}
 
 		[Option("blocks")]
@@ -95,47 +77,42 @@ namespace Mosa.Tool.CreateBootImage
 			get { return options.BlockCount; }
 		}
 
-		[Option("volume")]
+		[Option("volume-label", HelpText ="Name of the volume")]
 		public string VolumeLabel
 		{
 			set { options.VolumeLabel = value; }
 			get { return options.VolumeLabel; }
 		}
 
-		[Option("file", Separator = ',', HelpText = "A list of files which will be included in the output image file.")]
+		[Value(0, HelpText = "A list of files which will be included in the output image file.")]
 		public IEnumerable<string> RawFileList
 		{
 			set
 			{
-				var list = (IList<string>)value;
-
-				for (int x = 0; x < list.Count; x++)
+				foreach (var itm in value)
 				{
-					string path = list[x];
-					if (Path.IsPathRooted(path))
+					var ar = itm.Split(',');
+					string src = ar[0];
+					string dst = null;
+
+					if (ar.Length == 1)
 					{
-						if (x + 1 < list.Count) //Is there a next entry?
-						{
-							if (Path.IsPathRooted(list[x + 1]))
-							{
-								options.IncludeFiles.Add(new IncludeFile(path));
-							}
-							else //If the next is not rooted, it's the new name of the files
-							{
-								options.IncludeFiles.Add(new IncludeFile(path, list[++x]));
-							}
-						}
-						else
-						{
-							options.IncludeFiles.Add(new IncludeFile(path));
-						}
+						dst = Path.GetFileName(ar[0]);
 					}
-					else
+					else if (ar.Length >= 2)
+					{
+						dst = ar[1];
+					}
+
+					if (Path.IsPathRooted(src))
 					{
 						var currDir = Environment.CurrentDirectory;
-						options.IncludeFiles.Add(new IncludeFile(Path.GetFullPath(Path.Combine(currDir, path))));
+						src = Path.GetFullPath(Path.Combine(currDir, src));
 					}
+
+					options.IncludeFiles.Add(new IncludeFile(src, dst));
 				}
+
 			}
 		}
 


### PR DESCRIPTION
With the current Command line tools (Tool.Compiler & Tool.CreateDiskImage) it was impossible to create working boot image. This is fixed now. For now: Please keep the Command Line tools up to date, if you add/change options. Do not focus only on Tool.Launcher.

Secondary, a unix stack was added for the demo scripts.

Now it's possible (again) to compile mosa kernels on unix without using a custom builder. As you know, the Launcher Tool does not work on unix because of the ugly Controls.