### PR TITLE
Make x64 loadable

### DIFF
--- a/Demos/unix/Run-TestWorld-x64.sh
+++ b/Demos/unix/Run-TestWorld-x64.sh
@@ -2,4 +2,4 @@
 
 cd $(dirname $0)
 
-./Run-Demo.x64.sh ../../bin/Mosa.TestWorld.x64.exe
+./Run-Demo.x64.sh "$@" --assembly ../../bin/Mosa.TestWorld.x64.exe

--- a/Demos/unix/bochs-x64.bxrc
+++ b/Demos/unix/bochs-x64.bxrc
@@ -1,0 +1,11 @@
+megs: 128
+ata0: enabled=1,ioaddr1=0x1f0,ioaddr2=0x3f0,irq=14
+cpu: model=atom_n270
+boot: cdrom,disk
+log: "emulator.log"
+romimage: file="/usr/share/bochs/BIOS-bochs-latest"
+vgaromimage: file="/usr/share/bochs/VGABIOS-lgpl-latest"
+display_library: x, options="gui_debug"
+ata0-master: type=disk,path="Mosa.TestWorld.x64.img",biosdetect=none,cylinders=0,heads=0,spt=0
+com1: enabled=1, mode=file, dev=kernel.log
+magic_break: enabled=1

--- a/Source/Mosa.Compiler.Framework/Linker/Elf/MachineType.cs
+++ b/Source/Mosa.Compiler.Framework/Linker/Elf/MachineType.cs
@@ -25,6 +25,11 @@ namespace Mosa.Compiler.Framework.Linker.Elf
 		/// <summary>
 		/// Intel IA-64 processor architecture
 		/// </summary>
-		IA_64 = 50
+		IA_64 = 50,
+
+		/// <summary>
+		/// Intel x86_64 processor architecture
+		/// </summary>
+		x86_64 = 62
 	}
 }

--- a/Source/Mosa.Compiler.Framework/Linker/Elf/ProgramHeader.cs
+++ b/Source/Mosa.Compiler.Framework/Linker/Elf/ProgramHeader.cs
@@ -15,7 +15,7 @@ namespace Mosa.Compiler.Framework.Linker.Elf
 		/// </summary>
 		public const ushort EntrySize32 = 0x20;
 
-		internal const ushort EntrySize64 = 0x28;
+		internal const ushort EntrySize64 = 0x38;
 
 		/// <summary>
 		/// This member tells what kind of segment this array element describes or how to

--- a/Source/Mosa.Platform.x64/Architecture.cs
+++ b/Source/Mosa.Platform.x64/Architecture.cs
@@ -35,7 +35,7 @@ namespace Mosa.Platform.x64
 		/// <value>
 		/// The type of the elf machine.
 		/// </value>
-		public override MachineType MachineType { get { return MachineType.IA_64; } }
+		public override MachineType MachineType { get { return MachineType.Intel386; } }
 
 		/// <summary>
 		/// Defines the register set of the target architecture.

--- a/Source/Mosa.Tool.Explorer/DisassemblyStage.cs
+++ b/Source/Mosa.Tool.Explorer/DisassemblyStage.cs
@@ -33,6 +33,7 @@ namespace Mosa.Tool.Explorer
 			{
 				case MachineType.Intel386: mode = ArchitectureMode.x86_32; break;
 				case MachineType.IA_64: mode = ArchitectureMode.x86_64; break;
+				case MachineType.x86_64: mode = ArchitectureMode.x86_64; break;
 				case MachineType.ARM:
 				default:
 					trace.Log($"Unable to disassemble binary for machine type: {Architecture.MachineType}");


### PR DESCRIPTION
- Fixed a Bug in ELF64-Header (EntrySize64 had wrong size)
- MachineType IA64 refers to Itanium64, which is wrong. The correct Arch is x64_86. There's no dedicated x64 only. All Bootloaders (syslinux, grub, qemu -kernel) will refuse them to load, if the machine has no Itanium processor.
- Since Architecture.MachineType is for ELF-Type only (Quote from C#-Comment, Architecture.cs:33: `Gets the type of the elf machine`. If not wished, another property must be added), it must be i386, because otherwiese most bootloaders whill refuse loading (grub1, qemu -kernel, syslinux) because they cannot jump directly into x64 code. Forcing jumping into x64 directly from grub2/patches grub2 will restrict the use of mosa very much. ELF needs a small x86 stub. This is like all OS-Kernels are working (Rust, Linux, osdev recommendation and so on).

With that changes, i was able to load a kernel. There are still problems with the code generation itself, but this is not the goal of this patch.