### PR TITLE
021 fix resolve error

### DIFF
--- a/Demos/unix/Run-Demo.x86.sh
+++ b/Demos/unix/Run-Demo.x86.sh
@@ -17,16 +17,20 @@ name="${name%.*}"
 
 cd $(dirname $0)/../../bin
 
+echo Changing directory to $(pwd)
+
+set -x
+
 mono Mosa.Tool.Compiler.exe \
 	-o ${name}.bin \
 	-a x86 \
 	--mboot v1 \
 	--x86-irq-methods \
 	--base-address 0x00500000 \
-	${absfile} \
 	mscorlib.dll \
 	Mosa.Plug.Korlib.dll \
-	Mosa.Plug.Korlib.x86.dll
+	Mosa.Plug.Korlib.x86.dll \
+	${absfile}
 
 if [ $? -ne 0 ]
 then

--- a/Source/Mosa.Compiler.MosaTypeSystem/MosaModuleLoader.cs
+++ b/Source/Mosa.Compiler.MosaTypeSystem/MosaModuleLoader.cs
@@ -38,6 +38,18 @@ namespace Mosa.Compiler.MosaTypeSystem
 
 			foreach (var assemblyRef in module.GetAssemblyRefs())
 			{
+				// There are cases, where the Resolver will not be able to resolve the assemblis
+				// automaticly, even if they are in the same directory.
+				// (maybe this has todo with linux / specific mono versions?)
+				// So, try to load them manually recursivly first.
+				var subModuleFile = Path.Combine(Path.GetDirectoryName(module.Location), assemblyRef.Name + ".dll");
+				if (File.Exists(subModuleFile))
+				{
+					var subModule = ModuleDefMD.Load(subModuleFile, Resolver.DefaultModuleContext);
+					if (subModule != null)
+						LoadDependencies(subModule);
+				}
+
 				var assembly = Resolver.ResolveThrow(assemblyRef, null);
 
 				foreach (var moduleRef in assembly.Modules)


### PR DESCRIPTION
There are cases, where the Resolver will not be able to resolve the assemblis
automaticly, even if they are in the same directory.
(maybe this has todo with linux / specific mono versions?)
So, try to load them manually recursivly first.

The only way without this patch (maybe only on unix / mono?) would be to add ALL assemblies manually to the assembly list, in the order of most nested assemblies first in the list. This is not practicable, of course, because this means massive manual configuration for every different Mosa-OS.