### PR TITLE
029 fix bochs location

### DIFF
--- a/Source/Mosa.Utility.Launcher/AppLocations.cs
+++ b/Source/Mosa.Utility.Launcher/AppLocations.cs
@@ -147,22 +147,23 @@ namespace Mosa.Utility.Launcher
 				);
 			}
 
-			if (string.IsNullOrEmpty(BOCHSBIOSDirectory))
+			if (string.IsNullOrEmpty(BOCHSBIOSDirectory) && !string.IsNullOrEmpty(BOCHS))
 			{
-				BOCHSBIOSDirectory = Path.GetDirectoryName(
-					TryFind(
+				var dir = TryFind(
 						new string[] { "BIOS-bochs-latest" },
 						new string[] {
-								Path.GetDirectoryName(BOCHS),
-								"/usr/share/bochs/"
+											Path.GetDirectoryName(BOCHS),
+											"/usr/share/bochs/"
 						},
 						new string[]
 						{
-								@"..\packages",
-								@"..\..\packages",
+											@"..\packages",
+											@"..\..\packages",
 						}
-					)
-				);
+					);
+
+				if (!string.IsNullOrEmpty(dir))
+					BOCHSBIOSDirectory = Path.GetDirectoryName(dir);
 			}
 
 			if (string.IsNullOrEmpty(VMwarePlayer))


### PR DESCRIPTION
When BOCHS variable is invalid (why ever), it will crash on Windows because of Path.GetDirectoryName(BOCHS). Fixed.