### PR TITLE
Specify Interrupt Method

### DIFF
--- a/Source/Mosa.Compiler.Framework/CompilerOptions.cs
+++ b/Source/Mosa.Compiler.Framework/CompilerOptions.cs
@@ -47,6 +47,12 @@ namespace Mosa.Compiler.Framework
 		public string DebugFile { get; set; }
 
 		/// <summary>
+		/// Gets or sets interrupt method name to override the architecture specific default method
+		/// </summary>
+		/// <example>Mosa.Kernel.x86.IDT::ProcessInterrupt</example>
+		public string InterruptMethodName { get; set; }
+
+		/// <summary>
 		/// Gets or sets a value indicating whether SSA is enabled.
 		/// </summary>
 		public bool EnableSSA { get; set; }

--- a/Source/Mosa.Compiler.MosaTypeSystem/TypeSystem.cs
+++ b/Source/Mosa.Compiler.MosaTypeSystem/TypeSystem.cs
@@ -121,6 +121,34 @@ namespace Mosa.Compiler.MosaTypeSystem
 			return null;
 		}
 
+		/// <summary>
+		/// Get a type by fullName
+		/// </summary>
+		/// <param name="fullName">fullName like namespace.typeName</param>
+		public MosaType GetTypeByName(string fullName)
+		{
+			if (string.IsNullOrEmpty(fullName))
+				return null;
+
+			string ns;
+			string typeName;
+
+			var indexOfLastDot = fullName.LastIndexOf('.');
+			if (indexOfLastDot == -1)
+			{
+				// type is in no namespace
+				ns = "";
+				typeName = fullName;
+			}
+			else
+			{
+				ns = fullName.Substring(0, indexOfLastDot);
+				typeName = fullName.Substring(indexOfLastDot + 1);
+			}
+
+			return GetTypeByName(ns, typeName);
+		}
+
 		public MosaModule GetModuleByAssembly(string name)
 		{
 			foreach (var module in Modules)

--- a/Source/Mosa.Platform.x86/Intrinsic/IRQs.cs
+++ b/Source/Mosa.Platform.x86/Intrinsic/IRQs.cs
@@ -10,14 +10,27 @@ namespace Mosa.Platform.x86.Intrinsic
 	/// </summary>
 	static partial class IntrinsicMethods
 	{
+
+		private static readonly string DefaultInterruptMethodName = "Mosa.Kernel.x86.IDT::ProcessInterrupt";
+
 		private static void InsertIRQ(int irq, Context context, MethodCompiler methodCompiler)
 		{
-			var type = methodCompiler.TypeSystem.GetTypeByName("Mosa.Kernel.x86", "IDT");
+			var interruptMethodName = methodCompiler.Compiler.CompilerOptions.InterruptMethodName;
+			if (string.IsNullOrEmpty(interruptMethodName))
+				interruptMethodName = DefaultInterruptMethodName;
+
+			var ar = interruptMethodName.Split(new string[] { "::" }, System.StringSplitOptions.None);
+			if (ar.Length != 2)
+				return;
+			var typeFullname = ar[0];
+			var methodName = ar[1];
+
+			var type = methodCompiler.TypeSystem.GetTypeByName(typeFullname);
 
 			if (type == null)
 				return;
 
-			var method = type.FindMethodByName("ProcessInterrupt");
+			var method = type.FindMethodByName(methodName);
 
 			if (method == null)
 				return;

--- a/Source/Mosa.Utility.Launcher/Builder.cs
+++ b/Source/Mosa.Utility.Launcher/Builder.cs
@@ -117,9 +117,11 @@ namespace Mosa.Utility.Launcher
 				compiler.CompilerOptions.EmitStaticRelocations = LauncherOptions.EmitStaticRelocations;
 				compiler.CompilerOptions.EnableMethodScanner = LauncherOptions.EnableMethodScanner;
 				compiler.CompilerOptions.EnableBitTracker = LauncherOptions.EnableBitTracker;
+				compiler.CompilerOptions.InterruptMethodName = LauncherOptions.InterruptMethodName;
 
 				compiler.CompilerOptions.CreateExtraSections = LauncherOptions.CreateExtraSections;
 				compiler.CompilerOptions.CreateExtraProgramHeaders = LauncherOptions.CreateExtraProgramHeaders;
+
 
 				if (LauncherOptions.GenerateMapFile)
 				{

--- a/Source/Mosa.Utility.Launcher/LauncherOptions.cs
+++ b/Source/Mosa.Utility.Launcher/LauncherOptions.cs
@@ -70,6 +70,13 @@ namespace Mosa.Utility.Launcher
 		[Option("emulator-memory", HelpText = "Emulator memory in megabytes.")]
 		public uint EmulatorMemoryInMB { get; set; }
 
+		/// <summary>
+		/// Gets or sets interrupt method name to override the architecture specific default method
+		/// </summary>
+		/// <example>Mosa.Kernel.x86.IDT::ProcessInterrupt</example>
+		[Option("interrupt-method")]
+		public string InterruptMethodName { get; set; }
+
 		[Option("ssa")]
 		public bool EnableSSA { get; set; }
 


### PR DESCRIPTION
Added an option to set a custom path to Interrupt name. Reasons:

- Naming Convention specify, namespace and type name should match cs file path. This is not the case if working in another namespace.
- Keeping the namespaces clean, if no functionality of the reference implementation is needed.

At the Moment, IDT is the only class, that forces a specific placement within the namespace. This will forces a using statement at the top of the another accessing cs file, or absolute namespace accessors. The code is not clean in both cases.