### PR TITLE
fixed DWARF line numbers

### DIFF
--- a/Source/Mosa.Compiler.Extension.Dwarf/DwarfCompilerStage.cs
+++ b/Source/Mosa.Compiler.Extension.Dwarf/DwarfCompilerStage.cs
@@ -5,6 +5,7 @@ using Mosa.Compiler.Framework;
 using Mosa.Compiler.Framework.Linker;
 using Mosa.Compiler.Framework.Linker.Elf;
 using Mosa.Compiler.Framework.Source;
+using Mosa.Compiler.Framework.Trace;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -311,10 +312,16 @@ namespace Mosa.Compiler.Extensions.Dwarf
 
 					foreach (var loc in locations)
 					{
+
+						if (loc.StartLine == 0xFEEFEE)
+							continue;
+
 						uint newPc = methodVirtAddr + (uint)loc.Address;
 						uint pcDiff = newPc - pc;
 
 						int lineDiff = loc.StartLine - (int)line;
+						if (Math.Abs(lineDiff) > 100000)
+							PostCompilerTraceEvent(CompilerEvent.Warning, $"Warning Line Numbers wrong: Location={loc} Method={method} lineDiff={lineDiff}");
 
 						var newFile = FileHash[loc.Filename].FileNum;
 

--- a/Source/Mosa.Compiler.Extension.Dwarf/Mosa.Compiler.Extension.Dwarf.csproj
+++ b/Source/Mosa.Compiler.Extension.Dwarf/Mosa.Compiler.Extension.Dwarf.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -8,6 +8,7 @@
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\..\bin</OutputPath>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>..\..\bin</OutputPath>


### PR DESCRIPTION
- Ignoring all Lines with value 0xFEEFEE.
- All Line-Warnings are now gone
- Added Line-Number-Warning. There's now no warning anymore, because skipping 0xFEEFEE.