### PR TITLE
SL019 appveyor build order

### DIFF
--- a/Source/Compile.bat
+++ b/Source/Compile.bat
@@ -3,6 +3,16 @@ if exist %SYSTEMROOT%\Microsoft.NET\Framework64\v4.0.30319\msbuild.exe set MSBUI
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\msbuild.exe" set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\msbuild.exe"
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\amd64\msbuild.exe" set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\amd64\msbuild.exe"
 
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\msbuild.exe" set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\msbuild.exe"
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\msbuild.exe" set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\msbuild.exe"
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe"
+if exist "D:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" set MSBUILD="D:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe"
+
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\amd64\msbuild.exe" set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\amd64\msbuild.exe"
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\amd64\msbuild.exe" set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\amd64\msbuild.exe"
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64\msbuild.exe" set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64\msbuild.exe"
+if exist "D:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64\msbuild.exe" set MSBUILD="D:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64\msbuild.exe"
+
 ..\Tools\nuget\nuget.exe restore MOSA.sln
 
 %MSBUILD% /nologo /m /p:BuildInParallel=true /p:Configuration=Release /p:Platform="Any CPU" MOSA.sln

--- a/Source/Compile.sh
+++ b/Source/Compile.sh
@@ -1,5 +1,14 @@
-#cp ../3rdParty/*.dll ../bin/
 cd $(dirname $0) #Go to directory containing this script, if called from elsewhre
+
+if grep -q Microsoft /proc/version; then
+  echo "Detected Windows (WSL)"
+  
+  cmd.exe /C Compile.bat
+  exit
+fi
+
+echo "Detected Native Linux"
+
 mono ../Tools/nuget/nuget.exe restore Mosa.Tool.Mosactl.sln
 mono ../Tools/nuget/nuget.exe restore Mosa.sln
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,8 @@ configuration: Release
 platform: Any CPU
 image:
 - Visual Studio 2019
-- Visual Studio 2017
 - Ubuntu1804
+- Visual Studio 2017
 
 shallow_clone: true
 


### PR DESCRIPTION
Reasons:
With CI/CD, we want to check our builds. Often, we have minor changes, and want to quick check them, just to be sure, that even the minor change does not affect the build, but we need to wait for the build.

In 99,9% of the cases, we want to check MS VS219 Build and Mono Build. The MS VS2917 Build is from minor interest. So I have moved them down in the build order list.