### PR TITLE
appveyor build order

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,8 @@ configuration: Release
 platform: Any CPU
 image:
 - Visual Studio 2019
-- Visual Studio 2017
 - Ubuntu1804
+- Visual Studio 2017
 
 shallow_clone: true
 


### PR DESCRIPTION
Reasons:
With CI/CD, we want to check our builds. Often, we have minor changes, and want to quick check them, just to be sure, that even the minor change does not affect the build, but we need to wait for the build.

In 99,9% of the cases, we want to check MS VS219 Build and Mono Build. The MS VS2917 Build is from minor interest. So I have moved them down in the build order list.