### PR TITLE
use huntfor function in explorer

### DIFF
--- a/Source/Mosa.Tool.Explorer/MainForm.cs
+++ b/Source/Mosa.Tool.Explorer/MainForm.cs
@@ -6,6 +6,7 @@ using Mosa.Compiler.Framework;
 using Mosa.Compiler.Framework.Linker;
 using Mosa.Compiler.Framework.Trace;
 using Mosa.Compiler.MosaTypeSystem;
+using Mosa.Utility.Launcher;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -770,13 +771,15 @@ namespace Mosa.Tool.Explorer
 			Compiler.CompilerOptions.SearchPaths.Clear();
 			Compiler.CompilerOptions.SourceFiles.Clear();
 
+			var sourceDirectory = Path.GetDirectoryName(filename);
 			Compiler.CompilerOptions.AddSearchPath(includeDirectory);
-			Compiler.CompilerOptions.AddSearchPath(Path.GetDirectoryName(filename));
+			Compiler.CompilerOptions.AddSearchPath(sourceDirectory);
 
+			var fileHunter = new FileHunter(sourceDirectory);
 			Compiler.CompilerOptions.AddSourceFile(filename);
-			Compiler.CompilerOptions.AddSourceFile("Mosa.Plug.Korlib.dll");
-			Compiler.CompilerOptions.AddSourceFile("Mosa.Plug.Korlib." + platform + ".dll");
-			Compiler.CompilerOptions.AddSourceFile("Mosa.Runtime." + platform + ".dll");
+			Compiler.CompilerOptions.AddSourceFile(fileHunter.HuntFile("Mosa.Plug.Korlib.dll")?.FullName);
+			Compiler.CompilerOptions.AddSourceFile(fileHunter.HuntFile("Mosa.Plug.Korlib." + platform + ".dll")?.FullName);
+			Compiler.CompilerOptions.AddSourceFile(fileHunter.HuntFile("Mosa.Runtime." + platform + ".dll")?.FullName);
 
 			Compiler.Load();
 		}

--- a/Source/Mosa.Tool.Explorer/Mosa.Tool.Explorer.csproj
+++ b/Source/Mosa.Tool.Explorer/Mosa.Tool.Explorer.csproj
@@ -65,6 +65,7 @@
     <ProjectReference Include="..\Mosa.Platform.x64\Mosa.Platform.x64.csproj" />
     <ProjectReference Include="..\Mosa.Platform.x86\Mosa.Platform.x86.csproj" />
     <ProjectReference Include="..\Mosa.Utility.CodeCompiler\Mosa.Utility.CodeCompiler.csproj" />
+    <ProjectReference Include="..\Mosa.Utility.Launcher\Mosa.Utility.Launcher.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="magnifier.ico" />

--- a/Source/Mosa.Utility.Launcher/Builder.cs
+++ b/Source/Mosa.Utility.Launcher/Builder.cs
@@ -60,20 +60,6 @@ namespace Mosa.Utility.Launcher
 			Counters.Add(data);
 		}
 
-		private FileInfo HuntFor(string filename)
-		{
-			var directory = Hunt(filename);
-
-			if (directory == null)
-				return null;
-
-			var full = Path.Combine(directory, filename);
-
-			var file = new FileInfo(full);
-
-			return file;
-		}
-
 		private List<BaseCompilerExtension> GetCompilerExtensions()
 		{
 			return new List<BaseCompilerExtension>()
@@ -162,11 +148,13 @@ namespace Mosa.Utility.Launcher
 				compiler.CompilerOptions.AddSourceFile(LauncherOptions.SourceFile);
 				compiler.CompilerOptions.AddSearchPaths(LauncherOptions.Paths);
 
+				var fileHunter = new FileHunter(Path.GetDirectoryName(LauncherOptions.SourceFile));
+
 				var inputFiles = new List<FileInfo>
 				{
-					(LauncherOptions.HuntForCorLib) ? HuntFor("mscorlib.dll") : null,
-					(LauncherOptions.PlugKorlib) ? HuntFor("Mosa.Plug.Korlib.dll") : null,
-					(LauncherOptions.PlugKorlib) ? HuntFor("Mosa.Plug.Korlib." + LauncherOptions.PlatformType.ToString() + ".dll"): null,
+					(LauncherOptions.HuntForCorLib) ? fileHunter.HuntFile("mscorlib.dll") : null,
+					(LauncherOptions.PlugKorlib) ? fileHunter.HuntFile("Mosa.Plug.Korlib.dll") : null,
+					(LauncherOptions.PlugKorlib) ? fileHunter.HuntFile("Mosa.Plug.Korlib." + LauncherOptions.PlatformType.ToString() + ".dll"): null,
 				};
 
 				compiler.CompilerOptions.AddSourceFiles(inputFiles);
@@ -501,63 +489,6 @@ namespace Mosa.Utility.Launcher
 			}
 		}
 
-		private static bool Check(string directory, string filename)
-		{
-			return File.Exists(Path.GetFullPath(Path.Combine(directory, filename)));
-		}
 
-		private string Hunt(string filename)
-		{
-			// Only hunt if it's not in any of the path directories already, or the source directory
-
-			// let's check the source directory
-			string path = Path.GetDirectoryName(LauncherOptions.SourceFile);
-
-			if (Check(path, filename))
-				return path;
-
-			// check current directory
-			if (Check(Environment.CurrentDirectory, filename))
-			{
-				return Environment.CurrentDirectory;
-			}
-
-			// check within packages directory in 1 or 2 directories back
-			// this is how VS organizes projects and packages
-
-			var result = SearchSubdirectories(Path.Combine(Path.GetDirectoryName(LauncherOptions.SourceFile), "..", "packages"), filename);
-
-			if (result != null)
-				return result;
-
-			result = SearchSubdirectories(Path.Combine(Path.GetDirectoryName(LauncherOptions.SourceFile), "..", "..", "packages"), filename);
-
-			if (result != null)
-				return result;
-
-			result = SearchSubdirectories(Path.Combine(Environment.CurrentDirectory, "..", "packages"), filename);
-
-			if (result != null)
-				return result;
-
-			result = SearchSubdirectories(Path.Combine(Environment.CurrentDirectory, "..", "..", "packages"), filename);
-
-			return result;
-		}
-
-		private static string SearchSubdirectories(string path, string filename)
-		{
-			if (Directory.Exists(path))
-			{
-				var result = Directory.GetFiles(path, filename, SearchOption.AllDirectories);
-
-				if (result?.Length >= 1)
-				{
-					return Path.GetDirectoryName(result[0]);
-				}
-			}
-
-			return null;
-		}
 	}
 }

--- a/Source/Mosa.Utility.Launcher/FileHunter.cs
+++ b/Source/Mosa.Utility.Launcher/FileHunter.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Mosa.Utility.Launcher
+{
+	public class FileHunter
+	{
+
+		public string SourceDirectory { get; set; }
+
+		public FileHunter(string sourceDirectory)
+		{
+			SourceDirectory = sourceDirectory;
+		}
+
+		public FileInfo HuntFile(string filename)
+		{
+			var directory = HuntDirectory(filename);
+
+			if (directory == null)
+				return null;
+
+			var full = Path.Combine(directory, filename);
+
+			var file = new FileInfo(full);
+
+			return file;
+		}
+
+		private bool Check(string directory, string filename)
+		{
+			return File.Exists(Path.GetFullPath(Path.Combine(directory, filename)));
+		}
+
+		public string HuntDirectory(string filename)
+		{
+			// Only hunt if it's not in any of the path directories already, or the source directory
+
+			// let's check the source directory
+
+			if (Check(SourceDirectory, filename))
+				return SourceDirectory;
+
+			// check current directory
+			if (Check(Environment.CurrentDirectory, filename))
+			{
+				return Environment.CurrentDirectory;
+			}
+
+			// check within packages directory in 1 or 2 directories back
+			// this is how VS organizes projects and packages
+
+			var result = SearchSubdirectories(Path.Combine(SourceDirectory, "..", "packages"), filename);
+
+			if (result != null)
+				return result;
+
+			result = SearchSubdirectories(Path.Combine(SourceDirectory, "..", "..", "packages"), filename);
+
+			if (result != null)
+				return result;
+
+			result = SearchSubdirectories(Path.Combine(Environment.CurrentDirectory, "..", "packages"), filename);
+
+			if (result != null)
+				return result;
+
+			result = SearchSubdirectories(Path.Combine(Environment.CurrentDirectory, "..", "..", "packages"), filename);
+
+			return result;
+		}
+
+		private static string SearchSubdirectories(string path, string filename)
+		{
+			if (Directory.Exists(path))
+			{
+				var result = Directory.GetFiles(path, filename, SearchOption.AllDirectories);
+
+				if (result?.Length >= 1)
+				{
+					return Path.GetDirectoryName(result[0]);
+				}
+			}
+
+			return null;
+		}
+
+	}
+}


### PR DESCRIPTION
Reason:
Mosa Luncher Util's huntfor will solve several edge cases, for example if the Tool in folder A, but the requested source file is in folder B. Mosa-Explorer does not respect these situations.

To avoid code duplication, I generalized HuntFor in a separate helper class.