### PR TITLE
short symbolname fix

### DIFF
--- a/Source/Mosa.Compiler.Framework/Linker/Elf/ElfLinker.cs
+++ b/Source/Mosa.Compiler.Framework/Linker/Elf/ElfLinker.cs
@@ -487,12 +487,12 @@ namespace Mosa.Compiler.Framework.Linker.Elf
 			if (!linker.EmitShortSymbolName)
 				return symbol.Name;
 
-			int pos = symbol.Name.LastIndexOf("):");
+			int pos = symbol.Name.LastIndexOf(") ");
 
 			if (pos < 0)
 				return symbol.Name;
 
-			var shortname = symbol.Name.Substring(0, pos - 1);
+			var shortname = symbol.Name.Substring(0, pos + 1);
 
 			return shortname;
 		}


### PR DESCRIPTION
Currently, there's no ":", and the -1 is wrong also.