### PR TITLE
Sl030 unittest bug

### DIFF
--- a/Source/Mosa.UnitTests/CompilerBugTests.cs
+++ b/Source/Mosa.UnitTests/CompilerBugTests.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Mosa.UnitTests
+{
+	public static class CompilerBugTests
+	{
+
+		[MosaUnitTest]
+		public static bool Test()
+		{
+			ProcessManager.ProcessList = new List<Process>();
+			ProcessManager.ProcessList.Add(new Process { ProcessID = 0 });
+			ProcessManager.ProcessList.Add(new Process { ProcessID = 1 });
+			ProcessManager.ProcessList.Add(new Process { ProcessID = 2 });
+			ProcessManager.ProcessList.Add(new Process { ProcessID = 3 });
+
+			int targetProcessID = 2;
+			var proc = ProcessManager.GetProcess(targetProcessID);
+
+			return proc.ProcessID == 2;
+		}
+
+	}
+
+	internal static class ProcessManager
+	{
+
+		public static List<Process> ProcessList;
+
+		public static Process GetProcess(int processID)
+		{
+			lock (ProcessList)
+				for (var i = 0; i < ProcessList.Count; i++)
+					if (ProcessList[i].ProcessID == processID)
+						return ProcessList[i];
+			return null;
+		}
+
+	}
+
+	internal class Process : IDisposable
+	{
+
+		public int ProcessID;
+
+		public void Dispose()
+		{
+		}
+
+	}
+
+}

--- a/Source/Mosa.Utility.UnitTests/UnitTestEngine.cs
+++ b/Source/Mosa.Utility.UnitTests/UnitTestEngine.cs
@@ -33,7 +33,7 @@ namespace Mosa.Utility.UnitTests
 
 		private readonly object _lock = new object();
 
-		private volatile bool Aborted = false;
+		internal volatile bool Aborted = false;
 		private volatile bool Ready = false;
 
 		private const int MaxSentQueue = 10000;
@@ -57,14 +57,14 @@ namespace Mosa.Utility.UnitTests
 		{
 			LauncherOptions = new LauncherOptions()
 			{
-				EnableSSA = true,
-				EnableBasicOptimizations = true,
-				EnableSparseConditionalConstantPropagation = true,
-				EnableInlineMethods = true,
-				EnableLongExpansion = true,
-				EnableValueNumbering = true,
-				TwoPassOptimizations = true,
-				EnableBitTracker = true,
+				EnableSSA = false,
+				EnableBasicOptimizations = false,
+				EnableSparseConditionalConstantPropagation = false,
+				EnableInlineMethods = false,
+				EnableLongExpansion = false,
+				EnableValueNumbering = false,
+				TwoPassOptimizations = false,
+				EnableBitTracker = false,
 
 				EnableMultiThreading = false,
 				EnableMethodScanner = false,
@@ -96,6 +96,7 @@ namespace Mosa.Utility.UnitTests
 				GenerateMapFile = true,
 				GenerateDebugFile = true,
 				PlugKorlib = true,
+				HuntForCorLib = true,
 				NoDisplay = !display
 			};
 
@@ -516,7 +517,8 @@ namespace Mosa.Utility.UnitTests
 
 		void IBuilderEvent.NewStatus(string status)
 		{
-			//Console.WriteLine(status);
+			// Do not hide exceptions by default!
+			Console.WriteLine(status);
 		}
 
 		void IBuilderEvent.UpdateProgress(int total, int at)

--- a/Source/Mosa.Utility.UnitTests/UnitTestEngine.cs
+++ b/Source/Mosa.Utility.UnitTests/UnitTestEngine.cs
@@ -57,14 +57,14 @@ namespace Mosa.Utility.UnitTests
 		{
 			LauncherOptions = new LauncherOptions()
 			{
-				EnableSSA = false,
-				EnableBasicOptimizations = false,
-				EnableSparseConditionalConstantPropagation = false,
-				EnableInlineMethods = false,
-				EnableLongExpansion = false,
-				EnableValueNumbering = false,
-				TwoPassOptimizations = false,
-				EnableBitTracker = false,
+				EnableSSA = true,
+				EnableBasicOptimizations = true,
+				EnableSparseConditionalConstantPropagation = true,
+				EnableInlineMethods = true,
+				EnableLongExpansion = true,
+				EnableValueNumbering = true,
+				TwoPassOptimizations = true,
+				EnableBitTracker = true,
 
 				EnableMultiThreading = false,
 				EnableMethodScanner = false,

--- a/Source/Mosa.Utility.UnitTests/UnitTestSystem.cs
+++ b/Source/Mosa.Utility.UnitTests/UnitTestSystem.cs
@@ -34,6 +34,12 @@ namespace Mosa.Utility.UnitTests
 			Console.WriteLine("Elapsed: " + (elapsedCompile / 1000.0).ToString("F2") + " secs");
 			Console.WriteLine();
 
+			if(unitTestEngine.Aborted)
+			{
+				Console.WriteLine("Compilation aborted");
+				return 1;
+			}
+
 			Console.WriteLine("Preparing Unit Tests...");
 			var unitTests = PrepareUnitTest(discoveredUnitTests, unitTestEngine.TypeSystem, unitTestEngine.Linker);
 			var elapsedPreparing = stopwatch.ElapsedMilliseconds - elapsedDiscovery - elapsedCompile;
@@ -102,7 +108,16 @@ namespace Mosa.Utility.UnitTests
 
 			foreach (var unitTestInfo in discoveredUnitTests)
 			{
-				var linkerMethodInfo = Linker.GetMethodInfo(typeSystem, linker, unitTestInfo);
+				LinkerMethodInfo linkerMethodInfo;
+				try
+				{
+					linkerMethodInfo = Linker.GetMethodInfo(typeSystem, linker, unitTestInfo);
+				}
+				catch (Exception ex)
+				{
+					Console.WriteLine($"Error while resolving method '{unitTestInfo.FullMethodName}'");
+					throw;
+				}
 
 				var unitTest = new UnitTest(unitTestInfo, linkerMethodInfo);
 


### PR DESCRIPTION
This PR is not ready to merge. Pleas read carefully.

While i tried to make a unit test for my a complex bug, i discovered another problem:

```
Starting Unit Test Engine...
dnlib.DotNet.MemberRefResolveException: Could not resolve method: System.Void System.Threading.Monitor::Enter(System.Object,System.Boolean&) (mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at dnlib.DotNet.MemberRef.ResolveMethodThrow()
   at Mosa.Compiler.MosaTypeSystem.Metadata.MetadataResolver.ResolveMethodOperand(IMethod operand, GenericArgumentResolver resolver) in C:\Users\sebastian\Documents\abanu-org\abanu\external\MOSA-Project\Source\Mosa.Compiler.MosaTypeSystem\Metadata\MetadataResolver.cs:line 532
   at Mosa.Compiler.MosaTypeSystem.Metadata.MetadataResolver.ResolveInstruction(MethodDef methodDef, CilBody body, Int32 index, GenericArgumentResolver resolver) in C:\Users\sebastian\Documents\abanu-org\abanu\external\MOSA-Project\Source\Mosa.Compiler.MosaTypeSystem\Metadata\MetadataResolver.cs:line 415
   at Mosa.Compiler.MosaTypeSystem.Metadata.MetadataResolver.ResolveBody(MethodDef methodDef, Mutator method, CilBody body, GenericArgumentResolver resolver) in C:\Users\sebastian\Documents\abanu-org\abanu\external\MOSA-Project\Source\Mosa.Compiler.MosaTypeSystem\Metadata\MetadataResolver.cs:line 387
   at Mosa.Compiler.MosaTypeSystem.Metadata.MetadataResolver.ResolveMethod(MosaMethod method) in C:\Users\sebastian\Documents\abanu-org\abanu\external\MOSA-Project\Source\Mosa.Compiler.MosaTypeSystem\Metadata\MetadataResolver.cs:line 333
   at Mosa.Compiler.MosaTypeSystem.Metadata.MetadataResolver.Resolve() in C:\Users\sebastian\Documents\abanu-org\abanu\external\MOSA-Project\Source\Mosa.Compiler.MosaTypeSystem\Metadata\MetadataResolver.cs:line 85
   at Mosa.Compiler.MosaTypeSystem.Metadata.CLRMetadata.LoadMetadata() in C:\Users\sebastian\Documents\abanu-org\abanu\external\MOSA-Project\Source\Mosa.Compiler.MosaTypeSystem\Metadata\CLRMetadata.cs:line 42
   at Mosa.Compiler.MosaTypeSystem.TypeSystem.Load() in C:\Users\sebastian\Documents\abanu-org\abanu\external\MOSA-Project\Source\Mosa.Compiler.MosaTypeSystem\TypeSystem.cs:line 97
   at Mosa.Compiler.MosaTypeSystem.TypeSystem.Load(IMetadata metadata) in C:\Users\sebastian\Documents\abanu-org\abanu\external\MOSA-Project\Source\Mosa.Compiler.MosaTypeSystem\TypeSystem.cs:line 67
   at Mosa.Compiler.Framework.MosaCompiler.Load() in C:\Users\sebastian\Documents\abanu-org\abanu\external\MOSA-Project\Source\Mosa.Compiler.Framework\MosaCompiler.cs:line 62
   at Mosa.Utility.Launcher.Builder.Compile() in C:\Users\sebastian\Documents\abanu-org\abanu\external\MOSA-Project\Source\Mosa.Utility.Launcher\Builder.cs:line 168
Elapsed: 9,32 secs 
```

After this probem will be fixed, my unit test "CompilerBugTests.Test()" "should" work like expected. This means:

- If all Optimizations are on, it should work
- Now, disable all optimizations. Try again. CompilerBugTests.Test() should fail.

It's just a  guess, i was not able to run the unit test. In my real project, it's exact the same code. So, i "hope" the test will fail. Excpeted failing result: ProcessManager.GetProcess is returning a wrong process or a NULL. In my real project, i have some other modification, but that would bloat the unit test (for example, i'm using "KList<>" instead of "List<>", and Process as much more fields.

I'm sure the bug has todo with the LOCK statement/protected regions.