### PR TITLE
Compiler Bug

### DIFF
--- a/Source/Mosa.Utility.UnitTests/UnitTestEngine.cs
+++ b/Source/Mosa.Utility.UnitTests/UnitTestEngine.cs
@@ -57,14 +57,17 @@ namespace Mosa.Utility.UnitTests
 		{
 			LauncherOptions = new LauncherOptions()
 			{
-				EnableSSA = true,
-				EnableBasicOptimizations = true,
-				EnableSparseConditionalConstantPropagation = true,
+				EnableSSA = false,
+				EnableBasicOptimizations = false,
+				EnableSparseConditionalConstantPropagation = false,
 				EnableInlineMethods = true,
-				EnableLongExpansion = true,
-				EnableValueNumbering = true,
-				TwoPassOptimizations = true,
-				EnableBitTracker = true,
+				InlineExplicitOnly = true,
+				EnableLongExpansion = false,
+				EnableValueNumbering = false,
+				TwoPassOptimizations = false,
+				EnableBitTracker = false,
+				EnableLoopInvariantCodeMotion = false,
+				EnablePlatformOptimizations = false,
 
 				EnableMultiThreading = false,
 				EnableMethodScanner = false,


### PR DESCRIPTION
The UnitTest "CompilerBugTest" is now failing, when you disable "all" Optimizations except "Explicit Inlining".

Like the last, this is not a ready to merge PR; because i designed it in a way, that it's directly failing (this was the goal).