### PR TITLE
Fix launcher bat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ stderr.txt
 stdout.txt
 
 /docs/CNAME
+
+# Launcher output
+false

--- a/Launcher.bat
+++ b/Launcher.bat
@@ -1,1 +1,1 @@
-start bin\Mosa.Tool.Launcher.exe -autostart-off bin\Mosa.CoolWorld.x86.exe
+start bin\Mosa.Tool.Launcher.exe -autostart-off bin\Mosa.Demo.CoolWorld.x86.exe


### PR DESCRIPTION
Small things to fix to enhance the "get started" experience.

When executing the `Launch.bat` in the root directory, the Launcher pointed to `Mosa.CoolWorld.x86.exe` instead of the generated `Mosa.Demo.CoolWorld.x86.exe`.

Also the Launcher produces an artifact file `false` which is probably not meant to be committed into source control. I added that as well to the `.gitignore` file.