### PR TITLE
Add ++ and -- operators for Pointer

### DIFF
--- a/Source/Mosa.Runtime/Pointer.cs
+++ b/Source/Mosa.Runtime/Pointer.cs
@@ -266,6 +266,12 @@ namespace Mosa.Runtime
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static unsafe Pointer operator --(Pointer pointer)
+		{
+			return new Pointer((long)pointer.value - 1);
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public unsafe void* ToPointer()
 		{
 			return value;

--- a/Source/Mosa.Runtime/Pointer.cs
+++ b/Source/Mosa.Runtime/Pointer.cs
@@ -236,6 +236,12 @@ namespace Mosa.Runtime
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static unsafe Pointer operator ++(Pointer pointer)
+		{
+			return new Pointer(pointer.ToUInt64() + 1);
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static unsafe Pointer operator -(Pointer pointer, int offset)
 		{
 			return new Pointer((long)pointer.value - offset);

--- a/Source/Mosa.Runtime/Pointer.cs
+++ b/Source/Mosa.Runtime/Pointer.cs
@@ -238,7 +238,7 @@ namespace Mosa.Runtime
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static unsafe Pointer operator ++(Pointer pointer)
 		{
-			return new Pointer(pointer.ToUInt64() + 1);
+			return new Pointer(pointer.ToInt64() + 1);
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
This adds the ``++`` and ``--`` operators override for the ``Pointer`` class.

Example:
```cs
Pointer ptr = Pointer.Zero;
ptr++;
// ptr is now 1 instead of 0
ptr--;
// ptr is now 0 instead of 1
```