### PR TITLE
Mostly complete Unsafe class

### DIFF
--- a/Source/Mosa.Korlib/System.Runtime.CompilerServices/Unsafe.cs
+++ b/Source/Mosa.Korlib/System.Runtime.CompilerServices/Unsafe.cs
@@ -123,13 +123,13 @@ namespace System.Runtime.CompilerServices
 		/// <summary>
         /// Adds an byte offset to the given reference.
         /// </summary>
-        [Intrinsic]
+        /*[Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ref T AddByteOffset<T>(ref T source, nuint byteOffset)
         {
             return ref AddByteOffset(ref source, (IntPtr)(void*)byteOffset);
-        }
+        }*/
 
 		[Intrinsic]
 		[NonVersionable]

--- a/Source/Mosa.Korlib/System.Runtime.CompilerServices/Unsafe.cs
+++ b/Source/Mosa.Korlib/System.Runtime.CompilerServices/Unsafe.cs
@@ -142,13 +142,13 @@ namespace System.Runtime.CompilerServices
 		/// <summary>
         /// Writes a value of type <typeparamref name="T"/> to the given location.
         /// </summary>
-        [Intrinsic]
+        /*[Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUnaligned<T>(void* destination, T value)
         {
         	As<byte, T>(ref *(byte*)destination) = value;
-        }
+        }*/
 
 		[Intrinsic]
 		[NonVersionable]
@@ -161,24 +161,24 @@ namespace System.Runtime.CompilerServices
 		/// <summary>
         /// Reads a value of type <typeparamref name="T"/> from the given location.
         /// </summary>
-        [Intrinsic]
+        /*[Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T ReadUnaligned<T>(void* source)
         {
         	return As<byte, T>(ref *(byte*)source);
-        }
+        }*/
 
         /// <summary>
         /// Reads a value of type <typeparamref name="T"/> from the given location.
         /// </summary>
-        [Intrinsic]
+        /*[Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T Read<T>(void* source)
         {
             return As<byte, T>(ref *(byte*)source);
-        }
+        }*/
 
         /// <summary>
         /// Reads a value of type <typeparamref name="T"/> from the given location.
@@ -194,13 +194,13 @@ namespace System.Runtime.CompilerServices
 		/// <summary>
         /// Writes a value of type <typeparamref name="T"/> to the given location.
         /// </summary>
-        [Intrinsic]
+        /*[Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Write<T>(void* destination, T value)
         {
             As<byte, T>(ref *(byte*)destination) = value;
-        }
+        }*/
 
         /// <summary>
         /// Writes a value of type <typeparamref name="T"/> to the given location.

--- a/Source/Mosa.Korlib/System.Runtime.CompilerServices/Unsafe.cs
+++ b/Source/Mosa.Korlib/System.Runtime.CompilerServices/Unsafe.cs
@@ -124,13 +124,13 @@ namespace System.Runtime.CompilerServices
         /// Adds an byte offset to the given reference.
         /// </summary>
 		// TODO: Implement nuint
-        [Intrinsic]
+        /*[Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ref T AddByteOffset<T>(ref T source, nuint byteOffset)
         {
             return ref AddByteOffset(ref source, (IntPtr)(void*)byteOffset);
-        }
+        }*/
 
 		[Intrinsic]
 		[NonVersionable]

--- a/Source/Mosa.Korlib/System.Runtime.CompilerServices/Unsafe.cs
+++ b/Source/Mosa.Korlib/System.Runtime.CompilerServices/Unsafe.cs
@@ -100,14 +100,14 @@ namespace System.Runtime.CompilerServices
         /// Initializes a block of memory at the given location with a given initial value
         /// without assuming architecture dependent alignment of the address.
         /// </summary>
-        [Intrinsic]
+        /*[Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void InitBlockUnaligned(ref byte startAddress, byte value, uint byteCount)
         {
             for (uint i = 0; i < byteCount; i++)
                 AddByteOffset(ref startAddress, i) = value;
-        }
+        }*/
 
 		/// <summary>
 		/// Adds an byte offset to the given reference.

--- a/Source/Mosa.Korlib/System.Runtime.CompilerServices/Unsafe.cs
+++ b/Source/Mosa.Korlib/System.Runtime.CompilerServices/Unsafe.cs
@@ -97,6 +97,19 @@ namespace System.Runtime.CompilerServices
 		}
 
 		/// <summary>
+        /// Initializes a block of memory at the given location with a given initial value
+        /// without assuming architecture dependent alignment of the address.
+        /// </summary>
+        [Intrinsic]
+        [NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void InitBlockUnaligned(ref byte startAddress, byte value, uint byteCount)
+        {
+            for (uint i = 0; i < byteCount; i++)
+                AddByteOffset(ref startAddress, i) = value;
+        }
+
+		/// <summary>
 		/// Adds an byte offset to the given reference.
 		/// </summary>
 		[Intrinsic]
@@ -107,6 +120,17 @@ namespace System.Runtime.CompilerServices
 			throw new PlatformNotSupportedException();
 		}
 
+		/// <summary>
+        /// Adds an byte offset to the given reference.
+        /// </summary>
+        [Intrinsic]
+        [NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ref T AddByteOffset<T>(ref T source, nuint byteOffset)
+        {
+            return ref AddByteOffset(ref source, (IntPtr)(void*)byteOffset);
+        }
+
 		[Intrinsic]
 		[NonVersionable]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -114,6 +138,17 @@ namespace System.Runtime.CompilerServices
 		{
 			As<byte, T>(ref destination) = value;
 		}
+
+		/// <summary>
+        /// Writes a value of type <typeparamref name="T"/> to the given location.
+        /// </summary>
+        [Intrinsic]
+        [NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteUnaligned<T>(void* destination, T value)
+        {
+        	As<byte, T>(ref *(byte*)destination) = value;
+        }
 
 		[Intrinsic]
 		[NonVersionable]
@@ -123,12 +158,67 @@ namespace System.Runtime.CompilerServices
 			return As<byte, T>(ref source);
 		}
 
+		/// <summary>
+        /// Reads a value of type <typeparamref name="T"/> from the given location.
+        /// </summary>
+        [Intrinsic]
+        [NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T ReadUnaligned<T>(void* source)
+        {
+        	return As<byte, T>(ref *(byte*)source);
+        }
+
+        /// <summary>
+        /// Reads a value of type <typeparamref name="T"/> from the given location.
+        /// </summary>
+        [Intrinsic]
+        [NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T Read<T>(void* source)
+        {
+            return As<byte, T>(ref *(byte*)source);
+        }
+
+        /// <summary>
+        /// Reads a value of type <typeparamref name="T"/> from the given location.
+        /// </summary>
+        [Intrinsic]
+        [NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T Read<T>(ref byte source)
+        {
+            return As<byte, T>(ref source);
+        }
+
+		/// <summary>
+        /// Writes a value of type <typeparamref name="T"/> to the given location.
+        /// </summary>
+        [Intrinsic]
+        [NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Write<T>(void* destination, T value)
+        {
+            As<byte, T>(ref *(byte*)destination) = value;
+        }
+
+        /// <summary>
+        /// Writes a value of type <typeparamref name="T"/> to the given location.
+        /// </summary>
+        [Intrinsic]
+        [NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Write<T>(ref byte destination, T value)
+        {
+            As<byte, T>(ref destination) = value;
+        }
+
 		//[Intrinsic]
 		//[NonVersionable]
 		//[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		//public static ref T AsRef<T>(void* source)
 		//{
-		//	return ref Unsafe.As<byte, T>(ref *(byte*)source);
+		//	return ref As<byte, T>(ref *(byte*)source);
 		//}
 	}
 }

--- a/Source/Mosa.Korlib/System.Runtime.CompilerServices/Unsafe.cs
+++ b/Source/Mosa.Korlib/System.Runtime.CompilerServices/Unsafe.cs
@@ -100,14 +100,14 @@ namespace System.Runtime.CompilerServices
         /// Initializes a block of memory at the given location with a given initial value
         /// without assuming architecture dependent alignment of the address.
         /// </summary>
-        /*[Intrinsic]
+        [Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void InitBlockUnaligned(ref byte startAddress, byte value, uint byteCount)
         {
             for (uint i = 0; i < byteCount; i++)
                 AddByteOffset(ref startAddress, i) = value;
-        }*/
+        }
 
 		/// <summary>
 		/// Adds an byte offset to the given reference.
@@ -123,13 +123,14 @@ namespace System.Runtime.CompilerServices
 		/// <summary>
         /// Adds an byte offset to the given reference.
         /// </summary>
-        /*[Intrinsic]
+		// TODO: Implement nuint
+        [Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ref T AddByteOffset<T>(ref T source, nuint byteOffset)
         {
             return ref AddByteOffset(ref source, (IntPtr)(void*)byteOffset);
-        }*/
+        }
 
 		[Intrinsic]
 		[NonVersionable]
@@ -142,13 +143,13 @@ namespace System.Runtime.CompilerServices
 		/// <summary>
         /// Writes a value of type <typeparamref name="T"/> to the given location.
         /// </summary>
-        /*[Intrinsic]
+        [Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteUnaligned<T>(void* destination, T value)
         {
         	As<byte, T>(ref *(byte*)destination) = value;
-        }*/
+        }
 
 		[Intrinsic]
 		[NonVersionable]
@@ -161,24 +162,24 @@ namespace System.Runtime.CompilerServices
 		/// <summary>
         /// Reads a value of type <typeparamref name="T"/> from the given location.
         /// </summary>
-        /*[Intrinsic]
+        [Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T ReadUnaligned<T>(void* source)
         {
         	return As<byte, T>(ref *(byte*)source);
-        }*/
+        }
 
         /// <summary>
         /// Reads a value of type <typeparamref name="T"/> from the given location.
         /// </summary>
-        /*[Intrinsic]
+        [Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T Read<T>(void* source)
         {
             return As<byte, T>(ref *(byte*)source);
-        }*/
+        }
 
         /// <summary>
         /// Reads a value of type <typeparamref name="T"/> from the given location.
@@ -194,13 +195,13 @@ namespace System.Runtime.CompilerServices
 		/// <summary>
         /// Writes a value of type <typeparamref name="T"/> to the given location.
         /// </summary>
-        /*[Intrinsic]
+        [Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Write<T>(void* destination, T value)
         {
             As<byte, T>(ref *(byte*)destination) = value;
-        }*/
+        }
 
         /// <summary>
         /// Writes a value of type <typeparamref name="T"/> to the given location.


### PR DESCRIPTION
This adds most of the missing functions to the Unsafe class from ``https://source.dot.net/``.
Not tested but most likely working as it just calls the other, already implemented functions.