### PR TITLE
Double buffering, PS/2 mouse and ACPI fixes

### DIFF
--- a/Source/Mosa.Demo.VBEWorld.x86/Boot.cs
+++ b/Source/Mosa.Demo.VBEWorld.x86/Boot.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
 
 using Mosa.Demo.VBEWorld.x86.HAL;
+using Mosa.DeviceDriver;
+using Mosa.DeviceDriver.ISA;
+using Mosa.DeviceSystem;
+using Mosa.DeviceSystem.PCI;
 using Mosa.Kernel.x86;
 using Mosa.Runtime.Plug;
 using Mosa.Runtime.x86;
@@ -13,8 +17,10 @@ namespace Mosa.Demo.VBEWorld.x86
 	public static class Boot
 	{
 		public static ConsoleSession Console;
+		public static DeviceService DeviceService;
 
 		private static Hardware _hal;
+		private static StandardMouse _mouse;
 
 		[Plug("Mosa.Runtime.StartUp::SetInitialMemory")]
 		public static void SetInitialMemory()
@@ -37,25 +43,65 @@ namespace Mosa.Demo.VBEWorld.x86
 			Serial.SetupPort(Serial.COM1);
 
 			_hal = new Hardware();
+
+			// Create Service manager and basic services
+			var serviceManager = new ServiceManager();
+
+			DeviceService = new DeviceService();
+
+			var diskDeviceService = new DiskDeviceService();
+			var partitionService = new PartitionService();
+			var pciControllerService = new PCIControllerService();
+			var pciDeviceService = new PCIDeviceService();
+
+			serviceManager.AddService(DeviceService);
+			serviceManager.AddService(diskDeviceService);
+			serviceManager.AddService(partitionService);
+			serviceManager.AddService(pciControllerService);
+			serviceManager.AddService(pciDeviceService);
+
+			DeviceSystem.Setup.Initialize(_hal, DeviceService.ProcessInterrupt);
+
+			DeviceService.RegisterDeviceDriver(DeviceDriver.Setup.GetDeviceDriverRegistryEntries());
+			DeviceService.Initialize(new X86System(), null);
+
+			var standardMice = DeviceService.GetDevices("StandardMouse");
+			if (standardMice.Count == 0)
+			{
+				_hal.Pause();
+				_hal.Abort("Catastrophic failure, mouse and/or PIT not found.");
+			}
+
+			_mouse = standardMice[0].DeviceDriver as StandardMouse;
+			_mouse.SetScreenResolution(VBE.ScreenWidth, VBE.ScreenHeight);
+
 			if (VBEDisplay.InitVBE(_hal))
 			{
 				Log("VBE setup OK!");
-
 				DoGraphics();
-			}
-			else
-			{
-				Log("VBE setup ERROR!");
-			}
-
-			ForeverLoop();
+			} else Log("VBE setup ERROR!");
 		}
 
 		private static void DoGraphics()
 		{
-			VBEDisplay.Framebuffer.FillRectangle(0x00555555, 0, 0, VBEDisplay.Framebuffer.Width, VBEDisplay.Framebuffer.Height);
+			for (; ; )
+			{
+				VBEDisplay.Framebuffer.Clear(0x00555555);
+				VBEDisplay.Framebuffer.FillRectangle(0x0, 50, 50, 130, 80);
 
-			MosaLogo.Draw(VBEDisplay.Framebuffer, 10);
+				MosaLogo.Draw(VBEDisplay.Framebuffer, 10);
+				DrawMouse();
+
+				VBEDisplay.Framebuffer.Update();
+			}
+		}
+
+		private static void DrawMouse()
+		{
+			VBEDisplay.Framebuffer.SetPixel(0x0, (uint)_mouse.X, (uint)_mouse.Y);
+			VBEDisplay.Framebuffer.SetPixel(0x0, (uint)_mouse.X + 1, (uint)_mouse.Y);
+			VBEDisplay.Framebuffer.SetPixel(0x0, (uint)_mouse.X, (uint)_mouse.Y + 1);
+			VBEDisplay.Framebuffer.SetPixel(0x0, (uint)_mouse.X + 1, (uint)_mouse.Y + 1);
 		}
 
 		public static void Log(string line)
@@ -64,16 +110,10 @@ namespace Mosa.Demo.VBEWorld.x86
 			Console.WriteLine(line);
 		}
 
-		private static void ForeverLoop()
-		{
-			while (true)
-			{
-				Native.Hlt();
-			}
-		}
-
 		public static void ProcessInterrupt(uint interrupt, uint errorCode)
 		{
+			if (interrupt >= 0x20 && interrupt < 0x30)
+				_hal.ProcessInterrupt((byte)(interrupt - 0x20));
 		}
 	}
 }

--- a/Source/Mosa.Demo.VBEWorld.x86/HAL/Hardware.cs
+++ b/Source/Mosa.Demo.VBEWorld.x86/HAL/Hardware.cs
@@ -1,10 +1,10 @@
 // Copyright (c) MOSA Project. Licensed under the New BSD License.
 
+using Mosa.DeviceDriver.ISA;
 using Mosa.DeviceSystem;
 using Mosa.Kernel.x86;
 using Mosa.Runtime;
 using Mosa.Runtime.x86;
-using System;
 
 namespace Mosa.Demo.VBEWorld.x86.HAL
 {
@@ -68,6 +68,7 @@ namespace Mosa.Demo.VBEWorld.x86.HAL
 		/// <param name="milliseconds">The milliseconds.</param>
 		public override void Sleep(uint milliseconds)
 		{
+			
 		}
 
 		/// <summary>
@@ -100,7 +101,7 @@ namespace Mosa.Demo.VBEWorld.x86.HAL
 		/// <returns></returns>
 		public override BaseIOPortReadWrite GetReadWriteIOPort(ushort port)
 		{
-			throw new NotImplementedException();
+			return new X86IOPortReadWrite(port);
 		}
 
 		/// <summary>
@@ -110,7 +111,7 @@ namespace Mosa.Demo.VBEWorld.x86.HAL
 		/// <returns></returns>
 		public override BaseIOPortRead GetReadIOPort(ushort port)
 		{
-			throw new NotImplementedException();
+			return new X86IOPortReadWrite(port);
 		}
 
 		/// <summary>
@@ -120,7 +121,7 @@ namespace Mosa.Demo.VBEWorld.x86.HAL
 		/// <returns></returns>
 		public override BaseIOPortWrite GetWriteIOPort(ushort port)
 		{
-			throw new NotImplementedException();
+			return new X86IOPortWrite(port);
 		}
 
 		/// <summary>
@@ -155,7 +156,7 @@ namespace Mosa.Demo.VBEWorld.x86.HAL
 		/// </summary>
 		public override void Pause()
 		{
-			for (var i = Scheduler.ClockTicks + 25; i > Scheduler.ClockTicks;) { }
+			for (var i = Scheduler.ClockTicks + 5; i > Scheduler.ClockTicks;) { }
 		}
 	}
 }

--- a/Source/Mosa.Demo.VBEWorld.x86/HAL/X86IOPort.cs
+++ b/Source/Mosa.Demo.VBEWorld.x86/HAL/X86IOPort.cs
@@ -1,0 +1,150 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using Mosa.Kernel.x86;
+
+namespace Mosa.Demo.VBEWorld.x86.HAL
+{
+	/// <summary>
+	/// X86IOPortReadWrite
+	/// </summary>
+	/// <seealso cref="Mosa.DeviceSystem.BaseIOPortReadWrite" />
+	public sealed class X86IOPortReadWrite : DeviceSystem.BaseIOPortReadWrite
+	{
+		public X86IOPortReadWrite(ushort address)
+		{
+			Address = address;
+		}
+
+		/// <summary>
+		/// Reads a byte from the IO Port
+		/// </summary>
+		/// <returns></returns>
+		public override byte Read8()
+		{
+			return IOPort.In8(Address);
+		}
+
+		/// <summary>
+		/// Reads a short from the IO Port
+		/// </summary>
+		/// <returns></returns>
+		public override ushort Read16()
+		{
+			return IOPort.In16(Address);
+		}
+
+		/// <summary>
+		/// Reads an integer from the IO Port
+		/// </summary>
+		/// <returns></returns>
+		public override uint Read32()
+		{
+			return IOPort.In32(Address);
+		}
+
+		/// <summary>
+		///  Writes a byte to the IO Port
+		/// </summary>
+		/// <param name="data">The data.</param>
+		public override void Write8(byte data)
+		{
+			IOPort.Out8(Address, data);
+		}
+
+		/// <summary>
+		///  Writes a short to the IO Port
+		/// </summary>
+		/// <param name="data">The data.</param>
+		public override void Write16(ushort data)
+		{
+			IOPort.Out16(Address, data);
+		}
+
+		/// <summary>
+		///  Writes an integer to the IO Port
+		/// </summary>
+		/// <param name="data">The data.</param>
+		public override void Write32(uint data)
+		{
+			IOPort.Out32(Address, data);
+		}
+	}
+
+	/// <summary>
+	/// X86IOPortRead
+	/// </summary>
+	/// <seealso cref="Mosa.DeviceSystem.BaseIOPortRead" />
+	public sealed class X86IOPortRead : DeviceSystem.BaseIOPortRead
+	{
+		public X86IOPortRead(ushort address)
+		{
+			Address = address;
+		}
+
+		/// <summary>
+		/// Reads a byte from the IO Port
+		/// </summary>
+		/// <returns></returns>
+		public override byte Read8()
+		{
+			return IOPort.In8(Address);
+		}
+
+		/// <summary>
+		/// Reads a short from the IO Port
+		/// </summary>
+		/// <returns></returns>
+		public override ushort Read16()
+		{
+			return IOPort.In16(Address);
+		}
+
+		/// <summary>
+		/// Reads an integer from the IO Port
+		/// </summary>
+		/// <returns></returns>
+		public override uint Read32()
+		{
+			return IOPort.In32(Address);
+		}
+	}
+
+	/// <summary>
+	/// X86IOPortWrite
+	/// </summary>
+	/// <seealso cref="Mosa.DeviceSystem.BaseIOPortWrite" />
+	public sealed class X86IOPortWrite : DeviceSystem.BaseIOPortWrite
+	{
+		public X86IOPortWrite(ushort address)
+		{
+			Address = address;
+		}
+
+		/// <summary>
+		///  Writes a byte to the IO Port
+		/// </summary>
+		/// <param name="data">The data.</param>
+		public override void Write8(byte data)
+		{
+			IOPort.Out8(Address, data);
+		}
+
+		/// <summary>
+		/// Writes a short to the IO Port
+		/// </summary>
+		/// <param name="data">The data.</param>
+		public override void Write16(ushort data)
+		{
+			IOPort.Out16(Address, data);
+		}
+
+		/// <summary>
+		/// Writes an integer to the IO Port
+		/// </summary>
+		/// <param name="data">The data.</param>
+		public override void Write32(uint data)
+		{
+			IOPort.Out32(Address, data);
+		}
+	}
+}

--- a/Source/Mosa.DeviceDriver/ISA/ACPI.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI.cs
@@ -174,7 +174,7 @@ namespace Mosa.DeviceDriver.ISA
 				{
 					if (S5Addr.Load32() == 0x5f35535f) //_S5_
 						break;
-					S5Addr += 1;
+					S5Addr++;
 				}
 
 				if (dsdtLength > 0)
@@ -183,11 +183,11 @@ namespace Mosa.DeviceDriver.ISA
 						S5Addr += 5;
 						S5Addr += ((S5Addr.Load32() & 0xC0) >> 6) + 2;
 						if (S5Addr.Load8() == 0x0A)
-							S5Addr += 1;
+							S5Addr++;
 						SLP_TYPa = (short)(S5Addr.Load16() << 10);
-						S5Addr += 1;
+						S5Addr++;
 						if (S5Addr.Load8() == 0x0A)
-							S5Addr += 1;
+							S5Addr++;
 						SLP_TYPb = (short)(S5Addr.Load16() << 10);
 						SLP_EN = 1 << 13;
 
@@ -198,23 +198,39 @@ namespace Mosa.DeviceDriver.ISA
 			}
 		}
 
+		/// <summary>
+		/// Probes this instance.
+		/// </summary>
+		/// <remarks>
+		/// Override for ISA devices, if example
+		/// </remarks>
+		public override void Probe() => Device.Status = DeviceStatus.Available;
+
+		/// <summary>
+		/// Starts this hardware device.
+		/// </summary>
 		public override void Start()
 		{
-			SMI_CommandPort.Write8(FADT->AcpiEnable);//Native.Out8((ushort)FADT->SMI_CommandPort, FADT->AcpiEnable);
+			SMI_CommandPort.Write8(FADT->AcpiEnable);
 			HAL.Sleep(3000);
+			Device.Status = DeviceStatus.Online;
 		}
 
+		/// <summary>
+		/// Stops this hardware device.
+		/// </summary>
 		public override void Stop()
 		{
-			SMI_CommandPort.Write8(FADT->AcpiDisable);//Native.Out8((ushort)FADT->SMI_CommandPort, FADT->AcpiDisable);
+			SMI_CommandPort.Write8(FADT->AcpiDisable);
 			HAL.Sleep(3000);
+			Device.Status = DeviceStatus.Offline;
 		}
 
 		public void Shutdown()
 		{
-			PM1aControlBlock.Write16((ushort)(SLP_TYPa | SLP_EN));//Native.Out16((ushort)FADT->PM1aControlBlock, (ushort)(SLP_TYPa | SLP_EN));
+			PM1aControlBlock.Write16((ushort)(SLP_TYPa | SLP_EN));
 			if (FADT->PM1bControlBlock != 0)
-				PM1bControlBlock.Write16((ushort)(SLP_TYPb | SLP_EN));//Native.Out16((ushort)FADT->PM1aControlBlock, (ushort)(SLP_TYPb | SLP_EN));
+				PM1bControlBlock.Write16((ushort)(SLP_TYPb | SLP_EN));
 
 			HAL.Pause();
 			HAL.Abort("ACPI shutdown failed!");

--- a/Source/Mosa.DeviceDriver/ISA/StandardMouse.cs
+++ b/Source/Mosa.DeviceDriver/ISA/StandardMouse.cs
@@ -1,0 +1,207 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using Mosa.DeviceSystem;
+using System;
+
+namespace Mosa.DeviceDriver.ISA
+{
+	//https://github.com/nifanfa/MOSA-Core/blob/master/Source/Mosa.External.x86/Driver/Input/PS2Mouse.cs
+	//https://forum.osdev.org/viewtopic.php?t=10247
+	//https://wiki.osdev.org/Mouse_Input
+
+	public class StandardMouse : BaseDeviceDriver, IMouseDevice
+	{
+		private BaseIOPortReadWrite command;
+		private BaseIOPortReadWrite data;
+
+		private const byte SetDefaults = 0xF6, EnableDataReporting = 0xF4;
+
+		private int mouseState, screenWidth, screenHeight, phase = 0, aX, aY;
+
+		private byte[] mData = new byte[3];
+
+		public int X, Y;
+
+		public override void Initialize()
+		{
+			Device.Name = "StandardMouse";
+
+			data = Device.Resources.GetIOPortReadWrite(0, 0); // 0x60
+			command = Device.Resources.GetIOPortReadWrite(1, 0); // 0x64
+
+			// Enable the auxiliary mouse device
+			Wait(1);
+			command.Write8(0xA8);
+
+			// Enable the interrupts
+			Wait(1);
+			command.Write8(0x20);
+			Wait(0);
+			byte status = ((byte)(data.Read8() | 3));
+			Wait(1);
+			command.Write8(0x60);
+			Wait(1);
+			data.Write8(status);
+
+			WriteRegister(SetDefaults);
+			WriteRegister(EnableDataReporting);
+
+			// Get "MouseID", but somehow do nothing with it (?)
+			WriteRegister(0xF2);
+
+			// Set sample rate to 200 Hz (maximum)
+			// We're gradually going down to 80 Hz, see below
+			WriteRegister(0xF3);
+			WriteRegister(200);
+
+			// Set sample rate to 100 Hz
+			// See below for final register write of sample rate
+			WriteRegister(0xF3);
+			WriteRegister(100);
+
+			// Set sample rate to 800 Hz
+			// We're done!
+			WriteRegister(0xF3);
+			WriteRegister(80);
+
+			// Get "MouseID"
+			WriteRegister(0xF2);
+			byte result = ReadRegister();
+
+			if (result == 3)
+			{
+				// The scroll wheel is available
+			}
+
+			mouseState = byte.MaxValue;
+		}
+
+		/// <summary>
+		/// Probes this instance.
+		/// </summary>
+		/// <remarks>
+		/// Override for ISA devices, if example
+		/// </remarks>
+		public override void Probe() => Device.Status = DeviceStatus.Available;
+
+		/// <summary>
+		/// Starts this hardware device.
+		/// </summary>
+		public override void Start() => Device.Status = DeviceStatus.Online;
+
+		public override bool OnInterrupt()
+		{
+			byte D = data.Read8();
+
+			if (phase == 0)
+			{
+				if (D == 0xfa)
+					phase = 1;
+				return true;
+			}
+
+			if (phase == 1)
+			{
+				if ((D & (1 << 3)) == (1 << 3))
+				{
+					mData[0] = D;
+					phase = 2;
+				}
+				return true;
+			}
+
+			if (phase == 2)
+			{
+				mData[1] = D;
+				phase = 3;
+				return true;
+			}
+
+			if (phase == 3)
+			{
+				mData[2] = D;
+				phase = 1;
+
+				mData[0] &= 0x07;
+				mouseState = mData[0] switch
+				{
+					0x01 => 0,
+					0x02 => 1,
+					// TODO: Add scroll wheel
+					_ => byte.MaxValue,
+				};
+
+				if (mData[1] > 127)
+					aX = -(255 - mData[1]);
+				else
+					aX = mData[1];
+
+				if (mData[2] > 127)
+					aY = -(255 - mData[2]);
+				else
+					aY = mData[2];
+
+				X = Math.Clamp(X + aX, 0, screenWidth);
+				Y = Math.Clamp(Y - aY, 0, screenHeight);
+			}
+
+			return true;
+		}
+
+		public int GetMouseState()
+		{
+			return mouseState;
+		}
+
+		public void SetScreenResolution(int width, int height)
+		{
+			screenWidth = width;
+			screenHeight = height;
+
+			X = width / 2;
+			Y = height / 2;
+		}
+
+		#region Private
+
+		private void Wait(byte type)
+		{
+			int timeOut = 100000;
+
+			if (type == 0)
+			{
+				for (; timeOut > 0; timeOut--)
+					if ((command.Read8() & 1) == 1)
+						return;
+
+				return;
+			}
+			else
+			{
+				for (; timeOut > 0; timeOut--)
+					if ((command.Read8() & 2) == 0)
+						return;
+
+				return;
+			}
+		}
+
+		private void WriteRegister(byte value)
+		{
+			Wait(1);
+			command.Write8(0xD4);
+			Wait(1);
+			data.Write8(value);
+
+			ReadRegister();
+		}
+
+		private byte ReadRegister()
+		{
+			Wait(0);
+			return data.Read8();
+		}
+
+		#endregion
+	}
+}

--- a/Source/Mosa.DeviceDriver/Setup.cs
+++ b/Source/Mosa.DeviceDriver/Setup.cs
@@ -46,6 +46,19 @@ namespace Mosa.DeviceDriver
 
 				new ISADeviceDriverRegistryEntry()
 				{
+					Name = "StandardMouse",
+					Platforms = PlatformArchitecture.X86AndX64,
+					AutoLoad = true,
+					BasePort = 0x60,
+					PortRange = 1,
+					AltBasePort = 0x64,
+					AltPortRange = 1,
+					IRQ = 12,
+					Factory = delegate { return new ISA.StandardMouse(); }
+				},
+
+				new ISADeviceDriverRegistryEntry()
+				{
 					Name = "PCIController",
 					Platforms = PlatformArchitecture.X86AndX64,
 					AutoLoad = true,

--- a/Source/Mosa.DeviceSystem/FrameBuffer.cs
+++ b/Source/Mosa.DeviceSystem/FrameBuffer.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
 
+using Mosa.Runtime;
+
 namespace Mosa.DeviceSystem
 {
 	/// <summary>
@@ -34,6 +36,16 @@ namespace Mosa.DeviceSystem
 		protected uint depth;
 
 		/// <summary>
+		/// Is double buffering
+		/// </summary>
+		protected bool doubleBuffering;
+
+		/// <summary>
+		/// Second buffer for double buffering
+		/// </summary>
+		protected ConstrainedPointer secondBuffer;
+
+		/// <summary>
 		/// Gets the width.
 		/// </summary>
 		/// <value>The width.</value>
@@ -44,6 +56,12 @@ namespace Mosa.DeviceSystem
 		/// </summary>
 		/// <value>The height.</value>
 		public uint Height { get { return height; } }
+
+		/// <summary>
+		/// Checks if the frame buffer is double buffered.
+		/// </summary>
+		/// <value>The height.</value>
+		public bool DoubleBuffering { get { return doubleBuffering; } }
 
 		/// <summary>
 		/// Gets the offset.
@@ -78,5 +96,25 @@ namespace Mosa.DeviceSystem
 		/// <param name="w">Width of the rectangle.</param>
 		/// <param name="h">Width of the rectangle.</param>
 		public abstract void FillRectangle(uint color, uint x, uint y, uint w, uint h);
+
+		/// <summary>
+		/// If using double buffering, copies the second buffer to the screen.
+		/// </summary>
+		public void Update()
+		{
+			if (doubleBuffering)
+				Internal.MemoryCopy(buffer.Address, secondBuffer.Address, buffer.Size);
+		}
+
+		/// <summary>
+		/// Clears the screen with a specified color.
+		/// </summary>
+		public void Clear(uint color)
+		{
+			if (doubleBuffering)
+				Internal.MemoryClear(secondBuffer.Address, secondBuffer.Size, color);
+			else
+				Internal.MemoryClear(buffer.Address, buffer.Size, color);
+		}
 	}
 }

--- a/Source/Mosa.DeviceSystem/FrameBuffer16bpp.cs
+++ b/Source/Mosa.DeviceSystem/FrameBuffer16bpp.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
 
+using Mosa.Runtime;
+
 namespace Mosa.DeviceSystem
 {
 	/// <summary>
@@ -15,13 +17,16 @@ namespace Mosa.DeviceSystem
 		/// <param name="height">The height.</param>
 		/// <param name="offset">The offset.</param>
 		/// <param name="depth">The depth.</param>
-		public FrameBuffer16bpp(ConstrainedPointer buffer, uint width, uint height, uint offset, uint depth)
+		public FrameBuffer16bpp(ConstrainedPointer buffer, uint width, uint height, uint offset, uint depth, bool doubleBuffering = true)
 		{
 			this.buffer = buffer;
 			this.width = width;
 			this.height = height;
 			this.offset = offset;
 			this.depth = depth;
+
+			if (doubleBuffering)
+				secondBuffer = new ConstrainedPointer(GC.AllocateObject(buffer.Size), buffer.Size);
 		}
 
 		/// <summary>
@@ -43,7 +48,7 @@ namespace Mosa.DeviceSystem
 		/// <returns></returns>
 		public override uint GetPixel(uint x, uint y)
 		{
-			return buffer.Read16(GetOffset(x, y));
+			return doubleBuffering ? secondBuffer.Read16(GetOffset(x, y)) : buffer.Read16(GetOffset(x, y));
 		}
 
 		/// <summary>
@@ -54,7 +59,10 @@ namespace Mosa.DeviceSystem
 		/// <param name="y">The y.</param>
 		public override void SetPixel(uint color, uint x, uint y)
 		{
-			buffer.Write16(GetOffset(x, y), (ushort)color);
+			if (doubleBuffering)
+				secondBuffer.Write16(GetOffset(x, y), (ushort)color);
+			else
+				buffer.Write16(GetOffset(x, y), (ushort)color);
 		}
 
 		/// <summary>
@@ -73,7 +81,10 @@ namespace Mosa.DeviceSystem
 			{
 				for (uint offsetX = 0; offsetX < w; offsetX++)
 				{
-					buffer.Write16(startAddress + (offsetX << 1), (ushort)color);
+					if (doubleBuffering)
+						secondBuffer.Write16(startAddress + (offsetX << 1), (ushort)color);
+					else
+						buffer.Write16(startAddress + (offsetX << 1), (ushort)color);
 				}
 
 				startAddress += depth;

--- a/Source/Mosa.DeviceSystem/FrameBuffer8bpp.cs
+++ b/Source/Mosa.DeviceSystem/FrameBuffer8bpp.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
 
+using Mosa.Runtime;
+
 namespace Mosa.DeviceSystem
 {
 	/// <summary>
@@ -15,13 +17,16 @@ namespace Mosa.DeviceSystem
 		/// <param name="height">The height.</param>
 		/// <param name="offset">The offset.</param>
 		/// <param name="depth">The depth.</param>
-		public FrameBuffer8bpp(ConstrainedPointer buffer, uint width, uint height, uint offset, uint depth)
+		public FrameBuffer8bpp(ConstrainedPointer buffer, uint width, uint height, uint offset, uint depth, bool doubleBuffering = true)
 		{
 			this.buffer = buffer;
 			this.width = width;
 			this.height = height;
 			this.offset = offset;
 			this.depth = depth;
+
+			if (doubleBuffering)
+				secondBuffer = new ConstrainedPointer(GC.AllocateObject(buffer.Size), buffer.Size);
 		}
 
 		/// <summary>
@@ -43,7 +48,7 @@ namespace Mosa.DeviceSystem
 		/// <returns></returns>
 		public override uint GetPixel(uint x, uint y)
 		{
-			return buffer.Read8(GetOffset(x, y));
+			return doubleBuffering ? secondBuffer.Read8(GetOffset(x, y)) : buffer.Read8(GetOffset(x, y));
 		}
 
 		/// <summary>
@@ -54,7 +59,10 @@ namespace Mosa.DeviceSystem
 		/// <param name="y">The y.</param>
 		public override void SetPixel(uint color, uint x, uint y)
 		{
-			buffer.Write8(GetOffset(x, y), (byte)color);
+			if (doubleBuffering)
+				secondBuffer.Write8(GetOffset(x, y), (byte)color);
+			else
+				buffer.Write8(GetOffset(x, y), (byte)color);
 		}
 
 		/// <summary>
@@ -73,7 +81,10 @@ namespace Mosa.DeviceSystem
 			{
 				for (uint offsetX = 0; offsetX < w; offsetX++)
 				{
-					buffer.Write8(startAddress + offsetX, (byte)color);
+					if (doubleBuffering)
+						secondBuffer.Write8(startAddress + offsetX, (byte)color);
+					else
+						buffer.Write8(startAddress + offsetX, (byte)color);
 				}
 
 				startAddress += depth;

--- a/Source/Mosa.DeviceSystem/IFrameBuffer.cs
+++ b/Source/Mosa.DeviceSystem/IFrameBuffer.cs
@@ -45,6 +45,16 @@ namespace Mosa.DeviceSystem
 		/// <param name="h">Width of the rectangle.</param>
 		void FillRectangle(uint color, uint x, uint y, uint w, uint h);
 
+		/// <summary>
+		/// If using double buffering, copies the second buffer to the screen.
+		/// </summary>
+		void Update();
+
+		/// <summary>
+		/// Clears the screen with a specified color.
+		/// </summary>
+		void Clear(uint color);
+
 		//TODO: Add more methods
 	}
 }

--- a/Source/Mosa.DeviceSystem/IMouseDevice.cs
+++ b/Source/Mosa.DeviceSystem/IMouseDevice.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+namespace Mosa.DeviceSystem
+{
+	/// <summary>
+	/// Interface to a mouse device
+	/// </summary>
+	public interface IMouseDevice
+	{
+		/// <summary>
+		/// Get the current state of the mouse
+		///
+		/// 0 = Left
+		/// 1 = Right
+		/// 2 = Scroll wheel
+		/// 255 = None
+		/// </summary>
+		/// <returns></returns>
+		int GetMouseState();
+
+		/// <summary>
+		/// Sets the screen resolution inside the mouse to make it work properly.
+		/// Set this before using the mouse driver.
+		/// </summary>
+		/// <param name="width"></param>
+		/// <param name="height"></param>
+		void SetScreenResolution(int width, int height);
+	}
+}

--- a/Source/Mosa.Runtime/Internal.cs
+++ b/Source/Mosa.Runtime/Internal.cs
@@ -213,11 +213,11 @@ namespace Mosa.Runtime
 		}
 
 		[MethodImpl(MethodImplOptions.NoInlining)]
-		public static void MemoryClear(Pointer dest, uint count)
+		public static void MemoryClear(Pointer dest, uint count, uint value = 0)
 		{
 			for (int i = 0; i < count; i++)
 			{
-				dest.Store8(i, 0);
+				dest.Store8(i, (byte)value);
 			}
 		}
 


### PR DESCRIPTION
This is a pull request containing the following changes:
- Double buffering implemented in all framebuffers (along with a new Clear() method)
**This required me to add a parameter ``value`` in ``Internal.MemoryClear`` (which is 0 by default anyways so it won't break anything). Tell me if that causes any problems.**
- PS/2 mouse implemented
- Fixes in ACPI driver for device status

I've also modified the VBEWorld demo so that the double buffering and mouse can be tested.