### PR TITLE
ToLower() => ToLowerInvariant() & ToUpper() => ToUpperInvariant() changes

### DIFF
--- a/Source/Mosa.Compiler.Common/Configuration/Property.cs
+++ b/Source/Mosa.Compiler.Common/Configuration/Property.cs
@@ -35,7 +35,7 @@ namespace Mosa.Compiler.Common.Configuration
 				if (string.IsNullOrEmpty(Value))
 					return false;
 
-				return Value.ToLower().StartsWith("true") || Value.ToLower().StartsWith("y") || Value.ToLower().StartsWith("on");
+				return Value.ToLowerInvariant().StartsWith("true") || Value.ToLowerInvariant().StartsWith("y") || Value.ToLowerInvariant().StartsWith("on");
 			}
 		}
 
@@ -46,7 +46,7 @@ namespace Mosa.Compiler.Common.Configuration
 				if (string.IsNullOrEmpty(Value))
 					return false;
 
-				return Value.ToLower().StartsWith("false") || Value.ToLower().StartsWith("n") || Value.ToLower().StartsWith("off");
+				return Value.ToLowerInvariant().StartsWith("false") || Value.ToLowerInvariant().StartsWith("n") || Value.ToLowerInvariant().StartsWith("off");
 			}
 		}
 

--- a/Source/Mosa.Compiler.Common/StringExtension.cs
+++ b/Source/Mosa.Compiler.Common/StringExtension.cs
@@ -8,7 +8,7 @@ namespace Mosa.Compiler.Common
 	{
 		public static ulong ParseHexOrInteger(this string value)
 		{
-			string nbr = value.ToUpper().Trim();
+			string nbr = value.ToUpperInvariant().Trim();
 			int digits = 10;
 			int where = nbr.IndexOf('X');
 
@@ -23,7 +23,7 @@ namespace Mosa.Compiler.Common
 
 		public static ulong ParseHex(this string value)
 		{
-			string nbr = value.ToUpper().Trim();
+			string nbr = value.ToUpperInvariant().Trim();
 			int where = nbr.IndexOf('X');
 
 			if (where >= 0)

--- a/Source/Mosa.Compiler.Framework/Linker/MosaLinker.cs
+++ b/Source/Mosa.Compiler.Framework/Linker/MosaLinker.cs
@@ -48,7 +48,7 @@ namespace Mosa.Compiler.Framework.Linker
 
 			LinkerSettings = new LinkerSettings(compiler.CompilerSettings.Settings);
 
-			LinkerFormatType = LinkerSettings.LinkerFormat.ToLower() == "elf64" ? LinkerFormatType.Elf64 : LinkerFormatType.Elf32;
+			LinkerFormatType = LinkerSettings.LinkerFormat.ToLowerInvariant() == "elf64" ? LinkerFormatType.Elf64 : LinkerFormatType.Elf32;
 
 			ElfLinker = new ElfLinker(this, LinkerFormatType, compiler.Architecture.ElfMachineType);
 

--- a/Source/Mosa.Platform.x64/Architecture.cs
+++ b/Source/Mosa.Platform.x64/Architecture.cs
@@ -145,7 +145,7 @@ namespace Mosa.Platform.x64
 		/// <param name="pipeline">The pipeline to extend.</param>
 		public override void ExtendCompilerPipeline(Pipeline<BaseCompilerStage> pipeline, CompilerSettings compilerSettings)
 		{
-			if (compilerSettings.Settings.GetValue("Multiboot.Version", string.Empty).ToLower() == "v1")
+			if (compilerSettings.Settings.GetValue("Multiboot.Version", string.Empty).ToLowerInvariant() == "v1")
 			{
 				pipeline.InsertAfterFirst<TypeInitializerStage>(
 					new MultibootV1Stage()

--- a/Source/Mosa.Platform.x86/Architecture.cs
+++ b/Source/Mosa.Platform.x86/Architecture.cs
@@ -126,7 +126,7 @@ namespace Mosa.Platform.x86
 		/// <param name="pipeline">The pipeline to extend.</param>
 		public override void ExtendCompilerPipeline(Pipeline<BaseCompilerStage> pipeline, CompilerSettings compilerSettings)
 		{
-			if (compilerSettings.Settings.GetValue("Multiboot.Version", string.Empty).ToLower() == "v1")
+			if (compilerSettings.Settings.GetValue("Multiboot.Version", string.Empty).ToLowerInvariant() == "v1")
 			{
 				pipeline.InsertAfterFirst<TypeInitializerStage>(
 					new MultibootV1Stage()

--- a/Source/Mosa.Tool.Debugger/MainForm.cs
+++ b/Source/Mosa.Tool.Debugger/MainForm.cs
@@ -353,7 +353,7 @@ namespace Mosa.Tool.Debugger
 
 		public static ulong ParseHexAddress(string input)
 		{
-			string nbr = input.ToLower().Trim().Trim(',').Trim('[').Trim('[');
+			string nbr = input.ToLowerInvariant().Trim().Trim(',').Trim('[').Trim('[');
 
 			int where = nbr.IndexOf('x');
 
@@ -633,7 +633,7 @@ namespace Mosa.Tool.Debugger
 
 		private static string GetFormat(string fileName)
 		{
-			switch (Path.GetExtension(fileName).ToLower())
+			switch (Path.GetExtension(fileName).ToLowerInvariant())
 			{
 				case ".bin": return "BIN";
 				case ".img": return "IMG";

--- a/Source/Mosa.Tool.Debugger/Views/MethodParametersView.cs
+++ b/Source/Mosa.Tool.Debugger/Views/MethodParametersView.cs
@@ -129,7 +129,7 @@ namespace Mosa.Tool.Debugger.Views
 				{
 					Index = (int)parameter.Index,
 					Name = parameter.Name,
-					Offset = Platform.StackFrame.Name.ToUpper() +
+					Offset = Platform.StackFrame.Name.ToUpperInvariant() +
 						(offset >= 0
 						? "+" + BasePlatform.ToHex(offset + parameter.Offset, 1)
 						: "-" + BasePlatform.ToHex(-offset + parameter.Offset, 1)),

--- a/Source/Mosa.Tool.Debugger/Views/StackFrameView.cs
+++ b/Source/Mosa.Tool.Debugger/Views/StackFrameView.cs
@@ -89,7 +89,7 @@ namespace Mosa.Tool.Debugger.Views
 					Address = BasePlatform.ToHex(at, NativeIntegerSize),
 					HexValue = BasePlatform.ToHex(value, NativeIntegerSize),
 					Value = value,
-					Offset = Platform.StackFrame.Name.ToUpper() +
+					Offset = Platform.StackFrame.Name.ToUpperInvariant() +
 						(offset >= 0
 						? "-" + BasePlatform.ToHex(offset, 1)
 						: "+" + BasePlatform.ToHex(-(long)offset, 1)),

--- a/Source/Mosa.Tool.Explorer/MainForm.cs
+++ b/Source/Mosa.Tool.Explorer/MainForm.cs
@@ -1100,11 +1100,11 @@ namespace Mosa.Tool.Explorer
 
 			if (platform != null)
 			{
-				if (platform.ToLower() == "x86")
+				if (platform.ToLowerInvariant() == "x86")
 					cbPlatform.SelectedIndex = 0;
-				else if (platform.ToLower() == "x64")
+				else if (platform.ToLowerInvariant() == "x64")
 					cbPlatform.SelectedIndex = 1;
-				else if (platform.ToLower() == "armv8a32")
+				else if (platform.ToLowerInvariant() == "armv8a32")
 					cbPlatform.SelectedIndex = 2;
 			}
 		}

--- a/Source/Mosa.Tool.Launcher/MainForm.cs
+++ b/Source/Mosa.Tool.Launcher/MainForm.cs
@@ -476,7 +476,7 @@ namespace Mosa.Tool.Launcher
 			tbVBEDepth.Text = Settings.GetValue("Multiboot.Depth", "32");
 			tbOSName.Text = Settings.GetValue("OS.Name", "MOSA");
 
-			switch (Settings.GetValue("Image.Format", string.Empty).ToUpper())
+			switch (Settings.GetValue("Image.Format", string.Empty).ToUpperInvariant())
 			{
 				case "IMG": cbImageFormat.SelectedIndex = 0; break;
 				case "ISO": cbImageFormat.SelectedIndex = 1; break;
@@ -486,7 +486,7 @@ namespace Mosa.Tool.Launcher
 				default: break;
 			}
 
-			switch (Settings.GetValue("Emulator", string.Empty).ToLower())
+			switch (Settings.GetValue("Emulator", string.Empty).ToLowerInvariant())
 			{
 				case "qemu": cbEmulator.SelectedIndex = 0; break;
 				case "bochs": cbEmulator.SelectedIndex = 1; break;
@@ -494,7 +494,7 @@ namespace Mosa.Tool.Launcher
 				default: cbEmulator.SelectedIndex = -1; break;
 			}
 
-			switch (Settings.GetValue("Image.FileSystem", string.Empty).ToLower())
+			switch (Settings.GetValue("Image.FileSystem", string.Empty).ToLowerInvariant())
 			{
 				case "fat12": cbBootFileSystem.SelectedIndex = 0; break;
 				case "fat16": cbBootFileSystem.SelectedIndex = 1; break;
@@ -502,7 +502,7 @@ namespace Mosa.Tool.Launcher
 				default: break;
 			}
 
-			switch (Settings.GetValue("Image.BootLoader", string.Empty).ToLower())
+			switch (Settings.GetValue("Image.BootLoader", string.Empty).ToLowerInvariant())
 			{
 				case "syslinux3.72": cbBootLoader.SelectedIndex = 0; break;
 				case "syslinux6.03": cbBootLoader.SelectedIndex = 1; break;
@@ -511,7 +511,7 @@ namespace Mosa.Tool.Launcher
 				default: break;
 			}
 
-			switch (Settings.GetValue("Compiler.Platform", string.Empty).ToLower())
+			switch (Settings.GetValue("Compiler.Platform", string.Empty).ToLowerInvariant())
 			{
 				case "x86": cbPlatform.SelectedIndex = 0; break;
 				case "x64": cbPlatform.SelectedIndex = 1; break;
@@ -519,7 +519,7 @@ namespace Mosa.Tool.Launcher
 				default: cbPlatform.SelectedIndex = 0; break;
 			}
 
-			switch (Settings.GetValue("Emulator.Serial", string.Empty).ToLower())
+			switch (Settings.GetValue("Emulator.Serial", string.Empty).ToLowerInvariant())
 			{
 				case "none": cbDebugConnectionOption.SelectedIndex = 0; break;
 				case "pipe": cbDebugConnectionOption.SelectedIndex = 1; break;

--- a/Source/Mosa.Utility.BootImage/Generator.cs
+++ b/Source/Mosa.Utility.BootImage/Generator.cs
@@ -165,7 +165,7 @@ namespace Mosa.Utility.BootImage
 				if (includeFile.Hidden) fileAttributes |= FatFileAttributes.Hidden;
 				if (includeFile.System) fileAttributes |= FatFileAttributes.System;
 
-				string newname = (Path.GetFileNameWithoutExtension(includeFile.Filename).PadRight(8).Substring(0, 8) + Path.GetExtension(includeFile.Filename).PadRight(4).Substring(1, 3)).ToUpper();
+				string newname = (Path.GetFileNameWithoutExtension(includeFile.Filename).PadRight(8).Substring(0, 8) + Path.GetExtension(includeFile.Filename).PadRight(4).Substring(1, 3)).ToUpperInvariant();
 				var location = fat.CreateFile(newname, fileAttributes);
 
 				if (!location.IsValid)

--- a/Source/Mosa.Utility.BootImage/Syslinux.cs
+++ b/Source/Mosa.Utility.BootImage/Syslinux.cs
@@ -44,7 +44,7 @@ namespace Mosa.Utility.BootImage
 		{
 			// Locate ldlinux.sys file for patching
 			string filename = "ldlinux.sys";
-			string name = (Path.GetFileNameWithoutExtension(filename) + Path.GetExtension(filename).PadRight(4).Substring(0, 4)).ToUpper();
+			string name = (Path.GetFileNameWithoutExtension(filename) + Path.GetExtension(filename).PadRight(4).Substring(0, 4)).ToUpperInvariant();
 
 			var location = fat.FindEntry(name);
 
@@ -167,7 +167,7 @@ namespace Mosa.Utility.BootImage
 		{
 			// Locate ldlinux.sys file for patching
 			string filename = "ldlinux.sys";
-			string name = (Path.GetFileNameWithoutExtension(filename) + Path.GetExtension(filename).PadRight(4).Substring(0, 4)).ToUpper();
+			string name = (Path.GetFileNameWithoutExtension(filename) + Path.GetExtension(filename).PadRight(4).Substring(0, 4)).ToUpperInvariant();
 
 			var location = fat.FindEntry(name);
 

--- a/Source/Mosa.Utility.Disassembler/Disassembler.cs
+++ b/Source/Mosa.Utility.Disassembler/Disassembler.cs
@@ -25,7 +25,7 @@ namespace Mosa.Utility.Disassembler
 			var services = new ServiceContainer();
 			var options = new Dictionary<string, object>();
 
-			switch (platform.ToLower())
+			switch (platform.ToLowerInvariant())
 			{
 				case "armv8a32": arch = new Arm32Architecture(services, "arm32", options); break;
 				case "x86": arch = new X86ArchitectureFlat32(services, "x86-protected-32", options); break;

--- a/Source/Mosa.Utility.Launcher/BaseLauncher.cs
+++ b/Source/Mosa.Utility.Launcher/BaseLauncher.cs
@@ -49,12 +49,12 @@ namespace Mosa.Utility.Launcher
 		protected void NormalizeSettings()
 		{
 			// Normalize inputs
-			LauncherSettings.ImageBootLoader = LauncherSettings.ImageBootLoader == null ? string.Empty : LauncherSettings.ImageBootLoader.ToLower();
-			LauncherSettings.ImageFormat = LauncherSettings.ImageFormat == null ? string.Empty : LauncherSettings.ImageFormat.ToLower();
-			LauncherSettings.FileSystem = LauncherSettings.FileSystem == null ? string.Empty : LauncherSettings.FileSystem.ToLower();
-			LauncherSettings.EmulatorSerial = LauncherSettings.EmulatorSerial == null ? string.Empty : LauncherSettings.EmulatorSerial.ToLower();
-			LauncherSettings.Emulator = LauncherSettings.Emulator == null ? string.Empty : LauncherSettings.Emulator.ToLower();
-			LauncherSettings.Platform = LauncherSettings.Platform.ToLower();
+			LauncherSettings.ImageBootLoader = LauncherSettings.ImageBootLoader == null ? string.Empty : LauncherSettings.ImageBootLoader.ToLowerInvariant();
+			LauncherSettings.ImageFormat = LauncherSettings.ImageFormat == null ? string.Empty : LauncherSettings.ImageFormat.ToLowerInvariant();
+			LauncherSettings.FileSystem = LauncherSettings.FileSystem == null ? string.Empty : LauncherSettings.FileSystem.ToLowerInvariant();
+			LauncherSettings.EmulatorSerial = LauncherSettings.EmulatorSerial == null ? string.Empty : LauncherSettings.EmulatorSerial.ToLowerInvariant();
+			LauncherSettings.Emulator = LauncherSettings.Emulator == null ? string.Empty : LauncherSettings.Emulator.ToLowerInvariant();
+			LauncherSettings.Platform = LauncherSettings.Platform.ToLowerInvariant();
 		}
 
 		private void SetDefaults()

--- a/Source/Mosa.Utility.Launcher/CheckOptions.cs
+++ b/Source/Mosa.Utility.Launcher/CheckOptions.cs
@@ -8,9 +8,9 @@ namespace Mosa.Utility.Launcher
 	{
 		public static string Verify(Settings settings)
 		{
-			var emulator = settings.GetValue("Emulator", string.Empty).ToLower();
-			var imageformat = settings.GetValue("Image.Format", string.Empty).ToUpper();
-			var bootloader = settings.GetValue("Image.BootLoader", string.Empty).ToLower();
+			var emulator = settings.GetValue("Emulator", string.Empty).ToLowerInvariant();
+			var imageformat = settings.GetValue("Image.Format", string.Empty).ToUpperInvariant();
+			var bootloader = settings.GetValue("Image.BootLoader", string.Empty).ToLowerInvariant();
 			var platform = settings.GetValue("Compiler.Platform", string.Empty);
 
 			if (emulator == "qemu" && imageformat == "VDI")

--- a/Source/Mosa.Utility.SourceCodeGenerator/BuildCommonInstructionFiles.cs
+++ b/Source/Mosa.Utility.SourceCodeGenerator/BuildCommonInstructionFiles.cs
@@ -10,7 +10,7 @@ namespace Mosa.Utility.SourceCodeGenerator
 	{
 		protected virtual string Platform { get; }
 
-		protected string NormalizedPlatform { get { return Platform.Substring(0, 1).ToUpper() + Platform.Substring(1); } }
+		protected string NormalizedPlatform { get { return Platform.Substring(0, 1).ToUpperInvariant() + Platform.Substring(1); } }
 
 		private readonly Dictionary<string, string> EncodingTemplates = new Dictionary<string, string>();
 
@@ -87,11 +87,11 @@ namespace Mosa.Utility.SourceCodeGenerator
 			Lines.AppendLine("\t\t{");
 			Lines.AppendLine("\t\t}");
 
-			var FlagsUsed = node.FlagsUsed == null ? string.Empty : node.FlagsUsed.ToUpper(); // tested_f
-			var FlagsSet = node.FlagsSet == null ? string.Empty : node.FlagsSet.ToUpper(); // values_f (upper=set, lower=cleared)
-			var FlagsCleared = node.FlagsCleared == null ? string.Empty : node.FlagsCleared.ToUpper(); // above
-			var FlagsModified = node.FlagsModified == null ? string.Empty : node.FlagsModified.ToUpper(); // modif_f
-			var FlagsUndefined = node.FlagsUndefined == null ? string.Empty : node.FlagsUndefined.ToUpper(); // undef_f
+			var FlagsUsed = node.FlagsUsed == null ? string.Empty : node.FlagsUsed.ToUpperInvariant(); // tested_f
+			var FlagsSet = node.FlagsSet == null ? string.Empty : node.FlagsSet.ToUpperInvariant(); // values_f (upper=set, lower=cleared)
+			var FlagsCleared = node.FlagsCleared == null ? string.Empty : node.FlagsCleared.ToUpperInvariant(); // above
+			var FlagsModified = node.FlagsModified == null ? string.Empty : node.FlagsModified.ToUpperInvariant(); // modif_f
+			var FlagsUndefined = node.FlagsUndefined == null ? string.Empty : node.FlagsUndefined.ToUpperInvariant(); // undef_f
 
 			if (node.AlternativeName != null)
 			{
@@ -547,7 +547,7 @@ namespace Mosa.Utility.SourceCodeGenerator
 			for (int i = 0; i < parts.Length; i++)
 			{
 				var part = parts[i];
-				var normalized = part.Replace(" ", string.Empty).TrimStart('[').ToLower();
+				var normalized = part.Replace(" ", string.Empty).TrimStart('[').ToLowerInvariant();
 
 				if (string.IsNullOrWhiteSpace(normalized))
 					continue;
@@ -582,7 +582,7 @@ namespace Mosa.Utility.SourceCodeGenerator
 					string cond2 = string.Empty;
 					string cond3 = string.Empty;
 
-					switch (subpart2.ToLower())
+					switch (subpart2.ToLowerInvariant())
 					{
 						case "skip": continue;
 						case "ignore": continue;

--- a/Source/Mosa.Utility.SourceCodeGenerator/TransformExpressions/InstructionParser.cs
+++ b/Source/Mosa.Utility.SourceCodeGenerator/TransformExpressions/InstructionParser.cs
@@ -159,7 +159,7 @@ namespace Mosa.Utility.SourceCodeGenerator.TransformExpressions
 				}
 				else if (t == TokenType.Word)
 				{
-					var text = tokens[index].Value.ToLower();
+					var text = tokens[index].Value.ToLowerInvariant();
 
 					if (text == "u")
 					{

--- a/Source/Mosa.Utility.UnitTests/UnitTestEngine.cs
+++ b/Source/Mosa.Utility.UnitTests/UnitTestEngine.cs
@@ -394,7 +394,7 @@ namespace Mosa.Utility.UnitTests
 		{
 			DebugServerEngine.Stream = null;
 
-			var serial = Settings.GetValue("Emulator.Serial", string.Empty).ToLower();
+			var serial = Settings.GetValue("Emulator.Serial", string.Empty).ToLowerInvariant();
 
 			switch (serial)
 			{

--- a/Source/Mosa.Workspace.FileSystem.Debug/Program.cs
+++ b/Source/Mosa.Workspace.FileSystem.Debug/Program.cs
@@ -114,7 +114,7 @@ namespace Mosa.Workspace.FileSystem.Debug
 				if (includeFile.Hidden) fileAttributes |= FatFileAttributes.Hidden;
 				if (includeFile.System) fileAttributes |= FatFileAttributes.System;
 
-				string newname = (Path.GetFileNameWithoutExtension(includeFile.Filename).PadRight(8).Substring(0, 8) + Path.GetExtension(includeFile.Filename).PadRight(4).Substring(1, 3)).ToUpper();
+				string newname = (Path.GetFileNameWithoutExtension(includeFile.Filename).PadRight(8).Substring(0, 8) + Path.GetExtension(includeFile.Filename).PadRight(4).Substring(1, 3)).ToUpperInvariant();
 				var location = fat.CreateFile(newname, fileAttributes);
 
 				if (!location.IsValid)


### PR DESCRIPTION
After compiling on Windows 10 21H1 with Dotnet Core 5.0 (latest version as of today) regional settings (Turkish regional setting) were causing problems with the filenames including "i" character, because in Turkish we have four different characters for "i".
"ı" (lowercase), "I" (uppercase), "i" (lowercase), "İ" (uppercase). 

For example, the launcher was producing "*.ımg" files, which can't be launched by QEMU.
At same time, when inspected with WinImage, the "*.ımg" files included embedded filenames like "ma0n.exe", "ldl0nux.sys", "sysl0nux.cfg", etc...

The patch fixes these problems without needing to change the regional settings by using ToLowerInvariant() and ToUpperInvariant() string functions in an ASCII like manner.

