### PR TITLE
Internal.MemoryCopy function should be up to 4 times faster & Removed Mandelbrot zooming, it was too slow

### DIFF
--- a/Launch.bat
+++ b/Launch.bat
@@ -1,1 +1,2 @@
+@ECHO OFF
 start bin\Mosa.Tool.Launcher.exe -autostart-off bin\Mosa.Demo.CoolWorld.x86.dll

--- a/Source/Mosa.DeviceDriver/PCI/VMware/VMwareSVGA2.cs
+++ b/Source/Mosa.DeviceDriver/PCI/VMware/VMwareSVGA2.cs
@@ -485,8 +485,8 @@ namespace Mosa.DeviceDriver.PCI.VMware
 
 			Device.Status = DeviceStatus.Online;
 
-			MandelbrotAnimate();
-			//MosaLogoDraw(frameBuffer, 10);
+			Mandelbrot();
+			MosaLogoDraw(frameBuffer, 10);
 		}
 
 		public override bool OnInterrupt()
@@ -809,12 +809,13 @@ namespace Mosa.DeviceDriver.PCI.VMware
 				MandelbrotColor(106, 52, 3, 255)
 		};
 
-		public void Mandelbrot(double XMin, double YMin, double XMax, double YMax)
+		public void Mandelbrot()
 		{
-			double xmin = XMin;
-			double ymin = YMin;
-			double xmax = XMax;
-			double ymax = YMax;
+			const double xmin = -2.1;
+			const double ymin = -1.3;
+
+			const double xmax = 1;
+			const double ymax = 1.3;
 
 			const uint maxIterations = 100;
 
@@ -854,7 +855,7 @@ namespace Mosa.DeviceDriver.PCI.VMware
 
 					color = palette[looper % 16];
 
-					frameBuffer.SetPixel(color, s + GapLeft, z);
+					frameBuffer.SetPixel(color, z + GapLeft, s);
 
 					y += intigralY;
 				}
@@ -863,23 +864,6 @@ namespace Mosa.DeviceDriver.PCI.VMware
 			}
 
 			UpdateScreen(GapLeft, 0, (ushort)height, (ushort)height);
-		}
-
-		public void MandelbrotAnimate()
-		{
-			const double xmin = -2.1;
-			const double ymin = -1.3;
-
-			const double xmax = 1;
-			const double ymax = 1.3;
-
-			const double xstep = 0.01;
-			const double ystep = 0.01;
-
-			for (uint step = 0; step < 100; step++)
-			{
-				Mandelbrot(xmin + step*xstep, ymin + step*ystep, xmax - step*xstep, ymax - step*ystep);
-			}
 		}
 	}
 }

--- a/Source/Mosa.Runtime/Internal.cs
+++ b/Source/Mosa.Runtime/Internal.cs
@@ -177,18 +177,25 @@ namespace Mosa.Runtime
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		public static void MemoryCopy(Pointer dest, Pointer src, uint count)
 		{
-			// FUTURE: Improve
-			for (int i = 0; i < count; i++)
+			uint count32 = count >> 2;
+			for (uint i = 0; i < count32; i++)
 			{
-				byte value = src.Load8(i);
-				dest.Store8(i, value);
+				uint value = src.Load32(i << 2);
+				dest.Store32(i << 2, value);
+			}
+
+			uint count8 = count & 0x03;
+			for (uint i = 0; i < count8; i++)
+			{
+				byte value = src.Load8(count32 + i);
+				dest.Store8(count32 + i, value);
 			}
 		}
 
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		public static void MemorySet(Pointer dest, byte value, uint count)
 		{
-			for (int i = 0; i < count; i++)
+			for (uint i = 0; i < count; i++)
 			{
 				dest.Store8(i, value);
 			}
@@ -197,7 +204,7 @@ namespace Mosa.Runtime
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		public static void MemorySet(Pointer dest, ushort value, uint count)
 		{
-			for (int i = 0; i < count; i += 2)
+			for (uint i = 0; i < count; i += 2)
 			{
 				dest.Store16(i, value);
 			}
@@ -206,7 +213,7 @@ namespace Mosa.Runtime
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		public static void MemorySet(Pointer dest, uint value, uint count)
 		{
-			for (int i = 0; i < count; i += 4)
+			for (uint i = 0; i < count; i += 4)
 			{
 				dest.Store32(i, value);
 			}
@@ -215,7 +222,7 @@ namespace Mosa.Runtime
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		public static void MemoryClear(Pointer dest, uint count, uint value = 0)
 		{
-			for (int i = 0; i < count; i++)
+			for (uint i = 0; i < count; i++)
 			{
 				dest.Store8(i, (byte)value);
 			}


### PR DESCRIPTION
(1)
Internal.MemoryCopy function should be up to 4 times faster.

(2)
Removed Mandelbrot zooming, it was too slow.