### PR TITLE
Compiler performance improvement 

### DIFF
--- a/Source/Mosa.Compiler.Framework/Compiler.cs
+++ b/Source/Mosa.Compiler.Framework/Compiler.cs
@@ -418,13 +418,14 @@ namespace Mosa.Compiler.Framework
 		{
 			try
 			{
-				var method = MethodScheduler.GetMethodToCompile();
+				var methodData = MethodScheduler.GetMethodToCompile();
 
-				if (method == null)
+				if (methodData == null)
 					return null;
 
-				CompileMethod(method, threadID);
-				return method;
+				CompileMethod(methodData.Method, threadID);
+
+				return methodData.Method;
 			}
 			catch (Exception e)
 			{

--- a/Source/Mosa.Compiler.Framework/CompilerData.cs
+++ b/Source/Mosa.Compiler.Framework/CompilerData.cs
@@ -51,12 +51,15 @@ namespace Mosa.Compiler.Framework
 			{
 				if (!methods.TryGetValue(method, out MethodData methodData))
 				{
+					var code = method.Code;
+
 					methodData = new MethodData(method)
 					{
 						HasProtectedRegions = method.ExceptionHandlers.Count != 0,
 						IsCompilerGenerated = method.IsCompilerGenerated,
 						HasDoNotInlineAttribute = method.IsNoInlining,
-						HasAggressiveInliningAttribute = method.IsAggressiveInlining
+						HasAggressiveInliningAttribute = method.IsAggressiveInlining,
+						VirtualCodeSize = code == null ? 0 : code.Count
 					};
 
 					methods.Add(method, methodData);

--- a/Source/Mosa.Compiler.Framework/CompilerStages/InlinedSetupStage.cs
+++ b/Source/Mosa.Compiler.Framework/CompilerStages/InlinedSetupStage.cs
@@ -39,11 +39,6 @@ namespace Mosa.Compiler.Framework.CompilerStages
 								match = true;
 							}
 
-							//else
-							//{
-							//	match = Regex.Match(name, exclude).Success;
-							//}
-
 							if (match)
 							{
 								var methodData = Compiler.GetMethodData(method);
@@ -68,11 +63,6 @@ namespace Mosa.Compiler.Framework.CompilerStages
 							{
 								match = true;
 							}
-
-							//else
-							//{
-							//	match = Regex.Match(name, aggressive).Success;
-							//}
 
 							if (match)
 							{

--- a/Source/Mosa.Compiler.Framework/MethodData.cs
+++ b/Source/Mosa.Compiler.Framework/MethodData.cs
@@ -73,6 +73,8 @@ namespace Mosa.Compiler.Framework
 
 		public MosaMethod ReplacedBy { get; set; }
 
+		public int VirtualCodeSize { get; set; }
+
 		public bool IsInvoked { get; set; }
 
 		#endregion Properties

--- a/Source/Mosa.Compiler.Framework/SourceRegions.cs
+++ b/Source/Mosa.Compiler.Framework/SourceRegions.cs
@@ -66,14 +66,16 @@ namespace Mosa.Compiler.Framework.Source
 
 				foreach (var labelRegion in methodData.LabelRegions)
 				{
-					foreach (var instruction in methodData.Method.Code)
+					var code = methodData.Method.Code;
+
+					foreach (var instruction in code)
 					{
 						// special case: the return label is always 0xFFFFF
 						var searchForLabel = labelRegion.Label;
 
 						if (labelRegion.Label == 0xFFFFF)
 						{
-							searchForLabel = methodData.Method.Code.Last().Offset;
+							searchForLabel = code.Last().Offset;
 						}
 
 						if (instruction.StartLine > 0)

--- a/Source/Mosa.Compiler.Framework/Stages/CILDecodingStage.cs
+++ b/Source/Mosa.Compiler.Framework/Stages/CILDecodingStage.cs
@@ -127,9 +127,11 @@ namespace Mosa.Compiler.Framework.Stages
 		{
 			bool branched = false;
 
-			for (int i = 0; i < Method.Code.Count; i++)
+			var code = Method.Code;
+
+			for (int i = 0; i < code.Count; i++)
 			{
-				instruction = Method.Code[i];
+				instruction = code[i];
 
 				if (branched)
 				{
@@ -156,9 +158,11 @@ namespace Mosa.Compiler.Framework.Stages
 			// Prefix instruction
 			bool prefix = false;
 
-			for (int i = 0; i < Method.Code.Count; i++)
+			var code = Method.Code;
+
+			for (int i = 0; i < code.Count; i++)
 			{
-				instruction = Method.Code[i];
+				instruction = code[i];
 
 				block = BasicBlocks.GetByLabel(instruction.Offset) ?? block;
 
@@ -186,7 +190,7 @@ namespace Mosa.Compiler.Framework.Stages
 
 				if (flow == FlowControl.Next || flow == FlowControl.Call || flow == FlowControl.ConditionalBranch || flow == FlowControl.Switch)
 				{
-					var nextInstruction = Method.Code[i + 1];
+					var nextInstruction = code[i + 1];
 
 					if (BasicBlocks.GetByLabel(nextInstruction.Offset) != null)
 					{

--- a/Source/Mosa.Compiler.Framework/Stages/CILDecodingStageV2.cs
+++ b/Source/Mosa.Compiler.Framework/Stages/CILDecodingStageV2.cs
@@ -108,9 +108,11 @@ namespace Mosa.Compiler.Framework.Stages
 
 		private void CollectTargets()
 		{
-			for (int index = 0; index < Method.Code.Count; index++)
+			var code = Method.Code;
+
+			for (int index = 0; index < code.Count; index++)
 			{
-				var instruction = Method.Code[index];
+				var instruction = code[index];
 
 				var opcode = (OpCode)instruction.OpCode;
 
@@ -121,7 +123,7 @@ namespace Mosa.Compiler.Framework.Stages
 				else if (IsBranch(opcode))
 				{
 					AddTarget((int)instruction.Operand);
-					AddTarget(Method.Code[index + 1].Offset);
+					AddTarget(code[index + 1].Offset);
 				}
 				else if (opcode == OpCode.Switch)
 				{
@@ -130,7 +132,7 @@ namespace Mosa.Compiler.Framework.Stages
 						AddTarget((int)instruction.Operand);
 					}
 
-					AddTarget(Method.Code[index + 1].Offset);
+					AddTarget(code[index + 1].Offset);
 				}
 			}
 
@@ -243,9 +245,11 @@ namespace Mosa.Compiler.Framework.Stages
 
 			InstructionNode endNode = block.First;
 
-			for (int index = 0; index < Method.Code.Count; index++)
+			var code = Method.Code;
+
+			for (int index = 0; index < code.Count; index++)
 			{
-				var instruction = Method.Code[index];
+				var instruction = code[index];
 				var opcode = (OpCode)instruction.OpCode;
 				var label = instruction.Offset;
 
@@ -290,9 +294,11 @@ namespace Mosa.Compiler.Framework.Stages
 			var arg = new bool[count];
 			var argCount = 0;
 
-			for (int label = 0; label < Method.Code.Count; label++)
+			var code = Method.Code;
+
+			for (int label = 0; label < code.Count; label++)
 			{
-				var instruction = Method.Code[label];
+				var instruction = code[label];
 
 				var opcode = (OpCode)instruction.OpCode;
 

--- a/Source/Mosa.Compiler.Framework/Stages/CILTransformationStage.cs
+++ b/Source/Mosa.Compiler.Framework/Stages/CILTransformationStage.cs
@@ -939,7 +939,7 @@ namespace Mosa.Compiler.Framework.Stages
 			{
 				methodData.HasMethodPointerReferenced = true;
 
-				MethodScheduler.AddToRecompileQueue(invokedMethod); // FUTURE: Optimize this not to re-schedule when not necessary
+				MethodScheduler.AddToRecompileQueue(methodData); // FUTURE: Optimize this not to re-schedule when not necessary
 
 				//Debug.WriteLine($" Method Reference: [{MethodData.Version}] {invokedMethod}"); //DEBUGREMOVE
 			}

--- a/Source/Mosa.Demo.CoolWorld.x86/Boot.cs
+++ b/Source/Mosa.Demo.CoolWorld.x86/Boot.cs
@@ -62,14 +62,14 @@ namespace Mosa.Demo.CoolWorld.x86
 			var partitionService = new PartitionService();
 			var pciControllerService = new PCIControllerService();
 			var pciDeviceService = new PCIDeviceService();
-			var restartService = new RestartService();
+			var pcService = new PCService();
 
 			serviceManager.AddService(deviceService);
 			serviceManager.AddService(diskDeviceService);
 			serviceManager.AddService(partitionService);
 			serviceManager.AddService(pciControllerService);
 			serviceManager.AddService(pciDeviceService);
-			serviceManager.AddService(restartService);
+			serviceManager.AddService(pcService);
 
 			Console.WriteLine("> Initializing hardware abstraction layer...");
 

--- a/Source/Mosa.DeviceSystem/BaseService.cs
+++ b/Source/Mosa.DeviceSystem/BaseService.cs
@@ -39,9 +39,6 @@ namespace Mosa.DeviceSystem
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		protected Device MatchEvent<SERVICE>(ServiceEvent serviceEvent, ServiceEventType eventType) where SERVICE : class
 		{
-			//HAL.DebugWriteLine("BaseService:MatchEvent()-A");
-			//HAL.Pause();
-
 			if (serviceEvent.ServiceEventType != eventType)
 				return null;
 

--- a/Source/Mosa.DeviceSystem/PCIControllerService.cs
+++ b/Source/Mosa.DeviceSystem/PCIControllerService.cs
@@ -26,9 +26,6 @@ namespace Mosa.DeviceSystem
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		public override void PostEvent(ServiceEvent serviceEvent)
 		{
-			//HAL.DebugWriteLine("PCIControllerService:PostEvent()");
-			//HAL.Pause();
-
 			var device = MatchEvent<IPCIControllerLegacy>(serviceEvent, ServiceEventType.Start);
 
 			if (device == null)

--- a/Source/Mosa.DeviceSystem/PCService.cs
+++ b/Source/Mosa.DeviceSystem/PCService.cs
@@ -1,0 +1,55 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using Mosa.DeviceSystem.PCI;
+
+namespace Mosa.DeviceSystem
+{
+	/// <summary>
+	/// PC Service
+	/// </summary>
+	public class PCService : BaseService
+	{
+		/// <summary>
+		/// The device service
+		/// </summary>
+		protected DeviceService DeviceService;
+
+		/// <summary>
+		/// Initializes this instance.
+		/// </summary>
+		public override void Initialize()
+		{
+			DeviceService = ServiceManager.GetFirstService<DeviceService>();
+		}
+
+		public bool Reset()
+		{
+			var acpi = DeviceService.GetFirstDevice<IAPCI>(DeviceStatus.Online);
+
+			if (acpi == null)
+				return false;
+
+			// TODO: Get Reset information (type, address, value) from ACPI
+			int type = 0;
+			int address = 0;
+			int value = 0;
+
+			// If via PCI Bus, get Host bridge controller:
+			{
+				var device = DeviceService.GetDevices<IHostBridgeController>(DeviceStatus.Online);
+				var controller = device as IHostBridgeController;
+
+				controller.SetCPUResetInformation(address, value);
+				return controller.CPUReset();
+			}
+
+			return false;
+		}
+
+		public bool Shutdown()
+		{
+			// TODO
+			return Reset();
+		}
+	}
+}

--- a/Source/Mosa.DeviceSystem/PlatformArchitecture.cs
+++ b/Source/Mosa.DeviceSystem/PlatformArchitecture.cs
@@ -24,6 +24,11 @@ namespace Mosa.DeviceSystem
 		X64 = 2,
 
 		/// <summary>
+		/// The ARMv8 32bit
+		/// </summary>
+		ARMv8A32 = 3,
+
+		/// <summary>
 		/// The X86 and X64
 		/// </summary>
 		X86AndX64 = PlatformArchitecture.X86 | PlatformArchitecture.X64,


### PR DESCRIPTION
Method compiling is 2x faster. The compiler now prioritizes the order in which methods are compiled. This results in less recompilation due to method inlining.