### PR TITLE
Partial APIC initialization implementation

### DIFF
--- a/Source/Mosa.DeviceSystem/IACPI.cs
+++ b/Source/Mosa.DeviceSystem/IACPI.cs
@@ -16,5 +16,11 @@ namespace Mosa.DeviceSystem
 		short SLP_EN { get; set; }
 
 		byte ResetValue { get; set; }
+
+		byte[] ProcessorIDs { get; set; }
+		int ProcessorCount { get; set; }
+		
+		uint IOApicAddress { get; set; }
+		uint LocalApicAddress { get; set; }
 	}
 }


### PR DESCRIPTION
This PR implements a partial APIC initialization implementation. This doesn't really initialize it yet, it simply gets the MADT (https://wiki.osdev.org/MADT) from ACPI, then gets the APIC table and parses stuff in it. It does give a good start though.