### PR TITLE
* IComparable (CompareTo), IEquatable (Equals), GetHashCode functions changed & added to the value types

### DIFF
--- a/Source/Mosa.Korlib/System/Boolean.cs
+++ b/Source/Mosa.Korlib/System/Boolean.cs
@@ -5,7 +5,8 @@ namespace System
 	/// <summary>
 	///
 	/// </summary>
-	public struct Boolean
+	[Serializable]
+	public struct Boolean: IComparable, IComparable<bool>, IEquatable<bool>
 	{
 		//
 		// Member Variables
@@ -52,6 +53,47 @@ namespace System
 		public override string ToString()
 		{
 			return m_value ? "True" : "False";
+		}
+
+		// IComparable interface
+		//
+		public override bool Equals(object obj)
+		{
+			if (obj is Boolean)
+			{
+				return (this.m_value == ((Boolean)obj).m_value);
+			}
+			else
+			{
+				return false;
+			}
+		}
+
+		public bool Equals(bool obj)
+		{
+			return (this.m_value == obj.m_value);
+		}
+
+		public int CompareTo(object obj)
+		{
+			if (obj == null) { return 1; }
+
+			if (!(obj is bool)) { throw new ArgumentException("Argument Type Must Be Boolean", "obj"); }
+
+			if (this.m_value == ((bool)obj).m_value) { return 0; }
+
+			if (this.m_value == false) { return -1; }
+
+			return 1;	// this.m_value == true;
+		}
+
+		public int CompareTo(bool value)
+		{
+			if (this.m_value == value)	{ return 0;	}
+
+			if (this.m_value == false) { return -1; }
+
+			return 1;
 		}
 	}
 }

--- a/Source/Mosa.Korlib/System/Byte.cs
+++ b/Source/Mosa.Korlib/System/Byte.cs
@@ -5,43 +5,66 @@ namespace System
 	/// <summary>
 	///
 	/// </summary>
-	public struct Byte
+	[Serializable]
+	public struct Byte: IComparable, IComparable<byte>, IEquatable<byte>
 	{
+		internal byte m_value;
+
 		public const byte MinValue = 0;
 		public const byte MaxValue = 255;
 
-		internal byte _value;
-
-		public int CompareTo(byte value)
+		public override bool Equals(object obj)
 		{
-			if (_value < value) return -1;
-			else if (_value > value) return 1;
+			if (obj is Byte)
+			{
+				return (this.m_value == ((Byte)obj).m_value);
+			}
+			else
+			{
+				return false;
+			}
+		}
+
+		public bool Equals(byte value)
+		{
+			return (m_value == value);
+		}
+
+		public int CompareTo(object value)
+		{
+			if (value == null) { return 1; }
+
+			if (!(value is byte)) { throw new ArgumentException("Argument Type Must Be Byte", "value"); }
+
+			if (m_value < (((byte)value).m_value)) return -1;
+
+			if (m_value > (((byte)value).m_value)) return 1;
+
 			return 0;
 		}
 
-		public bool Equals(byte obj)
+		public int CompareTo(byte value)
 		{
-			return Equals((object)obj);
-		}
+			if (m_value < value) return -1;
 
-		public override bool Equals(object obj)
-		{
-			return ((byte)obj) == _value;
+			if (m_value > value) return 1;
+
+			return 0;
 		}
 
 		public override int GetHashCode()
 		{
-			return base.GetHashCode();
+			return m_value;
 		}
 
 		public override string ToString()
 		{
-			return int.CreateString(_value, false, false);
+			return int.CreateString(m_value, false, false);
 		}
 
 		public string ToString(string format)
 		{
-			return int.CreateString(_value, false, true);
+			return int.CreateString(m_value, false, true);
 		}
 	}
 }

--- a/Source/Mosa.Korlib/System/Char.cs
+++ b/Source/Mosa.Korlib/System/Char.cs
@@ -8,28 +8,52 @@ namespace System
 	/// <summary>
 	/// Char
 	/// </summary>
-	public struct Char
+	[Serializable]
+	public struct Char: IComparable, IComparable<char>, IEquatable<char>
 	{
+		internal char m_value;
+
 		public const char MaxValue = (char)0xffff;
 		public const char MinValue = (char)0;
 
-		internal char _value;
-
-		public int CompareTo(char value)
+		public override bool Equals(object obj)
 		{
-			if (_value < value) return -1;
-			else if (_value > value) return 1;
-			return 0;
+			if (obj is Char)
+			{
+				return (this.m_value == ((Char)obj).m_value);
+			}
+			else
+			{
+				return false;
+			}
+
 		}
 
 		public bool Equals(char obj)
 		{
-			return Equals((object)obj);
+			return m_value == obj;
 		}
 
-		public override bool Equals(object obj)
+		public int CompareTo(object value)
 		{
-			return ((char)obj) == _value;
+			if (value == null) return 1;
+
+			if (!(value is char)) throw new ArgumentException("Argument Type Must Be Char", "value");
+
+			if (m_value < ((char)value).m_value) return -1;
+
+			if (m_value > ((char)value).m_value) return 1;
+
+			return 0;
+		}
+
+		public int CompareTo(char value)
+		{
+			if (m_value < value) return -1;
+
+			if (m_value > value) return 1;
+
+			return 0;
 		}
 
 		public static bool IsUpper(char c)
@@ -62,12 +86,12 @@ namespace System
 
 		public override string ToString()
 		{
-			return new String(_value, 1);
+			return new String(m_value, 1);
 		}
 
 		public override int GetHashCode()
 		{
-			return _value;
+			return (int)m_value | ((int)m_value << 16);
 		}
 
 		private static bool IsWhiteSpaceLatin1(char c)

--- a/Source/Mosa.Korlib/System/Int16.cs
+++ b/Source/Mosa.Korlib/System/Int16.cs
@@ -5,38 +5,56 @@ namespace System
 	/// <summary>
 	///
 	/// </summary>
-	public struct Int16
+	[Serializable]
+	public struct Int16: IComparable, IComparable<short>, IEquatable<short>
 	{
+		internal short m_value;
+
 		public const short MaxValue = 32767;
 		public const short MinValue = -32768;
 
-		internal short _value;
-
-		public int CompareTo(short value)
+		public int CompareTo(object value)
 		{
-			if (_value < value) return -1;
-			else if (_value > value) return 1;
+			if (value == null) { return 1; }
+
+			if (!(value is short)) { throw new ArgumentException("Argument Type Must Be Int16", "value"); }
+
+			short s_value = ((short)value).m_value;
+
+			if (m_value < s_value) return -1;
+			if (m_value > s_value) return 1;
+
 			return 0;
 		}
 
-		public bool Equals(short obj)
+		public int CompareTo(short value)
 		{
-			return Equals((object)obj);
+			if (m_value < value) return -1;
+			if (m_value > value) return 1;
+
+			return 0;
 		}
 
 		public override bool Equals(object obj)
 		{
-			return ((short)obj) == _value;
+			if (!(obj is short)) { return false; }
+
+			return m_value == ((short)obj).m_value;
+		}
+
+		public bool Equals(short obj)
+		{
+			return m_value == obj;
 		}
 
 		public override string ToString()
 		{
-			return int.CreateString((uint)_value, true, false);
+			return int.CreateString((uint)m_value, true, false);
 		}
 
 		public override int GetHashCode()
 		{
-			return _value;
+			return m_value;
 		}
 
 		public static bool TryParse(string s, out short result)

--- a/Source/Mosa.Korlib/System/Int32.cs
+++ b/Source/Mosa.Korlib/System/Int32.cs
@@ -5,38 +5,56 @@ namespace System
 	/// <summary>
 	/// Int32
 	/// </summary>
-	public struct Int32
+	[Serializable]
+	public struct Int32: IComparable, IComparable<int>, IEquatable<int>
 	{
+		internal int m_value;
+
 		public const int MaxValue = 0x7fffffff;
 		public const int MinValue = -2147483648;
 
-		internal int _value;
-
-		public int CompareTo(int value)
+		public int CompareTo(object value)
 		{
-			if (_value < value) return -1;
-			else if (_value > value) return 1;
+			if (value == null) { return 1; }
+
+			if (!(value is int)) { throw new ArgumentException("Argument Type Must Be Int32", "value"); }
+
+			int i_value = ((int)value).m_value;
+
+			if (m_value < i_value) return -1;
+			if (m_value > i_value) return 1;
+
 			return 0;
 		}
 
-		public bool Equals(int obj)
+		public int CompareTo(int value)
 		{
-			return Equals((object)obj);
+			if (m_value < value) return -1;
+			if (m_value > value) return 1;
+
+			return 0;
 		}
 
 		public override bool Equals(object obj)
 		{
-			return ((int)obj) == _value;
+			if (!(obj is int)) { return false; }
+
+			return m_value == ((int)obj).m_value;
+		}
+
+		public bool Equals(int obj)
+		{
+			return m_value == obj;
 		}
 
 		public override string ToString()
 		{
-			return CreateString((uint)_value, true, false);
+			return CreateString((uint)m_value, true, false);
 		}
 
 		public string ToString(string format)
 		{
-			return CreateString((uint)_value, false, true);
+			return CreateString((uint)m_value, false, true);
 		}
 
 		unsafe internal static string CreateString(uint value, bool signed, bool hex)
@@ -95,7 +113,7 @@ namespace System
 
 		public override int GetHashCode()
 		{
-			return _value;
+			return m_value;
 		}
 
 		public static bool TryParse(string s, out int result)

--- a/Source/Mosa.Korlib/System/Int64.cs
+++ b/Source/Mosa.Korlib/System/Int64.cs
@@ -5,33 +5,51 @@ namespace System
 	/// <summary>
 	///
 	/// </summary>
-	public struct Int64
+	[Serializable]
+	public struct Int64: IComparable, IComparable<long>, IEquatable<long>
 	{
+		internal long m_value;
+
 		public const long MaxValue = 0x7fffffffffffffff;
 		public const long MinValue = -9223372036854775808;
 
-		internal long _value;
-
-		public int CompareTo(long value)
+		public int CompareTo(object value)
 		{
-			if (_value < value) return -1;
-			else if (_value > value) return 1;
+			if (value == null) { return 1; }
+
+			if (!(value is long)) { throw new ArgumentException("Argument Type Must Be Int64", "value"); }
+
+			long l_value = ((long)value).m_value;
+
+			if (m_value < l_value) return -1;
+			if (m_value > l_value) return 1;
+
 			return 0;
 		}
 
-		public bool Equals(long obj)
+		public int CompareTo(long value)
 		{
-			return Equals((object)obj);
+			if (m_value < value) return -1;
+			if (m_value > value) return 1;
+
+			return 0;
 		}
 
 		public override bool Equals(object obj)
 		{
-			return ((long)obj) == _value;
+			if (!(obj is long)) { return false; }
+
+			return m_value == ((long)obj).m_value;
+		}
+
+		public bool Equals(long obj)
+		{
+			return m_value == obj;
 		}
 
 		public override int GetHashCode()
 		{
-			return (int)_value;
+			return unchecked((int)m_value) ^ (int)(m_value >> 32);
 		}
 
 		public static bool TryParse(string s, out long result)

--- a/Source/Mosa.Korlib/System/SByte.cs
+++ b/Source/Mosa.Korlib/System/SByte.cs
@@ -5,38 +5,56 @@ namespace System
 	/// <summary>
 	///
 	/// </summary>
-	public struct SByte
+	[Serializable]
+	public struct SByte: IComparable, IComparable<sbyte>, IEquatable<sbyte>
 	{
+		internal sbyte m_value;
+
 		public const sbyte MinValue = -128;
 		public const sbyte MaxValue = 127;
 
-		internal sbyte _value;
-
-		public int CompareTo(SByte value)
+		public int CompareTo(object value)
 		{
-			if (_value < value) return -1;
-			else if (_value > value) return 1;
+			if (value == null) { return 1; }
+
+			if (!(value is sbyte)) { throw new ArgumentException("Argument Type Must Be SByte", "value"); }
+
+			sbyte s_value = ((sbyte)value).m_value;
+
+			if (m_value < s_value) return -1;
+			if (m_value > s_value) return 1;
+
 			return 0;
 		}
 
-		public bool Equals(sbyte obj)
+		public int CompareTo(sbyte value)
 		{
-			return Equals((object)obj);
+			if (m_value < value) return -1;
+			if (m_value > value) return 1;
+
+			return 0;
 		}
 
 		public override bool Equals(object obj)
 		{
-			return ((sbyte)obj) == _value;
+			if (!(obj is sbyte)) { return false; }
+
+			return m_value == ((sbyte)obj).m_value;
+		}
+
+		public bool Equals(sbyte obj)
+		{
+			return m_value == obj;
 		}
 
 		public override int GetHashCode()
 		{
-			return base.GetHashCode();
+			return m_value;
 		}
 
 		public override string ToString()
 		{
-			return int.CreateString((uint)_value, true, false);
+			return int.CreateString((uint)m_value, true, false);
 		}
 	}
 }

--- a/Source/Mosa.Korlib/System/Single.cs
+++ b/Source/Mosa.Korlib/System/Single.cs
@@ -7,8 +7,11 @@ namespace System
 	/// <summary>
 	/// Single
 	/// </summary>
-	public struct Single
+	[Serializable]
+	public struct Single: IComparable, IComparable<float>, IEquatable<float>
 	{
+		internal float m_value;
+
 		public const float Epsilon = 1.4e-45f;
 		public const float MaxValue = 3.40282346638528859e38f;
 		public const float MinValue = -3.40282346638528859e38f;
@@ -18,13 +21,11 @@ namespace System
 
 		internal const float NegativeZero = (float)-0.0;
 
-		internal float _value;
-
 		public static bool IsNaN(float s)
 		{
 #pragma warning disable 1718
 			return (s != s);
-#pragma warning restore
+#pragma warning restore 1718
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -50,54 +51,96 @@ namespace System
 			return IsNegativeInfinity(s) || IsPositiveInfinity(s);
 		}
 
-		public int CompareTo(float value)
+		public int CompareTo(object value)
 		{
-			if (IsPositiveInfinity(_value) && IsPositiveInfinity(value))
-				return 0;
-			if (IsNegativeInfinity(_value) && IsNegativeInfinity(value))
+			if (value == null) { return 1; }
+
+			if (!(value is float))
+			{
+				throw new ArgumentException("Argument Type Must Be Single", "value");
+			}
+
+			float f_value = ((float)value).m_value;
+
+			if (IsPositiveInfinity(m_value) && IsPositiveInfinity(f_value))
 				return 0;
 
-			if (IsNaN(value))
-				if (IsNaN(_value))
+			if (IsNegativeInfinity(m_value) && IsNegativeInfinity(f_value))
+				return 0;
+
+			if (IsNaN(f_value))
+			{
+				if (IsNaN(m_value))
 					return 0;
 				else
 					return 1;
+			}
 
-			if (IsNaN(_value))
+			if (IsNaN(m_value))
+			{
+				if (IsNaN(f_value))
+					return 0;
+				else
+					return -1;
+			}
+
+			if (m_value < f_value) { return -1; }
+			if (m_value > f_value) { return 1; }
+
+			return 0;
+		}
+
+		public int CompareTo(float value)
+		{
+			if (IsPositiveInfinity(m_value) && IsPositiveInfinity(value))
+				return 0;
+
+			if (IsNegativeInfinity(m_value) && IsNegativeInfinity(value))
+				return 0;
+
+			if (IsNaN(value))
+			{
+				if (IsNaN(m_value))
+					return 0;
+				else
+					return 1;
+			}
+
+			if (IsNaN(m_value))
+			{
 				if (IsNaN(value))
 					return 0;
 				else
 					return -1;
+			}
 
-			if (_value > value)
-				return 1;
-			else if (_value < value)
-				return -1;
-			else
-				return 0;
-		}
+			if (m_value > value) { return 1; }
+			if (m_value < value) { return -1; }
 
-		public bool Equals(float value)
-		{
-			if (IsNaN(value))
-				return IsNaN(_value);
-
-			return (value == _value);
+			return 0;
 		}
 
 		public override bool Equals(object obj)
 		{
-			float value = (float)obj;
+			if (!(obj is Single)) { return false; }
 
-			if (IsNaN(value))
-				return IsNaN(_value);
+			float value = ((float)obj).m_value;
 
-			return (value == _value);
+			if (m_value == value) { return true; }
+
+			return (IsNaN(m_value) && IsNaN(value));
+		}
+
+		public bool Equals(float value)
+		{
+			if (m_value == value) { return true; }
+
+			return (IsNaN(m_value) && IsNaN(value));
 		}
 
 		public override int GetHashCode()
 		{
-			var bits = BitConverter.SingleToInt32Bits(_value);
+			var bits = BitConverter.SingleToInt32Bits(m_value);
 
 			if (((bits - 1) & 0x7FFFFFFF) >= 0x7F800000)
 			{

--- a/Source/Mosa.Korlib/System/UInt16.cs
+++ b/Source/Mosa.Korlib/System/UInt16.cs
@@ -5,43 +5,61 @@ namespace System
 	/// <summary>
 	///
 	/// </summary>
-	public struct UInt16
+	[Serializable]
+	public struct UInt16: IComparable, IComparable<ushort>, IEquatable<ushort>
 	{
+		internal ushort m_value;
+
 		public const ushort MaxValue = 0xffff;
 		public const ushort MinValue = 0;
 
-		internal ushort _value;
-
-		public int CompareTo(ushort value)
+		public int CompareTo(object value)
 		{
-			if (_value < value) return -1;
-			else if (_value > value) return 1;
+			if (value == null) { return 1; }
+
+			if (!(value is ushort)) { throw new ArgumentException("Argument Type Must Be UInt16", "value"); }
+
+			ushort u_value = ((ushort)value).m_value;
+
+			if (m_value < u_value) return -1;
+			if (m_value > u_value) return 1;
+
 			return 0;
 		}
 
-		public bool Equals(ushort obj)
+		public int CompareTo(ushort value)
 		{
-			return Equals((object)obj);
+			if (m_value < value) return -1;
+		    if (m_value > value) return 1;
+
+			return 0;
 		}
 
 		public override bool Equals(object obj)
 		{
-			return ((ushort)obj) == _value;
+			if (!(obj is ushort)) { return false; }
+
+			return m_value == ((ushort)obj).m_value;
+		}
+
+		public bool Equals(ushort obj)
+		{
+			return m_value == obj;
 		}
 
 		public override string ToString()
 		{
-			return int.CreateString(_value, false, false);
+			return int.CreateString(m_value, false, false);
 		}
 
 		public string ToString(string format)
 		{
-			return int.CreateString(_value, false, true);
+			return int.CreateString(m_value, false, true);
 		}
 
 		public override int GetHashCode()
 		{
-			return _value;
+			return (int)m_value;
 		}
 	}
 }

--- a/Source/Mosa.Korlib/System/UInt32.cs
+++ b/Source/Mosa.Korlib/System/UInt32.cs
@@ -5,43 +5,61 @@ namespace System
 	/// <summary>
 	///
 	/// </summary>
-	public struct UInt32
+	[Serializable]
+	public struct UInt32: IComparable, IComparable<uint>, IEquatable<uint>
 	{
+		internal uint m_value;
+
 		public const uint MaxValue = 0xffffffff;
 		public const uint MinValue = 0;
 
-		internal uint _value;
-
-		public int CompareTo(uint value)
+		public int CompareTo(object value)
 		{
-			if (_value < value) return -1;
-			else if (_value > value) return 1;
+			if (value == null) { return 1; }
+
+			if (!(value is uint)) { throw new ArgumentException("Argument Type Must Be UInt32", "value"); }
+
+			uint u_value = ((uint)value).m_value;
+
+			if (m_value < u_value) return -1;
+			if (m_value > u_value) return 1;
+
 			return 0;
 		}
 
-		public bool Equals(uint obj)
+		public int CompareTo(uint value)
 		{
-			return Equals((object)obj);
+			if (m_value < value) return -1;
+			if (m_value > value) return 1;
+
+			return 0;
 		}
 
 		public override bool Equals(object obj)
 		{
-			return ((uint)obj) == _value;
+			if (!(obj is uint)) { return false; }
+
+			return m_value == ((uint)obj).m_value;
+		}
+
+		public bool Equals(uint value)
+		{
+			return m_value == value;
 		}
 
 		public override string ToString()
 		{
-			return int.CreateString(_value, false, false);
+			return int.CreateString(m_value, false, false);
 		}
 
 		public string ToString(string format)
 		{
-			return int.CreateString(_value, false, true);
+			return int.CreateString(m_value, false, true);
 		}
 
 		public override int GetHashCode()
 		{
-			return (int)_value;
+			return (int)m_value;
 		}
 
 		public static uint Parse(string s)

--- a/Source/Mosa.Korlib/System/UInt64.cs
+++ b/Source/Mosa.Korlib/System/UInt64.cs
@@ -5,39 +5,57 @@ namespace System
 	/// <summary>
 	///
 	/// </summary>
-	public struct UInt64
+	[Serializable]
+	public struct UInt64: IComparable, IComparable<ulong>, IEquatable<ulong>
 	{
+		internal ulong m_value;
+
 		public const ulong MaxValue = 0xffffffffffffffff;
 		public const ulong MinValue = 0;
 
-		internal ulong _value;
-
-		public int CompareTo(ulong value)
+		public int CompareTo(object value)
 		{
-			if (_value < value) return -1;
-			else if (_value > value) return 1;
+			if (value == null) { return 1; }
+
+			if (!(value is ulong)) { throw new ArgumentException("Argument Type Must Be UInt64", "value"); }
+
+			ulong u_value = ((ulong)value).m_value;
+
+			if (m_value < u_value) return -1;
+			if (m_value > u_value) return 1;
+
 			return 0;
 		}
 
-		public bool Equals(ulong obj)
+		public int CompareTo(ulong value)
 		{
-			return Equals((object)obj);
+			if (m_value < value) return -1;
+			if (m_value > value) return 1;
+
+			return 0;
 		}
 
 		public override bool Equals(object obj)
 		{
-			return ((ulong)obj) == _value;
+			if (!(obj is ulong)) { return false; }
+
+			return m_value == ((ulong)obj).m_value;
+		}
+
+		public bool Equals(ulong value)
+		{
+			return (m_value == value);
 		}
 
 		public override int GetHashCode()
 		{
-			return (int)_value;
+			return ((int)m_value) ^ (int)(m_value >> 32);
 		}
 
 		public override unsafe string ToString()
 		{
 			int count = 0;
-			var tmp = _value;
+			var tmp = m_value;
 			do
 			{
 				tmp /= 10;
@@ -45,7 +63,7 @@ namespace System
 			} while (tmp != 0);
 
 			var s = String.InternalAllocateString(count);
-			var temp = _value;
+			var temp = m_value;
 
 			for (int i = count - 1; i >= 0; i--)
 			{


### PR DESCRIPTION
* IComparable (CompareTo), IEquatable (Equals), GetHashCode functions changed and added to the following types according to source.dot.net. Implementations are API compatible:
* Boolean, Byte, Char, Double, Int16, Int32, Int64, SByte, Single, UInt16, UInt32, UInt64