### PR TITLE
BareMetal, app locations and VMware SVGA II bug fixes

### DIFF
--- a/Source/Mosa.DeviceDriver/PCI/VMware/VMwareSVGA2.cs
+++ b/Source/Mosa.DeviceDriver/PCI/VMware/VMwareSVGA2.cs
@@ -244,9 +244,6 @@ public class VMwareSVGA2 : BaseDeviceDriver, IGraphicsDevice
 		if (HasFifoCapability(SvgaCapability.ExtendedFifo) && ReadRegister(FifoRegister.Min) > FifoRegister.GuestHw3DVersion << 2)
 			WriteFifoRegister(FifoRegister.GuestHw3DVersion, (2 << 16) | (1 & 0xFF));
 
-		Enable();
-		WriteRegister(SvgaRegister.ConfigDone, 1);
-
 		Device.Status = DeviceStatus.Online;
 	}
 

--- a/Source/Mosa.Kernel.BareMetal.ARMv8A32/PlatformPlug.cs
+++ b/Source/Mosa.Kernel.BareMetal.ARMv8A32/PlatformPlug.cs
@@ -22,16 +22,6 @@ public static class PlatformPlug
 	{
 	}
 
-	[Plug("Mosa.Kernel.BareMetal.Platform::GetPlatformReservedMemory")]
-	public static AddressRange GetPlatformReservedMemory(int slot)
-	{
-		return slot switch
-		{
-			0 => new AddressRange(new Pointer(0), 1024 * 1024),
-			_ => new AddressRange(new Pointer(0), 0)
-		};
-	}
-
 	[Plug("Mosa.Kernel.BareMetal.Platform::GetBootReservedRegion")]
 	public static AddressRange GetBootReservedRegion()
 	{

--- a/Source/Mosa.Kernel.BareMetal.x64/PlatformPlug.cs
+++ b/Source/Mosa.Kernel.BareMetal.x64/PlatformPlug.cs
@@ -28,16 +28,6 @@ public static class PlatformPlug
 		//SSE.Setup();
 	}
 
-	[Plug("Mosa.Kernel.BareMetal.Platform::GetPlatformReservedMemory")]
-	public static AddressRange GetPlatformReservedMemory(int slot)
-	{
-		return slot switch
-		{
-			0 => new AddressRange(new Pointer(0), 1024 * 1024),
-			_ => new AddressRange(new Pointer(0), 0)
-		};
-	}
-
 	[Plug("Mosa.Kernel.BareMetal.Platform::GetBootReservedRegion")]
 	public static AddressRange GetBootReservedRegion()
 	{

--- a/Source/Mosa.Kernel.BareMetal.x86/GDTTable.cs
+++ b/Source/Mosa.Kernel.BareMetal.x86/GDTTable.cs
@@ -51,7 +51,7 @@ public struct GDTTable
 	[MethodImpl(MethodImplOptions.NoInlining)]
 	private void SetLgdt(Pointer address)
 	{
-		Native.Lgdt((uint)address.ToInt32());
+		Native.Lgdt(address.ToUInt32());
 		Native.SetSegments(0x10, 0x10, 0x10, 0x10, 0x10);
 		Native.FarJump();
 	}

--- a/Source/Mosa.Kernel.BareMetal.x86/PlatformPlug.cs
+++ b/Source/Mosa.Kernel.BareMetal.x86/PlatformPlug.cs
@@ -29,16 +29,6 @@ public static class PlatformPlug
 		SSE.Setup();
 	}
 
-	[Plug("Mosa.Kernel.BareMetal.Platform::GetPlatformReservedMemory")]
-	public static AddressRange GetPlatformReservedMemory(int slot)
-	{
-		return slot switch
-		{
-			0 => new AddressRange(new Pointer(0), 1024 * 1024),
-			_ => new AddressRange(new Pointer(0), 0)
-		};
-	}
-
 	[Plug("Mosa.Kernel.BareMetal.Platform::GetBootReservedRegion")]
 	public static AddressRange GetBootReservedRegion()
 	{

--- a/Source/Mosa.Kernel.BareMetal/BootMemory/BootMemoryMap.cs
+++ b/Source/Mosa.Kernel.BareMetal/BootMemory/BootMemoryMap.cs
@@ -48,16 +48,6 @@ public static class BootMemoryMap
 	{
 		SetMemoryMap(Platform.GetBootReservedRegion(), BootMemoryType.Kernel);
 		SetMemoryMap(Platform.GetInitialGCMemoryPool(), BootMemoryType.Kernel);
-
-		for (int slot = 0; ; slot++)
-		{
-			var region = Platform.GetPlatformReservedMemory(slot);
-
-			if (region.Size == 0)
-				break;
-
-			SetMemoryMap(region, BootMemoryType.Kernel);
-		}
 	}
 
 	public static BootMemoryMapEntry SetMemoryMap(AddressRange range, BootMemoryType type)

--- a/Source/Mosa.Kernel.BareMetal/Platform.cs
+++ b/Source/Mosa.Kernel.BareMetal/Platform.cs
@@ -17,11 +17,6 @@ public static class Platform
 	{
 	}
 
-	public static AddressRange GetPlatformReservedMemory(int slot)
-	{
-		return new AddressRange(0, 0);
-	}
-
 	public static AddressRange GetBootReservedRegion()
 	{
 		return new AddressRange(0, 0);

--- a/Source/Mosa.Utility.Launcher/AppLocationsSettings.cs
+++ b/Source/Mosa.Utility.Launcher/AppLocationsSettings.cs
@@ -129,7 +129,7 @@ public static class AppLocationsSettings
 	private static string FindVmwareWorkstation()
 	{
 		return TryFind(
-			new string[] { "vmware.exe", "vmworkstation", "vmware" },
+			new string[] { "vmware.exe", "vmware" },
 			new string[] {
 				@"%ProgramFiles%\VMware\VMware Workstation",
 				@"%ProgramFiles(x86)%\VMware\VMware Workstation",
@@ -141,7 +141,7 @@ public static class AppLocationsSettings
 	private static string FindVirtualBox()
 	{
 		return TryFind(
-			new string[] { "VBoxManage.exe", "vboxmanage" },
+			new string[] { "VBoxManage.exe", "VBoxManage" },
 			new string[] {
 				@"%ProgramFiles%\Oracle",
 				@"%ProgramFiles(x86)%\Oracle",


### PR DESCRIPTION
- Fixed bugs in BareMetal preventing it from booting
- Fixed a bug in the VirtualBox app location where, on Linux, it wouldn't find VBoxManage because it wasn't properly capitalized
- Removed ``vmworkstation`` in the VMware Workstation app location since it is never named that way
- Fixed a bug in the VMware SVGA II driver where the device was being enabled even without any mode set