### PR TITLE
More BareMetal changes

### DIFF
--- a/Source/Mosa.BareMetal.HelloWorld/AppManager.cs
+++ b/Source/Mosa.BareMetal.HelloWorld/AppManager.cs
@@ -6,9 +6,19 @@ namespace Mosa.BareMetal.HelloWorld;
 
 public static class AppManager
 {
-	private static readonly IApp[] Applications =
+	public static readonly IApp[] Applications =
 	{
-		new Shell()
+		new Clear(),
+		new Credits(),
+		new Help(),
+		new Mem(),
+		new Reboot(),
+		new Shell(),
+		new ShowDisks(),
+		new ShowFS(),
+		new ShowISA(),
+		new ShowPCI(),
+		new Shutdown()
 	};
 
 	public static bool Execute(string name)

--- a/Source/Mosa.BareMetal.HelloWorld/Apps/Clear.cs
+++ b/Source/Mosa.BareMetal.HelloWorld/Apps/Clear.cs
@@ -1,0 +1,17 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using System;
+
+namespace Mosa.BareMetal.HelloWorld.Apps;
+
+public class Clear : IApp
+{
+	public string Name => "Clear";
+
+	public string Description => "Clears the screen.";
+
+	public void Execute()
+	{
+		Console.Clear();
+	}
+}

--- a/Source/Mosa.BareMetal.HelloWorld/Apps/Credits.cs
+++ b/Source/Mosa.BareMetal.HelloWorld/Apps/Credits.cs
@@ -1,0 +1,30 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using System;
+
+namespace Mosa.BareMetal.HelloWorld.Apps;
+
+public class Credits : IApp
+{
+	public string Name => "Credits";
+
+	public string Description => "Shows everyone who contributed to the project.";
+
+	public void Execute()
+	{
+		Console.WriteLine("*** MOSA Credits ****");
+		Console.WriteLine(" Phil Garcia");
+		Console.WriteLine(" Simon Wollwage");
+		Console.WriteLine(" Michael Frohlich");
+		Console.WriteLine(" Stefan Andres Charsley");
+		Console.WriteLine(" Chin Ki Yuen");
+		Console.WriteLine(" Patrick Reisert");
+		Console.WriteLine(" Phillip Webster");
+		Console.WriteLine(" Kevin Thompson");
+		Console.WriteLine(" Kai P.Reisert");
+		Console.WriteLine(" M.de Bruijn");
+		Console.WriteLine(" Royce Mitchell III");
+		Console.WriteLine(" Sebastian Loncar");
+		Console.WriteLine(" AnErrupTion");
+	}
+}

--- a/Source/Mosa.BareMetal.HelloWorld/Apps/Help.cs
+++ b/Source/Mosa.BareMetal.HelloWorld/Apps/Help.cs
@@ -1,0 +1,18 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using System;
+
+namespace Mosa.BareMetal.HelloWorld.Apps;
+
+public class Help : IApp
+{
+	public string Name => "Help";
+
+	public string Description => "Shows information about all commands.";
+
+	public void Execute()
+	{
+		foreach (var app in AppManager.Applications)
+			Console.WriteLine(app.Name + " - " + app.Description);
+	}
+}

--- a/Source/Mosa.BareMetal.HelloWorld/Apps/Mem.cs
+++ b/Source/Mosa.BareMetal.HelloWorld/Apps/Mem.cs
@@ -1,0 +1,22 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using System;
+using Mosa.Kernel.BareMetal;
+
+namespace Mosa.BareMetal.HelloWorld.Apps;
+
+public class Mem : IApp
+{
+	public string Name => "Mem";
+
+	public string Description => "Shows memory information.";
+
+	public void Execute()
+	{
+		Console.WriteLine("**** Memory ****");
+		Console.WriteLine(" Total Pages : " + PageFrameAllocator.TotalPages);
+		Console.WriteLine(" Used Pages  : " + PageFrameAllocator.UsedPages);
+		Console.WriteLine(" Page Size   : " + Page.Size);
+		Console.WriteLine(" Free Memory : " + (PageFrameAllocator.TotalPages - PageFrameAllocator.UsedPages) * Page.Size / (1024 * 1024) + " MB");
+	}
+}

--- a/Source/Mosa.BareMetal.HelloWorld/Apps/Reboot.cs
+++ b/Source/Mosa.BareMetal.HelloWorld/Apps/Reboot.cs
@@ -1,0 +1,24 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using System;
+using Mosa.DeviceSystem;
+using Mosa.DeviceSystem.Service;
+
+namespace Mosa.BareMetal.HelloWorld.Apps;
+
+public class Reboot : IApp
+{
+	public string Name => "Reboot";
+
+	public string Description => "Reboots the computer.";
+
+	public void Execute()
+	{
+		Console.WriteLine("Rebooting...");
+
+		var pc = Kernel.BareMetal.Kernel.ServiceManager.GetFirstService<PCService>();
+		pc.Reset();
+
+		for (;;) HAL.Yield();
+	}
+}

--- a/Source/Mosa.BareMetal.HelloWorld/Apps/Shell.cs
+++ b/Source/Mosa.BareMetal.HelloWorld/Apps/Shell.cs
@@ -8,16 +8,22 @@ public class Shell : IApp
 {
 	public string Name => "Shell";
 
+	public string Description => "Runs the interactive shell.";
+
 	public void Execute()
 	{
 		Console.WriteLine();
 		Console.WriteLine("MOSA Shell v2.4");
+		Console.WriteLine("Enter \"quit\" to exit the shell.");
 
 		while (true)
 		{
 			Console.Write("> ");
 
 			var cmd = Console.ReadLine().ToLower();
+
+			if (cmd == "quit")
+				break;
 
 			if (!AppManager.Execute(cmd))
 				Console.WriteLine("Unknown command: " + cmd);

--- a/Source/Mosa.BareMetal.HelloWorld/Apps/ShowDisks.cs
+++ b/Source/Mosa.BareMetal.HelloWorld/Apps/ShowDisks.cs
@@ -1,0 +1,45 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using System;
+using Mosa.DeviceDriver.ISA;
+using Mosa.DeviceSystem;
+using Mosa.DeviceSystem.Service;
+
+namespace Mosa.BareMetal.HelloWorld.Apps;
+
+public class ShowDisks : IApp
+{
+	public string Name => "ShowDisks";
+
+	public string Description => "Shows information about disk controllers and disks.";
+
+	public void Execute()
+	{
+		Console.Write("> Probing for disk controllers...");
+		var diskControllers = Program.DeviceService.GetDevices<IDiskControllerDevice>();
+		Console.WriteLine("[Completed: " + diskControllers.Count + " found]");
+
+		foreach (var device in diskControllers)
+		{
+			Console.Write("  ");
+			Program.Bullet(ConsoleColor.Yellow);
+			Console.Write(" ");
+			Program.InBrackets(device.Name, ConsoleColor.White, ConsoleColor.Green);
+			Console.WriteLine();
+		}
+
+		Console.Write("> Probing for disks...");
+		var disks = Program.DeviceService.GetDevices<IDiskDevice>();
+		Console.WriteLine("[Completed: " + disks.Count + " found]");
+
+		foreach (var disk in disks)
+		{
+			Console.Write("  ");
+			Program.Bullet(ConsoleColor.Yellow);
+			Console.Write(" ");
+			Program.InBrackets(disk.Name, ConsoleColor.White, ConsoleColor.Green);
+			Console.Write(" " + (disk.DeviceDriver as IDiskDevice).TotalBlocks + " blocks");
+			Console.WriteLine();
+		}
+	}
+}

--- a/Source/Mosa.BareMetal.HelloWorld/Apps/ShowFS.cs
+++ b/Source/Mosa.BareMetal.HelloWorld/Apps/ShowFS.cs
@@ -1,0 +1,63 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using System;
+using Mosa.DeviceSystem;
+using Mosa.FileSystem.FAT;
+
+namespace Mosa.BareMetal.HelloWorld.Apps;
+
+public class ShowFS : IApp
+{
+	public string Name => "ShowFS";
+
+	public string Description => "Shows information about partitions and file systems.";
+
+	public void Execute()
+	{
+		Console.Write("> Finding partitions...");
+		var partitions = Program.DeviceService.GetDevices<IPartitionDevice>();
+		Console.WriteLine("[Completed: " + partitions.Count + " found]");
+
+		foreach (var partition in partitions)
+		{
+			Console.Write("  ");
+			Program.Bullet(ConsoleColor.Yellow);
+			Console.Write(" ");
+			Program.InBrackets(partition.Name, ConsoleColor.White, ConsoleColor.Green);
+			Console.Write(" " + (partition.DeviceDriver as IPartitionDevice).BlockCount + " blocks");
+			Console.WriteLine();
+		}
+
+		Console.Write("> Finding file systems...");
+
+		foreach (var partition in partitions)
+		{
+			var fat = new FatFileSystem(partition.DeviceDriver as IPartitionDevice);
+			if (!fat.IsValid) continue;
+
+			Console.WriteLine("Found a FAT file system!");
+
+			var location = fat.FindEntry("TEST.TXT");
+			if (!location.IsValid) continue;
+
+			Console.Write("Found test file!");
+
+			var testStream = new FatFileStream(fat, location);
+
+			Console.WriteLine(" - Length: " + (uint)testStream.Length + " bytes");
+			Console.Write("Reading File: ");
+
+			for (; ; )
+			{
+				var i = testStream.ReadByte();
+
+				if (i < 0)
+					break;
+
+				Console.Write((char)i);
+			}
+
+			Console.WriteLine();
+		}
+	}
+}

--- a/Source/Mosa.BareMetal.HelloWorld/Apps/ShowISA.cs
+++ b/Source/Mosa.BareMetal.HelloWorld/Apps/ShowISA.cs
@@ -1,0 +1,30 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using System;
+using Mosa.DeviceDriver.ISA;
+
+namespace Mosa.BareMetal.HelloWorld.Apps;
+
+public class ShowISA : IApp
+{
+	public string Name => "ShowISA";
+
+	public string Description => "Shows information about ISA devices.";
+
+	public void Execute()
+	{
+		Console.Write("> Probing for ISA devices...");
+
+		var isaDevices = Program.DeviceService.GetChildrenOf(Program.DeviceService.GetFirstDevice<ISABus>());
+		Console.WriteLine("[Completed: " + isaDevices.Count + " found]");
+
+		foreach (var device in isaDevices)
+		{
+			Console.Write("  ");
+			Program.Bullet(ConsoleColor.Yellow);
+			Console.Write(" ");
+			Program.InBrackets(device.Name, ConsoleColor.White, ConsoleColor.Green);
+			Console.WriteLine();
+		}
+	}
+}

--- a/Source/Mosa.BareMetal.HelloWorld/Apps/ShowPCI.cs
+++ b/Source/Mosa.BareMetal.HelloWorld/Apps/ShowPCI.cs
@@ -1,0 +1,44 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using System;
+using Mosa.DeviceSystem.PCI;
+
+namespace Mosa.BareMetal.HelloWorld.Apps;
+
+public class ShowPCI : IApp
+{
+	public string Name => "ShowPCI";
+
+	public string Description => "Shows information about PCI devices.";
+
+	public void Execute()
+	{
+		Console.Write("> Probing for PCI devices...");
+		var devices = Program.DeviceService.GetDevices<PCIDevice>();
+		Console.WriteLine("[Completed: " + devices.Count + " found]");
+
+		foreach (var device in devices)
+		{
+			Console.Write("  ");
+			Program.Bullet(ConsoleColor.Yellow);
+			Console.Write(" ");
+
+			var pciDevice = device.DeviceDriver as PCIDevice;
+			Program.InBrackets(device.Name + ": " + pciDevice.VendorID.ToString("x") + ":" + pciDevice.DeviceID.ToString("x") + " " + pciDevice.SubSystemID.ToString("x") + ":" + pciDevice.SubSystemVendorID.ToString("x") + " (" + pciDevice.ClassCode.ToString("x") + ":" + pciDevice.SubClassCode.ToString("x") + ":" + pciDevice.ProgIF.ToString("x") + ":" + pciDevice.RevisionID.ToString("x") + ")", ConsoleColor.White, ConsoleColor.Green);
+
+			var children = Program.DeviceService.GetChildrenOf(device);
+
+			if (children.Count != 0)
+			{
+				var child = children[0];
+
+				Console.WriteLine();
+				Console.Write("    ");
+
+				Program.InBrackets(child.Name, ConsoleColor.White, ConsoleColor.Green);
+			}
+
+			Console.WriteLine();
+		}
+	}
+}

--- a/Source/Mosa.BareMetal.HelloWorld/Apps/Shutdown.cs
+++ b/Source/Mosa.BareMetal.HelloWorld/Apps/Shutdown.cs
@@ -1,0 +1,24 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using System;
+using Mosa.DeviceSystem;
+using Mosa.DeviceSystem.Service;
+
+namespace Mosa.BareMetal.HelloWorld.Apps;
+
+public class Shutdown : IApp
+{
+	public string Name => "Shutdown";
+
+	public string Description => "Shuts down the computer.";
+
+	public void Execute()
+	{
+		Console.WriteLine("Shutting down...");
+
+		var pc = Kernel.BareMetal.Kernel.ServiceManager.GetFirstService<PCService>();
+		pc.Shutdown();
+
+		for (;;) HAL.Yield();
+	}
+}

--- a/Source/Mosa.BareMetal.HelloWorld/IApp.cs
+++ b/Source/Mosa.BareMetal.HelloWorld/IApp.cs
@@ -6,5 +6,7 @@ public interface IApp
 {
 	string Name { get; }
 
+	string Description { get; }
+
 	void Execute();
 }

--- a/Source/Mosa.BareMetal.HelloWorld/Program.cs
+++ b/Source/Mosa.BareMetal.HelloWorld/Program.cs
@@ -12,152 +12,6 @@ namespace Mosa.BareMetal.HelloWorld;
 
 public static class Program
 {
-	public static void EntryPoint()
-	{
-		Debug.WriteLine("Program::EntryPoint()");
-
-		var deviceService = Kernel.BareMetal.Kernel.ServiceManger.GetFirstService<DeviceService>();
-
-		Console.BackgroundColor = ConsoleColor.Black;
-		Console.ForegroundColor = ConsoleColor.White;
-		Console.Clear();
-		Console.Write("> Probing for ISA devices...");
-
-		var isaDevices = deviceService.GetChildrenOf(deviceService.GetFirstDevice<ISABus>());
-		Console.WriteLine("[Completed: " + isaDevices.Count + " found]");
-
-		foreach (var device in isaDevices)
-		{
-			Console.Write("  ");
-			Bullet(ConsoleColor.Yellow);
-			Console.Write(" ");
-			InBrackets(device.Name, ConsoleColor.White, ConsoleColor.Green);
-			Console.WriteLine();
-		}
-
-		Console.Write("> Probing for PCI devices...");
-		var devices = deviceService.GetDevices<PCIDevice>();
-		Console.WriteLine("[Completed: " + devices.Count + " found]");
-
-		foreach (var device in devices)
-		{
-			Console.Write("  ");
-			Bullet(ConsoleColor.Yellow);
-			Console.Write(" ");
-
-			var pciDevice = device.DeviceDriver as PCIDevice;
-			InBrackets(device.Name + ": " + pciDevice.VendorID.ToString("x") + ":" + pciDevice.DeviceID.ToString("x") + " " + pciDevice.SubSystemID.ToString("x") + ":" + pciDevice.SubSystemVendorID.ToString("x") + " (" + pciDevice.ClassCode.ToString("x") + ":" + pciDevice.SubClassCode.ToString("x") + ":" + pciDevice.ProgIF.ToString("x") + ":" + pciDevice.RevisionID.ToString("x") + ")", ConsoleColor.White, ConsoleColor.Green);
-
-			var children = deviceService.GetChildrenOf(device);
-
-			if (children.Count != 0)
-			{
-				var child = children[0];
-
-				Console.WriteLine();
-				Console.Write("    ");
-
-				InBrackets(child.Name, ConsoleColor.White, ConsoleColor.Green);
-			}
-
-			Console.WriteLine();
-		}
-
-		Console.Write("> Probing for disk controllers...");
-		var diskControllers = deviceService.GetDevices<IDiskControllerDevice>();
-		Console.WriteLine("[Completed: " + diskControllers.Count + " found]");
-
-		foreach (var device in diskControllers)
-		{
-			Console.Write("  ");
-			Bullet(ConsoleColor.Yellow);
-			Console.Write(" ");
-			InBrackets(device.Name, ConsoleColor.White, ConsoleColor.Green);
-			Console.WriteLine();
-		}
-
-		Console.Write("> Probing for disks...");
-		var disks = deviceService.GetDevices<IDiskDevice>();
-		Console.WriteLine("[Completed: " + disks.Count + " found]");
-
-		foreach (var disk in disks)
-		{
-			Console.Write("  ");
-			Bullet(ConsoleColor.Yellow);
-			Console.Write(" ");
-			InBrackets(disk.Name, ConsoleColor.White, ConsoleColor.Green);
-			Console.Write(" " + (disk.DeviceDriver as IDiskDevice).TotalBlocks + " blocks");
-			Console.WriteLine();
-		}
-
-		var partitionService = Mosa.Kernel.BareMetal.Kernel.ServiceManger.GetFirstService<PartitionService>();
-
-		partitionService.CreatePartitionDevices();
-
-		Console.Write("> Finding partitions...");
-		var partitions = deviceService.GetDevices<IPartitionDevice>();
-		Console.WriteLine("[Completed: " + partitions.Count + " found]");
-
-		foreach (var partition in partitions)
-		{
-			Console.Write("  ");
-			Bullet(ConsoleColor.Yellow);
-			Console.Write(" ");
-			InBrackets(partition.Name, ConsoleColor.White, ConsoleColor.Green);
-			Console.Write(" " + (partition.DeviceDriver as IPartitionDevice).BlockCount + " blocks");
-			Console.WriteLine();
-		}
-
-		Console.Write("> Finding file systems...");
-
-		foreach (var partition in partitions)
-		{
-			var fat = new FatFileSystem(partition.DeviceDriver as IPartitionDevice);
-			if (!fat.IsValid)
-				continue;
-
-			Console.WriteLine("Found a FAT file system!");
-
-			var location = fat.FindEntry("TEST.TXT");
-			if (location.IsValid)
-			{
-				Console.Write("Found test file!");
-
-				var testStream = new FatFileStream(fat, location);
-
-				Console.WriteLine(" - Length: " + (uint)testStream.Length + " bytes");
-				Console.Write("Reading File: ");
-
-				for (; ; )
-				{
-					var i = testStream.ReadByte();
-
-					if (i < 0)
-						break;
-
-					Console.Write((char)i);
-				}
-
-				Console.WriteLine();
-			}
-
-			var bmpLoc = fat.FindEntry("WALLP.BMP");
-			if (!bmpLoc.IsValid)
-				continue;
-
-			Console.Write("Found wallpaper file! ");
-
-			var wallpaperStream = new FatFileStream(fat, bmpLoc);
-
-			Console.WriteLine(" - Length: " + (uint)wallpaperStream.Length + " bytes");
-			Console.WriteLine();
-		}
-
-		Debug.WriteLine("##PASS##");
-
-		AppManager.Execute("shell");
-	}
-
 	//[Plug("Mosa.Runtime.StartUp::BootOptions")]
 	public static void SetBootOptions()
 	{
@@ -166,7 +20,37 @@ public static class Program
 		//BootOptions.EnableMinimalBoot = true;
 	}
 
-	private static void InBrackets(string message, ConsoleColor outerColor, ConsoleColor innerColor)
+	public static DeviceService DeviceService { get; private set; }
+
+	public static void EntryPoint()
+	{
+		Debug.WriteLine("Program::EntryPoint()");
+
+		DeviceService = Kernel.BareMetal.Kernel.ServiceManager.GetFirstService<DeviceService>();
+
+		Console.BackgroundColor = ConsoleColor.Black;
+		Console.ForegroundColor = ConsoleColor.White;
+		Console.Clear();
+
+		AppManager.Execute("ShowISA");
+		AppManager.Execute("ShowPCI");
+		AppManager.Execute("ShowDisks");
+		AppManager.Execute("ShowFS");
+
+		Debug.WriteLine("##PASS##");
+
+		AppManager.Execute("Shell");
+
+		Console.WriteLine("User has decided to exit out of shell.");
+		Console.WriteLine("Shutting down...");
+
+		var pcService = Kernel.BareMetal.Kernel.ServiceManager.GetFirstService<PCService>();
+		pcService.Shutdown();
+
+		for (;;) HAL.Yield();
+	}
+
+	public static void InBrackets(string message, ConsoleColor outerColor, ConsoleColor innerColor)
 	{
 		var restore = Console.ForegroundColor;
 		Console.ForegroundColor = outerColor;
@@ -178,7 +62,7 @@ public static class Program
 		Console.ForegroundColor = restore;
 	}
 
-	private static void Bullet(ConsoleColor color)
+	public static void Bullet(ConsoleColor color)
 	{
 		var restore = Console.ForegroundColor;
 		Console.ForegroundColor = color;

--- a/Source/Mosa.Demo.SVGAWorld.x86/Plugs/ConsolePlug.cs
+++ b/Source/Mosa.Demo.SVGAWorld.x86/Plugs/ConsolePlug.cs
@@ -8,13 +8,6 @@ namespace Mosa.Demo.SVGAWorld.x86.Plugs;
 
 public static class ConsolePlug
 {
-	[Plug("System.Console::ResetColor")]
-	internal static void ResetColor()
-	{
-		Screen.Color = (byte)ConsoleColor.White;
-		Screen.BackgroundColor = (byte)ConsoleColor.Black;
-	}
-
 	[Plug("System.Console::Clear")]
 	internal static void Clear()
 	{
@@ -56,26 +49,14 @@ public static class ConsolePlug
 		Screen.Goto((uint)left, (uint)top);
 	}
 
-	[Plug("System.Console::GetForegroundColor")]
-	internal static ConsoleColor GetForegroundColor()
-	{
-		return (ConsoleColor)Screen.Color;
-	}
-
-	[Plug("System.Console::GetBackgroundColor")]
-	internal static ConsoleColor GetBackgroundColor()
-	{
-		return (ConsoleColor)Screen.BackgroundColor;
-	}
-
-	[Plug("System.Console::SetForegroundColor")]
-	internal static void SetForegroundColor(ConsoleColor color)
+	[Plug("System.Console::UpdateForegroundColor")]
+	internal static void UpdateForegroundColor(ConsoleColor color)
 	{
 		Screen.Color = (byte)color;
 	}
 
-	[Plug("System.Console::SetBackgroundColor")]
-	internal static void SetBackgroundColor(ConsoleColor color)
+	[Plug("System.Console::UpdateBackgroundColor")]
+	internal static void UpdateBackgroundColor(ConsoleColor color)
 	{
 		Screen.BackgroundColor = (byte)color;
 	}

--- a/Source/Mosa.Kernel.BareMetal.x86/CPUInfo.cs
+++ b/Source/Mosa.Kernel.BareMetal.x86/CPUInfo.cs
@@ -1,0 +1,96 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using System;
+using Mosa.Runtime.x86;
+
+namespace Mosa.Kernel.BareMetal.x86;
+
+public static class CPUInfo
+{
+	public static uint NumberOfCores => (Native.CpuIdEAX(4, 0) >> 26) + 1;
+
+	public static uint Type => (Native.CpuIdEAX(1, 0) & 0x3000) >> 12;
+
+	public static uint Stepping => Native.CpuIdEAX(1, 0) & 0xF;
+
+	public static uint Model => (Native.CpuIdEAX(1, 0) & 0xF0) >> 4;
+
+	public static uint Family => (Native.CpuIdEAX(1, 0) & 0xF00) >> 8;
+
+	public static bool SupportsExtendedCpuid => (Native.CpuIdEAX(0x80000000, 0) & 0x80000000) != 0;
+
+	public static bool SupportsBrandString => Native.CpuIdEAX(0x80000000, 0) >= 0x80000004U;
+
+	public static void PrintVendorString()
+	{
+		var identifier = Native.CpuIdEBX(0, 0);
+		for (var i = 0; i < 4; ++i)
+			Console.Write((char)((identifier >> (i * 8)) & 0xFF));
+
+		identifier = Native.CpuIdEDX(0, 0);
+		for (var i = 0; i < 4; ++i)
+			Console.Write((char)((identifier >> (i * 8)) & 0xFF));
+
+		identifier = Native.CpuIdECX(0, 0);
+		for (var i = 0; i < 4; ++i)
+			Console.Write((char)((identifier >> (i * 8)) & 0xFF));
+	}
+
+	public static void PrintBrandString()
+	{
+		if (SupportsBrandString)
+		{
+			PrintBrand(0x80000002);
+			PrintBrand(0x80000003);
+			PrintBrand(0x80000004);
+			return;
+		}
+
+		Console.Write(@"Unknown (Generic x86)");
+	}
+
+	private static void PrintBrand(uint param)
+	{
+		var whitespace = true;
+
+		var identifier = Native.CpuIdEAX(param, 0);
+		if (identifier != 0x20202020)
+			for (var i = 0; i < 4; ++i)
+				PrintBrandPart(identifier, i, ref whitespace);
+
+		identifier = Native.CpuIdEBX(param, 0);
+		if (identifier != 0x20202020)
+			for (var i = 0; i < 4; ++i)
+				PrintBrandPart(identifier, i, ref whitespace);
+
+		identifier = Native.CpuIdECX(param, 0);
+		if (identifier != 0x20202020)
+			for (var i = 0; i < 4; ++i)
+				PrintBrandPart(identifier, i, ref whitespace);
+
+		identifier = Native.CpuIdEDX(param, 0);
+		if (identifier != 0x20202020)
+			for (var i = 0; i < 4; ++i)
+				PrintBrandPart(identifier, i, ref whitespace);
+	}
+
+	private static void PrintBrandPart(uint identifier, int i, ref bool whitespace)
+	{
+		var character = (char)((identifier >> (i * 8)) & 0xFF);
+
+		switch (whitespace)
+		{
+			case true when character == ' ': return;
+			case true when character != ' ':
+			{
+				Console.Write(character);
+				whitespace = false;
+				return;
+			}
+		}
+
+		if (character == ' ') whitespace = true;
+
+		Console.Write(character);
+	}
+}

--- a/Source/Mosa.Kernel.BareMetal.x86/PlatformPlug.cs
+++ b/Source/Mosa.Kernel.BareMetal.x86/PlatformPlug.cs
@@ -35,30 +35,30 @@ public static class PlatformPlug
 	public static PlatformArchitecture GetPlatformArchitecture() => PlatformArchitecture.X86;
 
 	[Plug("Mosa.Kernel.BareMetal.Platform::ConsoleWrite")]
-	public static void ConsoleWrite(byte c) => x86.VGAConsole.Write(c);
+	public static void ConsoleWrite(byte c) => VGAConsole.Write(c);
 
 	[Plug("Mosa.Kernel.BareMetal.Platform::DebugWrite")]
-	public static void DebugWrite(byte c) => x86.SerialDebug.Write(c);
+	public static void DebugWrite(byte c) => SerialDebug.Write(c);
 
 	public static class PageTablePlug
 	{
 		[Plug("Mosa.Kernel.BareMetal.Platform+PageTable::Setup")]
-		public static void Setup() => x86.PageTable.Setup();
+		public static void Setup() => PageTable.Setup();
 
 		[Plug("Mosa.Kernel.BareMetal.Platform+PageTable::GetPageShift")]
 		public static uint GetPageShift() => 12;
 
 		[Plug("Mosa.Kernel.BareMetal.Platform+PageTable::Initialize")]
-		public static void Initialize() => x86.PageTable.Initialize();
+		public static void Initialize() => PageTable.Initialize();
 
 		[Plug("Mosa.Kernel.BareMetal.Platform+PageTable::Enable")]
-		public static void Enable() => x86.PageTable.Enable();
+		public static void Enable() => PageTable.Enable();
 
 		[Plug("Mosa.Kernel.BareMetal.Platform+PageTable::MapVirtualAddressToPhysical")]
-		public static void MapVirtualAddressToPhysical(Pointer virtualAddress, Pointer physicalAddress, bool present = true) => x86.PageTable.MapVirtualAddressToPhysical(virtualAddress, physicalAddress, present);
+		public static void MapVirtualAddressToPhysical(Pointer virtualAddress, Pointer physicalAddress, bool present = true) => PageTable.MapVirtualAddressToPhysical(virtualAddress, physicalAddress, present);
 
 		[Plug("Mosa.Kernel.BareMetal.Platform+PageTable::GetPhysicalAddressFromVirtual")]
-		public static Pointer GetPhysicalAddressFromVirtual(Pointer virtualAddress) => x86.PageTable.GetPhysicalAddressFromVirtual(virtualAddress);
+		public static Pointer GetPhysicalAddressFromVirtual(Pointer virtualAddress) => PageTable.GetPhysicalAddressFromVirtual(virtualAddress);
 	}
 
 	public static class InterruptPlug
@@ -76,7 +76,7 @@ public static class PlatformPlug
 		public static void Disable() => Native.Cli();
 	}
 
-	public static class IOPlugPlug
+	public static class IOPlug
 	{
 		[Plug("Mosa.Kernel.BareMetal.Platform+IO::In8")]
 		public static byte In8(ushort address) => Native.In8(address);
@@ -100,29 +100,29 @@ public static class PlatformPlug
 	public static class SchedulerPlug
 	{
 		[Plug("Mosa.Kernel.BareMetal.Platform+Scheduler::Start")]
-		public static void Start() => x86.Scheduler.Start();
+		public static void Start() => Scheduler.Start();
 
 		[Plug("Mosa.Kernel.BareMetal.Platform+Scheduler::Yield")]
-		public static void Yield() => x86.Scheduler.Yield();
+		public static void Yield() => Scheduler.Yield();
 
 		[Plug("Mosa.Kernel.BareMetal.Platform+Scheduler::SignalTermination")]
-		public static void SignalTermination() => x86.Scheduler.SignalTermination();
+		public static void SignalTermination() => Scheduler.SignalTermination();
 
 		[Plug("Mosa.Kernel.BareMetal.Platform+Scheduler::SwitchToThread")]
-		public static void SwitchToThread(Thread thread) => x86.Scheduler.SwitchToThread(thread);
+		public static void SwitchToThread(Thread thread) => Scheduler.SwitchToThread(thread);
 
 		[Plug("Mosa.Kernel.BareMetal.Platform+Scheduler::SetupThreadStack")]
-		public static Pointer SetupThreadStack(Pointer stackTop, Pointer methodAddress, Pointer termAddress) => x86.Scheduler.SetupThreadStack(stackTop, methodAddress, termAddress);
+		public static Pointer SetupThreadStack(Pointer stackTop, Pointer methodAddress, Pointer termAddress) => Scheduler.SetupThreadStack(stackTop, methodAddress, termAddress);
 	}
 
 	public static class SerialPlug
 	{
-		public static void Setup(int serial) => x86.Serial.Setup((ushort)serial);
+		public static void Setup(int serial) => Serial.Setup((ushort)serial);
 
-		public static void Write(int serial, byte data) => x86.Serial.Write((ushort)serial, data);
+		public static void Write(int serial, byte data) => Serial.Write((ushort)serial, data);
 
-		public static byte Read(int serial) => x86.Serial.Read((ushort)serial);
+		public static byte Read(int serial) => Serial.Read((ushort)serial);
 
-		public static bool IsDataReady(int serial) => x86.Serial.IsDataReady((ushort)serial);
+		public static bool IsDataReady(int serial) => Serial.IsDataReady((ushort)serial);
 	}
 }

--- a/Source/Mosa.Kernel.BareMetal.x86/RTC.cs
+++ b/Source/Mosa.Kernel.BareMetal.x86/RTC.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using Mosa.Runtime.x86;
+
+//https://github.com/nifanfa/MOOS/blob/master/Kernel/Driver/RTC.cs
+namespace Mosa.Kernel.BareMetal.x86;
+
+public static class RTC
+{
+	public static byte Second
+	{
+		get
+		{
+			var b = Get(0);
+			return (byte)((b & 0x0F) + b / 16 * 10);
+		}
+	}
+
+	public static byte Minute
+	{
+		get
+		{
+			var b = Get(2);
+			return (byte)((b & 0x0F) + b / 16 * 10);
+		}
+	}
+
+	public static byte Hour
+	{
+		get
+		{
+			var b = Get(4);
+			return (byte)(((b & 0x0F) + (b & 0x70) / 16 * 10) | (b & 0x80));
+		}
+	}
+
+	public static byte Century
+	{
+		get
+		{
+			var b = Get(0x32);
+			return (byte)((b & 0x0F) + b / 16 * 10);
+		}
+	}
+
+	public static byte Year
+	{
+		get
+		{
+			var b = Get(9);
+			return (byte)((b & 0x0F) + b / 16 * 10);
+		}
+	}
+
+	public static byte Month
+	{
+		get
+		{
+			var b = Get(8);
+			return (byte)((b & 0x0F) + b / 16 * 10);
+		}
+	}
+
+	public static byte Day
+	{
+		get
+		{
+			var b = Get(7);
+			return (byte)((b & 0x0F) + b / 16 * 10);
+		}
+	}
+
+	public static bool BCD => (Get(0x0B) & 0x04) == 0x00;
+
+	public static byte Get(byte index)
+	{
+		Native.Out8(0x70, index);
+
+		return Native.In8(0x71);
+	}
+
+	public static void Set(byte index, byte value)
+	{
+		Native.Out8(0x70, index);
+		Native.Out8(0x71, value);
+	}
+
+	private static void Delay()
+	{
+		Native.In8(0x80);
+		Native.Out8(0x80, 0);
+	}
+}

--- a/Source/Mosa.Kernel.BareMetal.x86/SMBIOS/BIOSInformationStructure.cs
+++ b/Source/Mosa.Kernel.BareMetal.x86/SMBIOS/BIOSInformationStructure.cs
@@ -1,0 +1,46 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using Mosa.Runtime;
+
+namespace Mosa.Kernel.BareMetal.x86.SMBIOS;
+
+/// <summary>
+/// Bios Information Structure
+/// </summary>
+public class BIOSInformationStructure : SMBIOSStructure
+{
+	/// <summary>
+	/// Gets the bios vendor.
+	/// </summary>
+	/// <value>
+	/// The bios vendor.
+	/// </value>
+	public string BiosVendor { get; set; }
+
+	/// <summary>
+	/// Gets the bios version.
+	/// </summary>
+	/// <value>
+	/// The bios version.
+	/// </value>
+	public string BiosVersion { get; set; }
+
+	/// <summary>
+	/// Gets the bios date.
+	/// </summary>
+	/// <value>
+	/// The bios date.
+	/// </value>
+	public string BiosDate { get; set; }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="BIOSInformationStructure"/> class.
+	/// </summary>
+	public BIOSInformationStructure()
+		: base(SMBIOSManager.GetStructureOfType(0x00))
+	{
+		BiosVendor = GetStringFromIndex(Intrinsic.Load8(address, 0x04u));
+		BiosVersion = GetStringFromIndex(Intrinsic.Load8(address, 0x05u));
+		BiosDate = GetStringFromIndex(Intrinsic.Load8(address, 0x08u));
+	}
+}

--- a/Source/Mosa.Kernel.BareMetal.x86/SMBIOS/CPUStructure.cs
+++ b/Source/Mosa.Kernel.BareMetal.x86/SMBIOS/CPUStructure.cs
@@ -1,0 +1,53 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+namespace Mosa.Kernel.BareMetal.x86.SMBIOS;
+
+/// <summary>
+/// Cpu Structure
+/// </summary>
+public class CPUStructure : SMBIOSStructure
+{
+	/// <summary>
+	/// Gets the maximum speed.
+	/// </summary>
+	/// <value>
+	/// The maximum speed.
+	/// </value>
+	public uint MaxSpeed { get; private set; }
+
+	/// <summary>
+	/// Gets the socket.
+	/// </summary>
+	/// <value>
+	/// The socket.
+	/// </value>
+	public string Socket { get; private set; }
+
+	/// <summary>
+	/// Gets the vendor.
+	/// </summary>
+	/// <value>
+	/// The vendor.
+	/// </value>
+	public string Vendor { get; private set; }
+
+	/// <summary>
+	/// Gets the version.
+	/// </summary>
+	/// <value>
+	/// The version.
+	/// </value>
+	public string Version { get; private set; }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="CPUStructure"/> class.
+	/// </summary>
+	public CPUStructure()
+		: base(SMBIOSManager.GetStructureOfType(0x04))
+	{
+		Version = GetStringFromIndex(address.Load8(0x10u));
+		Socket = GetStringFromIndex(address.Load8(0x04u));
+		MaxSpeed = address.Load16(0x16u);
+		Vendor = GetStringFromIndex(address.Load8(0x07u));
+	}
+}

--- a/Source/Mosa.Kernel.BareMetal.x86/SMBIOS/SMBIOSManager.cs
+++ b/Source/Mosa.Kernel.BareMetal.x86/SMBIOS/SMBIOSManager.cs
@@ -1,0 +1,200 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using Mosa.Runtime;
+
+namespace Mosa.Kernel.BareMetal.x86.SMBIOS;
+
+/// <summary>
+/// Smbios Manager
+/// </summary>
+public static class SMBIOSManager
+{
+	/// <summary>
+	/// Gets the table's entry point
+	/// </summary>
+	/// <value>
+	/// The entry point.
+	/// </value>
+	public static Pointer EntryPoint { get; private set; }
+
+	/// <summary>
+	/// Gets the major version.
+	/// </summary>
+	/// <value>
+	/// The major version.
+	/// </value>
+	public static uint MajorVersion { get; private set; }
+
+	/// <summary>
+	/// Gets the minor version.
+	/// </summary>
+	/// <value>
+	/// The minor version.
+	/// </value>
+	public static uint MinorVersion { get; private set; }
+
+	/// <summary>
+	/// Gets the table's length
+	/// </summary>
+	/// <value>
+	/// The length of the table.
+	/// </value>
+	public static uint TableLength { get; private set; }
+
+	/// <summary>
+	/// Gets the entry address for smbios structures
+	/// </summary>
+	/// <value>
+	/// The table address.
+	/// </value>
+	public static Pointer TableAddress { get; private set; }
+
+	/// <summary>
+	/// Gets the total number of available structures
+	/// </summary>
+	/// <value>
+	/// The number of structures.
+	/// </value>
+	public static uint NumberOfStructures { get; private set; }
+
+	/// <summary>
+	/// Checks if SMBIOS is available
+	/// </summary>
+	/// <value>
+	///   <c>true</c> if this instance is available; otherwise, <c>false</c>.
+	/// </value>
+	public static bool IsAvailable => EntryPoint != new Pointer(0x100000);
+
+	/// <summary>
+	/// Setups this instance.
+	/// </summary>
+	public static void Setup()
+	{
+		LocateEntryPoint();
+
+		if (!IsAvailable)
+			return;
+
+		GetTableAddress();
+		GetTableLength();
+		GetNumberOfStructures();
+		GetMajorVersion();
+		GetMinorVersion();
+	}
+
+	/// <summary>
+	/// Gets the type of the structure of.
+	/// </summary>
+	/// <param name="type">The type.</param>
+	/// <returns></returns>
+	public static Pointer GetStructureOfType(byte type)
+	{
+		var address = TableAddress;
+
+		while (GetType(address) != 127u)
+		{
+			if (GetType(address) == type)
+				return address;
+
+			address = GetAddressOfNextStructure(address);
+		}
+
+		return new Pointer(0xFFFF);
+	}
+
+	/// <summary>
+	/// Gets the type.
+	/// </summary>
+	/// <param name="address">The address.</param>
+	/// <returns></returns>
+	private static byte GetType(Pointer address)
+	{
+		return address.Load8();
+	}
+
+	/// <summary>
+	/// Gets the address of next structure.
+	/// </summary>
+	/// <param name="address">The address.</param>
+	/// <returns></returns>
+	private static Pointer GetAddressOfNextStructure(Pointer address)
+	{
+		byte length = address.Load8(0x01);
+		var endOfFormattedArea = address + length;
+
+		while (endOfFormattedArea.Load16() != 0x0000)
+		{
+			endOfFormattedArea += 1;
+		}
+
+		endOfFormattedArea += 0x02;
+
+		return endOfFormattedArea;
+	}
+
+	/// <summary>
+	/// Locates the entry point.
+	/// </summary>
+	private static void LocateEntryPoint()
+	{
+		var memory = new Pointer(0xF0000);
+
+		while (memory < new Pointer(0x100000))
+		{
+			char a = (char)memory.Load8();
+			char s = (char)memory.Load8(1u);
+			char m = (char)memory.Load8(2u);
+			char b = (char)memory.Load8(3u);
+
+			if (a == '_' && s == 'S' && m == 'M' && b == '_')
+			{
+				EntryPoint = memory;
+				return;
+			}
+
+			memory += 0x10;
+		}
+
+		EntryPoint = memory;
+	}
+
+	/// <summary>
+	/// Gets the major version.
+	/// </summary>
+	private static void GetMajorVersion()
+	{
+		MajorVersion = EntryPoint.Load8(0x06u);
+	}
+
+	/// <summary>
+	/// Gets the minor version.
+	/// </summary>
+	private static void GetMinorVersion()
+	{
+		MinorVersion = EntryPoint.Load8(0x07u);
+	}
+
+	/// <summary>
+	/// Gets the table address.
+	/// </summary>
+	private static void GetTableAddress()
+	{
+		TableAddress = EntryPoint.LoadPointer(0x18u);
+	}
+
+	/// <summary>
+	/// Gets the length of the table.
+	/// </summary>
+	private static void GetTableLength()
+	{
+		TableLength = EntryPoint.Load16(0x16u);
+	}
+
+	/// <summary>
+	/// Gets the number of structures.
+	/// </summary>
+	private static void GetNumberOfStructures()
+	{
+		NumberOfStructures = EntryPoint.Load16(0x1Cu);
+	}
+}

--- a/Source/Mosa.Kernel.BareMetal.x86/SMBIOS/SMBIOSStructure.cs
+++ b/Source/Mosa.Kernel.BareMetal.x86/SMBIOS/SMBIOSStructure.cs
@@ -1,0 +1,47 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using Mosa.Runtime;
+
+namespace Mosa.Kernel.BareMetal.x86.SMBIOS;
+
+/// <summary>
+/// Smbios Structure
+/// </summary>
+public abstract class SMBIOSStructure
+{
+	protected Pointer address;
+	protected uint length;
+	protected uint handle;
+
+	protected SMBIOSStructure(Pointer address)
+	{
+		this.address = address;
+		length = Intrinsic.Load8(address, 0x01u);
+		handle = Intrinsic.Load16(address, 0x02u);
+	}
+
+	protected unsafe string GetStringFromIndex(byte index)
+	{
+		if (index == 0)
+			return string.Empty;
+
+		var first = address + length;
+		int offset = 0;
+
+		for (byte count = 1; count != index;)
+		{
+			if (first.Load8(offset++) == 0x00)
+				count++;
+		}
+
+		var start = first + offset;
+		var end = start;
+		int len = 0;
+
+		while (end.Load8(len++) != 0x00)
+		{
+		}
+
+		return new string((sbyte*)start.ToPointer(), 0, len);
+	}
+}

--- a/Source/Mosa.Kernel.BareMetal/Boot.cs
+++ b/Source/Mosa.Kernel.BareMetal/Boot.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
 
+using System;
 using Mosa.DeviceDriver;
 using Mosa.DeviceDriver.ISA;
 using Mosa.DeviceDriver.ScanCodeMap;
@@ -16,27 +17,34 @@ public static class Boot
 	[Plug("Mosa.Runtime.StartUp::PlatformInitialization")]
 	public static void PlatformInitialization()
 	{
+		Platform.Interrupt.Disable();
+
 		Debug.WriteLine("[Platform Initialization]");
 
 		BootStatus.Initalize();
 
-		ScreenConsole.SetBackground(ScreenColor.Black);
-		ScreenConsole.ClearScreen();
+		Console.BackgroundColor = ConsoleColor.Black;
+		Console.ForegroundColor = ConsoleColor.Yellow;
+		Console.Clear();
 
-		ScreenConsole.WriteLine(ScreenColor.BrightYellow, "MOSA BareMetal v0.1");
+		Console.WriteLine("MOSA BareMetal v2.4");
 
-		ScreenConsole.WriteLine();
+		Console.WriteLine();
 
-		ScreenConsole.WriteLine(ScreenColor.BrightYellow, "Initializing kernel...");
+		Console.WriteLine("Initializing kernel...");
 		Debug.Setup(true);
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> Initial garbage collection...");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Initial garbage collection...");
 		InitialGCMemory.Initialize();
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> Platform initialization...");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Platform initialization...");
 		Platform.EntryPoint();
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 	}
 
 	[Plug("Mosa.Runtime.StartUp::KernelEntryPoint")]
@@ -44,114 +52,181 @@ public static class Boot
 	{
 		Debug.WriteLine("[Kernel Entry Point]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> Enabling debug logging...");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Enabling debug logging...");
 		Debug.Setup(true);
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> Boot page allocator...");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Boot page allocator...");
 		BootPageAllocator.Setup();
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> Memory map...");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Memory map...");
 		BootMemoryMap.Setup();
 		BootMemoryMap.Dump();
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> Physical page allocator...");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Physical page allocator...");
 		PageFrameAllocator.Setup();
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> Page table...");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Page table...");
 		PageTable.Setup();
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> Virtual page allocator...");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Virtual page allocator...");
 		VirtualPageAllocator.Setup();
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> Interrupt Manager...");
-		InterreuptManager.Setup();
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Interrupt Manager...");
+		InterruptManager.Setup();
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> Garbage collection...");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Garbage collection...");
 		GCMemory.Setup();
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> Interrupt Handler...");
-		InterreuptManager.SetHandler(null);
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Interrupt Handler...");
+		InterruptManager.SetHandler(ProcessInterrupt);
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> Virtual memory allocator...");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Virtual memory allocator...");
 		VirtualMemoryAllocator.Setup();
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
 		//Console.Write(ConsoleColor.BrightGreen, "> Scheduler...");
 		//Scheduler.Setup();
 		//Console.WriteLine(ConsoleColor.BrightBlack, " [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> Hardware abstraction layer...");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Hardware abstraction layer...");
 		var hardware = new HardwareAbstractionLayer();
 		var deviceService = new DeviceService();
 		DeviceSystem.Setup.Initialize(hardware, deviceService.ProcessInterrupt);
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> Registering device drivers...");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Registering device drivers...");
 		deviceService.RegisterDeviceDriver(DeviceDriver.Setup.GetDeviceDriverRegistryEntries());
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.WriteLine();
-		ScreenConsole.WriteLine(ScreenColor.BrightYellow, "Initializing services...");
+		Console.ForegroundColor = ConsoleColor.Yellow;
+		Console.WriteLine();
+		Console.WriteLine("Initializing services...");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> Service Manager...");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Service Manager...");
 		var serviceManager = new ServiceManager();
-		Kernel.ServiceManger = serviceManager;
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		var diskDeviceService = new DiskDeviceService();
+		var partitionService = new PartitionService();
+		var pciControllerService = new PCIControllerService();
+		var pciDeviceService = new PCIDeviceService();
+		var pcService = new PCService();
+		Kernel.ServiceManager = serviceManager;
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> Device Service...");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Device Service...");
 		serviceManager.AddService(deviceService);
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> Disk Device Service...");
-		serviceManager.AddService(new DiskDeviceService());
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Disk Device Service...");
+		serviceManager.AddService(diskDeviceService);
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> Partition Service...");
-		serviceManager.AddService(new PartitionService());
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Partition Service...");
+		serviceManager.AddService(partitionService);
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> PCI Controller Service...");
-		serviceManager.AddService(new PCIControllerService());
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> PCI Controller Service...");
+		serviceManager.AddService(pciControllerService);
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> PCI Device Service...");
-		serviceManager.AddService(new PCIDeviceService());
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> PCI Device Service...");
+		serviceManager.AddService(pciDeviceService);
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> PC Service...");
-		serviceManager.AddService(new PCService());
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> PC Service...");
+		serviceManager.AddService(pcService);
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> X86System...");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> X86System...");
 		deviceService.Initialize(new X86System(), null);
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 
-		ScreenConsole.Write(ScreenColor.BrightGreen, "> StandardKeyboard...");
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Creating partition devices...");
+		partitionService.CreatePartitionDevices();
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
+
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> StandardKeyboard...");
 		{
 			var stdKeyboard = deviceService.GetFirstDevice<StandardKeyboard>().DeviceDriver as IKeyboardDevice;
 			if (stdKeyboard == null)
 			{
-				ScreenConsole.WriteLine(ScreenColor.Red, " [FAIL]");
-				ScreenConsole.WriteLine(ScreenColor.Red, "No keyboard detected!");
+				Console.ForegroundColor = ConsoleColor.Red;
+				Console.WriteLine(" [FAIL]");
+				Console.WriteLine("No keyboard detected!");
 				while (true) HAL.Yield();
 			}
 
 			Kernel.Keyboard = new Keyboard(stdKeyboard, new US());
 		}
-		ScreenConsole.WriteLine(ScreenColor.BrightBlack, " [Completed]");
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
+
+		Console.ForegroundColor = ConsoleColor.LightGreen;
+		Console.Write("> Enabling interrupts...");
+		Platform.Interrupt.Enable();
+		Console.ForegroundColor = ConsoleColor.DarkGray;
+		Console.WriteLine(" [Completed]");
 	}
 
 	[Plug("Mosa.Runtime.GC::AllocateMemory")]
 	private static Pointer AllocateMemory(uint size)
 	{
 		return BootStatus.IsGCEnabled ? GCMemory.AllocateMemory(size) : InitialGCMemory.AllocateMemory(size);
+	}
+
+	private static void ProcessInterrupt(uint interrupt, uint errorCode)
+	{
+		if (interrupt is >= 0x20 and < 0x30)
+			HAL.ProcessInterrupt((byte)(interrupt - 0x20));
 	}
 }

--- a/Source/Mosa.Kernel.BareMetal/BootPageAllocator.cs
+++ b/Source/Mosa.Kernel.BareMetal/BootPageAllocator.cs
@@ -4,7 +4,7 @@ using Mosa.Runtime;
 
 namespace Mosa.Kernel.BareMetal;
 
-public class BootPageAllocator
+public static class BootPageAllocator
 {
 	#region Private Members
 

--- a/Source/Mosa.Kernel.BareMetal/Debug.cs
+++ b/Source/Mosa.Kernel.BareMetal/Debug.cs
@@ -11,7 +11,7 @@ public static class Debug
 {
 	private const byte NewLine = (byte)'\n';
 
-	public static bool IsEnabled { get; set; } = false;
+	public static bool IsEnabled { get; set; }
 
 	#region Public API
 
@@ -28,7 +28,7 @@ public static class Debug
 
 	public static void Enable() => IsEnabled = true;
 
-	public static void Disable() => IsEnabled = true;
+	public static void Disable() => IsEnabled = false;
 
 	public static void Kill()
 	{

--- a/Source/Mosa.Kernel.BareMetal/InterruptManager.cs
+++ b/Source/Mosa.Kernel.BareMetal/InterruptManager.cs
@@ -4,7 +4,7 @@ namespace Mosa.Kernel.BareMetal;
 
 public delegate void InterruptHandler(uint irq, uint error);
 
-public static class InterreuptManager
+public static class InterruptManager
 {
 	public static void Setup()
 	{

--- a/Source/Mosa.Kernel.BareMetal/Kernel.cs
+++ b/Source/Mosa.Kernel.BareMetal/Kernel.cs
@@ -6,7 +6,7 @@ namespace Mosa.Kernel.BareMetal;
 
 public static class Kernel
 {
-	public static ServiceManager ServiceManger { get; set; }
+	public static ServiceManager ServiceManager { get; set; }
 
 	public static Keyboard Keyboard { get; set; }
 }

--- a/Source/Mosa.Kernel.BareMetal/Korlib/ConsolePlug.cs
+++ b/Source/Mosa.Kernel.BareMetal/Korlib/ConsolePlug.cs
@@ -8,9 +8,6 @@ namespace Mosa.Kernel.BareMetal.Korlib;
 
 public static class ConsolePlug
 {
-	private static ConsoleColor ForegroundColor = ConsoleColor.White;
-	private static ConsoleColor BackgroundColor = ConsoleColor.Black;
-
 	[Plug("System.Console::Clear")]
 	public static void Clear()
 	{
@@ -41,30 +38,16 @@ public static class ConsolePlug
 		ScreenConsole.Write(value);
 	}
 
-	[Plug("System.Console::SetForegroundColor")]
-	public static void SetForegroundColor(ConsoleColor color)
+	[Plug("System.Console::UpdateForegroundColor")]
+	public static void UpdateForegroundColor(ConsoleColor color)
 	{
-		ForegroundColor = color;
 		ScreenConsole.SetForground(Convert(color));
 	}
 
-	[Plug("System.Console::SetBackgroundColor")]
-	public static void SetBackgroundColor(ConsoleColor color)
+	[Plug("System.Console::UpdateBackgroundColor")]
+	public static void UpdateBackgroundColor(ConsoleColor color)
 	{
-		BackgroundColor = color;
 		ScreenConsole.SetBackground(Convert(color));
-	}
-
-	[Plug("System.Console::GetForegroundColor")]
-	public static ConsoleColor GetForegroundColor()
-	{
-		return ForegroundColor;
-	}
-
-	[Plug("System.Console::GetBackgroundColor")]
-	public static ConsoleColor GetBackgroundColor()
-	{
-		return BackgroundColor;
 	}
 
 	[Plug("System.Console::SetCursorPosition")]
@@ -73,14 +56,6 @@ public static class ConsolePlug
 		ScreenConsole.Goto((uint)top, (uint)left);
 	}
 
-	[Plug("System.Console::ResetColor")]
-	public static void ResetColor()
-	{
-		SetBackgroundColor(ConsoleColor.Black);
-		SetForegroundColor(ConsoleColor.White);
-	}
-
-	// TODO: Fix!
 	[Plug("System.Console::ReadLine")]
 	public static string ReadLine()
 	{
@@ -110,6 +85,7 @@ public static class ConsolePlug
 					{
 						ScreenConsole.Write(ScreenConsole.Backspace);
 						ScreenConsole.Write(' ');
+						ScreenConsole.Write(ScreenConsole.Backspace);
 						length--;
 					}
 					break;
@@ -118,37 +94,12 @@ public static class ConsolePlug
 				// Any other key
 				default:
 				{
-					WriteLine("char");
 					buffer[length++] = key.Character;
 					ScreenConsole.Write(key.Character);
 					break;
 				}
 			}
 		}
-	}
-
-	private static ConsoleColor Convert(ScreenColor color)
-	{
-		return color switch
-		{
-			ScreenColor.White => ConsoleColor.White,
-			ScreenColor.Black => ConsoleColor.Black,
-			ScreenColor.Red => ConsoleColor.Red,
-			ScreenColor.Green => ConsoleColor.Green,
-			ScreenColor.Yellow => ConsoleColor.Yellow,
-			ScreenColor.Blue => ConsoleColor.Blue,
-			ScreenColor.Magenta => ConsoleColor.Magenta,
-			ScreenColor.Cyan => ConsoleColor.Cyan,
-			ScreenColor.BrightBlack => ConsoleColor.DarkGray,
-			ScreenColor.BrightRed => ConsoleColor.LightRed,
-			ScreenColor.BrightGreen => ConsoleColor.LightGreen,
-			ScreenColor.BrightYellow => ConsoleColor.Yellow,
-			ScreenColor.BrightBlue => ConsoleColor.LightBlue,
-			ScreenColor.BrightMagenta => ConsoleColor.LightMagenta,
-			ScreenColor.BrightCyan => ConsoleColor.LightCyan,
-			ScreenColor.BrightWhite => ConsoleColor.Gray,
-			_ => ConsoleColor.White,
-		};
 	}
 
 	private static ScreenColor Convert(ConsoleColor color)

--- a/Source/Mosa.Kernel.BareMetal/Korlib/EnvironmentPlug.cs
+++ b/Source/Mosa.Kernel.BareMetal/Korlib/EnvironmentPlug.cs
@@ -20,4 +20,10 @@ public class EnvironmentPlug
 	{
 		Debug.Fatal();
 	}
+
+	[Plug("System.Environment::GetProcessorCount")]
+	internal static int GetProcessorCount()
+	{
+		return 1;
+	}
 }

--- a/Source/Mosa.Kernel.BareMetal/LZF.cs
+++ b/Source/Mosa.Kernel.BareMetal/LZF.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+// LibLZF used under the following license:
+
+/*
+ * Improved version to C# LibLZF Port:
+ * Copyright (c) 2010 Roman Atachiants <kelindar@gmail.com>
+ *
+ * Original CLZF Port:
+ * Copyright (c) 2005 Oren J. Maurice <oymaurice@hazorea.org.il>
+ *
+ * Original LibLZF Library & Algorithm:
+ * Copyright (c) 2000-2008 Marc Alexander Lehmann <schmorp@schmorp.de>
+ *
+ * Redistribution and use in source and binary forms, with or without modifica-
+ * tion, are permitted provided that the following conditions are met:
+ *
+ *   1.  Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *   2.  Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *   3.  The name of the author may not be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MER-
+ * CHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPE-
+ * CIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTH-
+ * ERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * the GNU General Public License version 2 (the "GPL"), in which case the
+ * provisions of the GPL are applicable instead of the above. If you wish to
+ * allow the use of your version of this file only under the terms of the
+ * GPL and not to allow others to use your version of this file under the
+ * BSD license, indicate your decision by deleting the provisions above and
+ * replace them with the notice and other provisions required by the GPL. If
+ * you do not delete the provisions above, a recipient may use your version
+ * of this file under either the BSD or the GPL.
+ */
+
+using Mosa.Runtime;
+
+namespace Mosa.Kernel.BareMetal;
+
+/// <summary>
+/// Improved C# LZF Compressor, a very small data compression library. The compression algorithm is extremely fast.
+/// </summary>
+public static class LZF
+{
+	/// <summary>
+	/// Decompresses the data using LibLZF algorithm
+	/// </summary>
+	/// <param name="input">Reference to the data to decompress</param>
+	/// <param name="inputLength">Length of the data to decompress</param>
+	/// <param name="output">Reference to a buffer which will contain the decompressed data</param>
+	/// <param name="outputLength">The size of the decompressed archive in the output buffer</param>
+	/// <returns></returns>
+	public static bool Decompress(Pointer input, uint inputLength, Pointer output, uint outputLength)
+	{
+		uint iidx = 0;
+		uint oidx = 0;
+
+		do
+		{
+			//uint ctrl = input[iidx++];
+			uint ctrl = Intrinsic.Load8(input, iidx);
+			iidx++;
+
+			if (ctrl < 1 << 5) /* literal run */
+			{
+				ctrl++;
+
+				if (oidx + ctrl > outputLength)
+				{
+					//SET_ERRNO (E2BIG);
+					return false;
+				}
+
+				do
+				{
+					//output[oidx++] = input[iidx++];
+					Intrinsic.Store8(output, oidx, Intrinsic.Load8(input, iidx));
+					oidx++;
+					iidx++;
+				}
+				while (--ctrl != 0);
+			}
+			else /* back reference */
+			{
+				var len = ctrl >> 5;
+
+				var reference = oidx - ((ctrl & 0x1f) << 8) - 1;
+
+				if (len == 7)
+				{
+					//len += input[iidx++];
+					len += Intrinsic.Load8(input, iidx);
+					iidx++;
+				}
+
+				//reference -= input[iidx++];
+				reference -= Intrinsic.Load8(input, iidx);
+				iidx++;
+
+				if (oidx + len + 2 > outputLength)
+				{
+					//SET_ERRNO (E2BIG);
+					return false;
+				}
+
+				//if (reference < 0)
+				//{
+				//	//SET_ERRNO (EINVAL);
+				//	return false;
+				//}
+
+				//output[oidx++] = output[reference++];
+				Intrinsic.Store8(output, oidx, Intrinsic.Load8(output, reference));
+				oidx++;
+				reference++;
+
+				//output[oidx++] = output[reference++];
+				Intrinsic.Store8(output, oidx, Intrinsic.Load8(output, reference));
+				oidx++;
+				reference++;
+
+				do
+				{
+					//output[oidx++] = output[reference++];
+					Intrinsic.Store8(output, oidx, Intrinsic.Load8(output, reference));
+					oidx++;
+					reference++;
+				}
+				while (--len != 0);
+			}
+		}
+		while (iidx < inputLength);
+
+		return true;
+	}
+}

--- a/Source/Mosa.Kernel.BareMetal/PageFrameAllocator.cs
+++ b/Source/Mosa.Kernel.BareMetal/PageFrameAllocator.cs
@@ -12,6 +12,8 @@ public static class PageFrameAllocator
 
 	public static uint TotalPages { get; private set; }
 
+	public static uint UsedPages { get; private set; }
+
 	#endregion Public Members
 
 	#region Private Members
@@ -146,6 +148,7 @@ public static class PageFrameAllocator
 	public static void Release(Pointer page, uint count)
 	{
 		SetPageBitMapEntry((uint)page.ToInt64() / Page.Size, count, true);
+		UsedPages--;
 	}
 
 	public static Pointer Allocate()
@@ -188,6 +191,7 @@ public static class PageFrameAllocator
 				SetPageBitMapEntry(at, count, true);
 
 				SearchNextStartPage = restartAt;
+				UsedPages++;
 
 				Debug.WriteLine(" > Return: ", new Hex(at));
 

--- a/Source/Mosa.Kernel.BareMetal/Platform.cs
+++ b/Source/Mosa.Kernel.BareMetal/Platform.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
 
 using Mosa.DeviceSystem;
-using Mosa.DeviceSystem.VirtIO;
 using Mosa.Runtime;
 
 namespace Mosa.Kernel.BareMetal;
@@ -11,12 +10,11 @@ public static class Platform
 	// These methods will be plugged and implemented elsewhere in the platform specific implementation
 
 	public static void EntryPoint()
-	{
-	}
+	{ }
 
-	public static AddressRange GetBootReservedRegion() => new AddressRange(0, 0);
+	public static AddressRange GetBootReservedRegion() => new(0, 0);
 
-	public static AddressRange GetInitialGCMemoryPool() => new AddressRange(0, 0);
+	public static AddressRange GetInitialGCMemoryPool() => new(0, 0);
 
 	public static PlatformArchitecture GetPlatformArchitecture() => PlatformArchitecture.None;
 

--- a/Source/Mosa.Korlib/System/Console.cs
+++ b/Source/Mosa.Korlib/System/Console.cs
@@ -6,32 +6,33 @@ namespace System;
 
 public static class Console
 {
+	private static ConsoleColor foregroundColor, backgroundColor;
+
 	public static ConsoleColor ForegroundColor
 	{
-		get => GetForegroundColor();
-		set => SetForegroundColor(value);
+		get => foregroundColor;
+		set
+		{
+			foregroundColor = value;
+			UpdateForegroundColor(value);
+		}
 	}
 
 	public static ConsoleColor BackgroundColor
 	{
-		get => GetBackgroundColor();
-		set => SetBackgroundColor(value);
+		get => backgroundColor;
+		set
+		{
+			backgroundColor = value;
+			UpdateBackgroundColor(value);
+		}
 	}
 
-	[MethodImpl(MethodImplOptions.InternalCall)]
-	private static extern ConsoleColor GetForegroundColor();
-
-	[MethodImpl(MethodImplOptions.InternalCall)]
-	private static extern ConsoleColor GetBackgroundColor();
-
-	[MethodImpl(MethodImplOptions.InternalCall)]
-	private static extern void SetForegroundColor(ConsoleColor color);
-
-	[MethodImpl(MethodImplOptions.InternalCall)]
-	private static extern void SetBackgroundColor(ConsoleColor color);
-
-	[MethodImpl(MethodImplOptions.InternalCall)]
-	public static extern void ResetColor();
+	public static void ResetColor()
+	{
+		BackgroundColor = ConsoleColor.Black;
+		ForegroundColor = ConsoleColor.White;
+	}
 
 	[MethodImpl(MethodImplOptions.InternalCall)]
 	public static extern void Clear();
@@ -53,4 +54,10 @@ public static class Console
 
 	[MethodImpl(MethodImplOptions.InternalCall)]
 	public static extern string ReadLine();
+
+	[MethodImpl(MethodImplOptions.InternalCall)]
+	private static extern void UpdateForegroundColor(ConsoleColor color);
+
+	[MethodImpl(MethodImplOptions.InternalCall)]
+	private static extern void UpdateBackgroundColor(ConsoleColor color);
 }

--- a/Source/Mosa.Korlib/System/UInt32.cs
+++ b/Source/Mosa.Korlib/System/UInt32.cs
@@ -54,7 +54,8 @@ public struct UInt32: IComparable, IComparable<uint>, IEquatable<uint>
 
 	public string ToString(string format)
 	{
-		return int.CreateString(m_value, false, true);
+		// TOOO: Actual formats
+		return int.CreateString(m_value, false, char.ToLower(format[0]) == 'x');
 	}
 
 	public override int GetHashCode()

--- a/Source/Mosa.UnitTests.BareMetal.x86/Address.cs
+++ b/Source/Mosa.UnitTests.BareMetal.x86/Address.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
 
-namespace Mosa.UnitTests.Framework;
+namespace Mosa.UnitTests.BareMetal.x86;
 
 public static class Address
 {

--- a/Source/Mosa.UnitTests.BareMetal.x86/Boot.cs
+++ b/Source/Mosa.UnitTests.BareMetal.x86/Boot.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
 
+using System;
 using Mosa.Kernel.BareMetal;
 using Mosa.Kernel.BareMetal.x86;
 using Mosa.Runtime.Plug;
-using Mosa.UnitTests.Framework;
 using Mosa.UnitTests.Optimization;
 
 namespace Mosa.UnitTests.BareMetal.x86;
@@ -22,13 +22,13 @@ public static class Boot
 
 		UnitTestEngine.Setup(0x3F8); // Serial.COM1
 
-		ScreenConsole.SetBackground(ScreenColor.Blue);
-		ScreenConsole.ClearScreen();
-		ScreenConsole.GotoTop();
-		ScreenConsole.SetForground(ScreenColor.Yellow);
-		ScreenConsole.Write("MOSA OS Version 2.0 - UnitTest");
-		ScreenConsole.WriteLine();
-		ScreenConsole.WriteLine();
+		Console.BackgroundColor = ConsoleColor.Blue;
+		Console.Clear();
+		Console.SetCursorPosition(0, 0);
+		Console.ForegroundColor = ConsoleColor.Yellow;
+		Console.Write("MOSA OS Version 2.4 - UnitTest");
+		Console.WriteLine();
+		Console.WriteLine();
 
 		UnitTestEngine.DisplayUpdate();
 

--- a/Source/Mosa.UnitTests.BareMetal.x86/Screen.cs
+++ b/Source/Mosa.UnitTests.BareMetal.x86/Screen.cs
@@ -3,7 +3,7 @@
 using Mosa.Runtime;
 using Mosa.Runtime.x86;
 
-namespace Mosa.UnitTests.Framework;
+namespace Mosa.UnitTests.BareMetal.x86;
 
 /// <summary>
 /// Screen

--- a/Source/Mosa.UnitTests.BareMetal.x86/UnitTestEngine.cs
+++ b/Source/Mosa.UnitTests.BareMetal.x86/UnitTestEngine.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
 
+using System;
 using Mosa.Kernel.BareMetal;
 using Mosa.Runtime;
 using Mosa.Runtime.x86;
 
-namespace Mosa.UnitTests.Framework;
+namespace Mosa.UnitTests.BareMetal.x86;
 
 /// <summary>
 /// Unit Test Engine
@@ -279,21 +280,21 @@ public static class UnitTestEngine
 	{
 		if (!test)
 		{
-			ScreenConsole.Goto(4, 0);
-			ScreenConsole.Write("Total  : ");
-			ScreenConsole.WriteValue(TestCount, 7);
+			Console.SetCursorPosition(4, 0);
+			Console.Write("Total  : ");
+			Console.Write(TestCount.ToString("D7"));
 
-			ScreenConsole.Goto(5, 0);
-			ScreenConsole.Write("Pending: ");
-			ScreenConsole.WriteValue(PendingCount, 7);
+			Console.SetCursorPosition(5, 0);
+			Console.Write("Pending: ");
+			Console.Write(PendingCount.ToString("D7"));
 		}
 		else
 		{
-			ScreenConsole.Goto(6, 0);
-			ScreenConsole.Write("Active : ");
-			ScreenConsole.WriteValue(TestID, 7);
-			ScreenConsole.Write(" @ ");
-			ScreenConsole.WriteValueAsHex(TestMethodAddress.ToUInt32(), 8);
+			Console.SetCursorPosition(6, 0);
+			Console.Write("Active : ");
+			Console.Write(TestID.ToString("D7"));
+			Console.Write(" @ ");
+			Console.Write(TestMethodAddress.ToUInt32().ToString("X8"));
 		}
 	}
 }


### PR DESCRIPTION
- Completed port of CoolWorld to BareMetal HelloWorld.
- Fixed interrupts not being catched in BareMetal.
- Simplified System.Console and its plugs.
- Added LZF, RTC, CPUInfo and SMBIOS classes from Mosa.Kernel.x86 into Mosa.Kernel.BareMetal.x86.
- Made ScreenConsole to be only used in ConsolePlug.
- Made PartitionService create the partition devices in Mosa.Kernel.BareMetal.Boot.
- Plugged System.Environment.GetProcessorCount() in BareMetal.
- Added UsedPages Mosa.Kernel.BareMetal.PageFrameAllocator to track used physical pages.
- Made System.UInt32.ToString(string) accept decimal formats.
- Tons of other minor changes (fixing typos, removing unused code, fixing namespaces)