### PR TITLE
Moved the int.ToString(uvalue) to Numbers.cs

### DIFF
--- a/Source/Mosa.Korlib/System/Byte.cs
+++ b/Source/Mosa.Korlib/System/Byte.cs
@@ -91,11 +91,11 @@ public struct Byte: IComparable, IComparable<byte>, IEquatable<byte>
 
 	public override string ToString()
 	{
-		return int.CreateString(m_value, false, false);
+		return Numbers.UInt8ToString(m_value);
 	}
 
 	public string ToString(string format)
 	{
-		return int.CreateString(m_value, false, true);
+		return Numbers.UInt8ToString(m_value, format);
 	}
 }

--- a/Source/Mosa.Korlib/System/Int16.cs
+++ b/Source/Mosa.Korlib/System/Int16.cs
@@ -49,7 +49,7 @@ public struct Int16: IComparable, IComparable<short>, IEquatable<short>
 
 	public override string ToString()
 	{
-		return int.CreateString((uint)m_value, true, false);
+		return Numbers.Int16ToString(m_value);
 	}
 
 	public override int GetHashCode()

--- a/Source/Mosa.Korlib/System/Int32.cs
+++ b/Source/Mosa.Korlib/System/Int32.cs
@@ -49,66 +49,13 @@ public struct Int32: IComparable, IComparable<int>, IEquatable<int>
 
 	public override string ToString()
 	{
-		return CreateString((uint)m_value, true, false);
+		return Numbers.Int32ToString(m_value);
 	}
 
 	public string ToString(string format)
-	{
-		return CreateString((uint)m_value, false, true);
-	}
-
-	unsafe internal static string CreateString(uint value, bool signed, bool hex)
-	{
-		int offset = 0;
-
-		uint uvalue = value;
-		var divisor = hex ? 16u : 10;
-		int length = 0;
-		int count = 0;
-		uint temp;
-		bool negative = false;
-
-		if (value < 0 && !hex && signed)
-		{
-			count++;
-			uvalue = (uint)-value;
-			negative = true;
-		}
-
-		temp = uvalue;
-
-		do
-		{
-			temp /= divisor;
-			count++;
-		}
-		while (temp != 0);
-
-		length = count;
-		var result = String.InternalAllocateString(length);
-
-		var chars = result.first_char;
-
-		if (negative)
-		{
-			*(chars + offset) = '-';
-			offset++;
-			count--;
-		}
-
-		for (var i = 0; i < count; i++)
-		{
-			var remainder = uvalue % divisor;
-
-			if (remainder < 10)
-				*(chars + offset + count - 1 - i) = (char)('0' + remainder);
-			else
-				*(chars + offset + count - 1 - i) = (char)('A' + remainder - 10);
-
-			uvalue /= divisor;
-		}
-
-		return result;
+	{		
+		// TODO: Actual formats
+		return Numbers.Int32ToString(m_value);
 	}
 
 	public override int GetHashCode()

--- a/Source/Mosa.Korlib/System/Numbers.cs
+++ b/Source/Mosa.Korlib/System/Numbers.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+namespace System
+{
+	internal static class Numbers
+	{
+		public static string UInt8ToString(byte value, string format = null)
+		{
+			// TODO: Actually formats
+			return CreateString(value, false, format);
+		}
+
+		public static string Int8ToString(sbyte value, string format = null)
+		{
+			// TODO: Actually formats
+			return CreateString(value, true, format);
+		}
+
+		public static string Int16ToString(short value, string format = null)
+		{
+			// TODO: Actually formats
+			return CreateString(value, true, format);
+		}
+
+		public static string UInt16ToString(ushort value, string format = null)
+		{
+			// TODO: Actually formats
+			return CreateString(value, true, format);
+		}
+
+		public static string Int32ToString(int value, string format = null)
+		{
+			// TODO: Actually formats
+			return CreateString(value, true, format);
+		}
+
+		public static string UInt32ToString(uint value, string format = null)
+		{
+			// TODO: Actually formats
+			return CreateString(value, format);
+		}
+
+		/// Used for all times except uint.
+		unsafe static string CreateString(int value, bool signed, string format)
+		{
+			bool hex = format != null ? true : false;
+
+			int offset = 0;
+
+			uint uvalue = (uint)value;
+			var divisor = hex ? 16u : 10;
+			int length = 0;
+			int count = 0;
+			uint temp;
+			bool negative = false;
+
+			if (value < 0 && !hex && signed)
+			{
+				count++;
+				uvalue = (uint)-value;
+				negative = true;
+			}
+
+			temp = uvalue;
+
+			do
+			{
+				temp /= divisor;
+				count++;
+			}
+			while (temp != 0);
+
+			length = count;
+			var result = String.InternalAllocateString(length);
+		
+			char* chars = result.first_char;
+
+
+			if (negative)
+			{
+				*(chars + offset) = '-';
+				offset++;
+				count--;
+			}
+
+			for (var i = 0; i < count; i++)
+			{
+				var remainder = uvalue % divisor;
+
+				if (remainder < 10)
+					*(chars + offset + count - 1 - i) = (char)('0' + remainder);
+				else
+					*(chars + offset + count - 1 - i) = (char)('A' + remainder - 10);
+
+				uvalue /= divisor;
+			}
+
+			return result;
+		}
+
+		/// Used for uints only atm.
+		unsafe static string CreateString(uint value, string format)
+		{
+			bool hex = format != null ? true : false;
+
+			int offset = 0;
+
+			uint uvalue = (uint)value;
+			var divisor = hex ? 16u : 10;
+			int length = 0;
+			int count = 0;
+			uint temp;
+
+			temp = uvalue;
+
+			do
+			{
+				temp /= divisor;
+				count++;
+			}
+			while (temp != 0);
+
+			length = count;
+			var result = String.InternalAllocateString(length);
+			var chars = result.first_char;
+
+			for (var i = 0; i < count; i++)
+			{
+				var remainder = uvalue % divisor;
+
+				if (remainder < 10)
+					*(chars + offset + count - 1 - i) = (char)('0' + remainder);
+				else
+					*(chars + offset + count - 1 - i) = (char)('A' + remainder - 10);
+				uvalue /= divisor;
+			}
+
+			return result;
+		}
+	}
+}

--- a/Source/Mosa.Korlib/System/SByte.cs
+++ b/Source/Mosa.Korlib/System/SByte.cs
@@ -54,6 +54,6 @@ public readonly struct SByte: IComparable, IComparable<sbyte>, IEquatable<sbyte>
 
 	public override string ToString()
 	{
-		return int.CreateString((uint)m_value, true, false);
+		return Numbers.Int8ToString(m_value);
 	}
 }

--- a/Source/Mosa.Korlib/System/UInt16.cs
+++ b/Source/Mosa.Korlib/System/UInt16.cs
@@ -49,12 +49,12 @@ public struct UInt16: IComparable, IComparable<ushort>, IEquatable<ushort>
 
 	public override string ToString()
 	{
-		return int.CreateString(m_value, false, false);
+		return Numbers.UInt16ToString(m_value); 
 	}
 
 	public string ToString(string format)
 	{
-		return int.CreateString(m_value, false, true);
+		return Numbers.UInt16ToString(m_value, format);
 	}
 
 	public override int GetHashCode()

--- a/Source/Mosa.Korlib/System/UInt32.cs
+++ b/Source/Mosa.Korlib/System/UInt32.cs
@@ -49,13 +49,12 @@ public struct UInt32: IComparable, IComparable<uint>, IEquatable<uint>
 
 	public override string ToString()
 	{
-		return int.CreateString(m_value, false, false);
+		return Numbers.UInt32ToString(m_value);
 	}
 
 	public string ToString(string format)
 	{
-		// TOOO: Actual formats
-		return int.CreateString(m_value, false, char.ToLower(format[0]) == 'x');
+		return Numbers.UInt32ToString(m_value);
 	}
 
 	public override int GetHashCode()


### PR DESCRIPTION
![image](https://github.com/mosa/MOSA-Project/assets/67616852/ecb32962-4de7-4530-a485-cc6125812d7c)

unsafe static string CreateString(uint value,

seemed to be used for signed types as well, and that doesnt work ( if value < 0 ) will never executed.