### PR TITLE
Mosa.DeviceSystem: code style refactoring

### DIFF
--- a/Source/Mosa.DeviceSystem/AddressRegion.cs
+++ b/Source/Mosa.DeviceSystem/AddressRegion.cs
@@ -37,8 +37,5 @@ public struct AddressRegion
 	/// <returns>
 	/// 	<c>true</c> if [contains] [the specified address]; otherwise, <c>false</c>.
 	/// </returns>
-	public bool Contains(Pointer address)
-	{
-		return address >= Address && address < Address + Size;
-	}
+	public bool Contains(Pointer address) => address >= Address && address < Address + Size;
 }

--- a/Source/Mosa.DeviceSystem/BaseDeviceConfiguration.cs
+++ b/Source/Mosa.DeviceSystem/BaseDeviceConfiguration.cs
@@ -5,6 +5,4 @@ namespace Mosa.DeviceSystem;
 /// <summary>
 /// Interface Device Configuration
 /// </summary>
-public abstract class BaseDeviceConfiguration
-{
-}
+public abstract class BaseDeviceConfiguration { }

--- a/Source/Mosa.DeviceSystem/BaseDeviceDriver.cs
+++ b/Source/Mosa.DeviceSystem/BaseDeviceDriver.cs
@@ -33,25 +33,17 @@ public abstract class BaseDeviceDriver
 	/// <summary>
 	/// Probes this instance.
 	/// </summary>
-	public virtual void Probe()
-	{
-		Device.Status = DeviceStatus.NotFound;
-	}
+	public virtual void Probe() => Device.Status = DeviceStatus.NotFound;
 
 	/// <summary>
 	/// Starts this hardware device.
 	/// </summary>
-	public virtual void Start()
-	{
-		Device.Status = DeviceStatus.Error;
-	}
+	public virtual void Start() => Device.Status = DeviceStatus.Error;
 
 	/// <summary>
 	/// Stops this hardware device.
 	/// </summary>
-	public virtual void Stop()
-	{
-	}
+	public virtual void Stop() { }
 
 	/// <summary>
 	/// Called when an interrupt is received.

--- a/Source/Mosa.DeviceSystem/BaseService.cs
+++ b/Source/Mosa.DeviceSystem/BaseService.cs
@@ -24,34 +24,24 @@ public abstract class BaseService
 	/// <summary>
 	/// Initializes this instance.
 	/// </summary>
-	protected virtual void Initialize()
-	{ }
+	protected virtual void Initialize() { }
 
 	/// <summary>
 	/// Posts the event.
 	/// </summary>
 	/// <param name="serviceEvent">The service event.</param>
-	public virtual void PostEvent(ServiceEvent serviceEvent)
-	{
-	}
+	public virtual void PostEvent(ServiceEvent serviceEvent) { }
 
 	//[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	[MethodImpl(MethodImplOptions.NoInlining)]
-	protected static Device MatchEvent<SERVICE>(ServiceEvent serviceEvent, ServiceEventType eventType) where SERVICE : class
+	protected static Device MatchEvent<TService>(ServiceEvent serviceEvent, ServiceEventType eventType) where TService : class
 	{
 		if (serviceEvent.ServiceEventType != eventType)
 			return null;
 
-		var device = serviceEvent.Subject as Device;
-
-		if (device == null)
+		if (serviceEvent.Subject is not Device device)
 			return null;
 
-		var service = device.DeviceDriver as SERVICE;
-
-		if (service == null)
-			return null;
-
-		return device;
+		return device.DeviceDriver is not TService ? null : device;
 	}
 }

--- a/Source/Mosa.DeviceSystem/CHS.cs
+++ b/Source/Mosa.DeviceSystem/CHS.cs
@@ -51,8 +51,10 @@ public class CHS
 
 		Sector = (ushort)(lba % diskGeometry.SectorsPerTrack + 1);
 		lba /= diskGeometry.SectorsPerTrack;
+
 		Head = (byte)(lba % diskGeometry.Heads);
 		lba /= diskGeometry.Heads;
+
 		Cylinder = (ushort)(lba & 0xFF);
 		Sector |= (ushort)((lba >> 2) & 0xC0);
 	}

--- a/Source/Mosa.DeviceSystem/ConstrainedPointer.cs
+++ b/Source/Mosa.DeviceSystem/ConstrainedPointer.cs
@@ -25,17 +25,8 @@ public readonly struct ConstrainedPointer
 
 	public ConstrainedPointer(Pointer address, uint size)
 	{
-		this.Address = address;
-		this.Size = size;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	private void CheckOffset(uint offset)
-	{
-		if (offset >= Size)
-		{
-			throw new ArgumentOutOfRangeException(nameof(offset));
-		}
+		Address = address;
+		Size = size;
 	}
 
 	public byte this[uint offset]
@@ -163,5 +154,12 @@ public readonly struct ConstrainedPointer
 	{
 		CheckOffset(offset);
 		Address.Store64(offset, value);
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private void CheckOffset(uint offset)
+	{
+		if (offset >= Size)
+			throw new ArgumentOutOfRangeException(nameof(offset));
 	}
 }

--- a/Source/Mosa.DeviceSystem/DataBlock.cs
+++ b/Source/Mosa.DeviceSystem/DataBlock.cs
@@ -26,19 +26,13 @@ public class DataBlock
 	/// Initializes a new instance of the <see cref="DataBlock"/> struct.
 	/// </summary>
 	/// <param name="data">The data.</param>
-	public DataBlock(byte[] data)
-	{
-		Data = data;
-	}
+	public DataBlock(byte[] data) => Data = data;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="DataBlock"/> struct.
 	/// </summary>
 	/// <param name="length">The length.</param>
-	public DataBlock(uint length)
-	{
-		Data = new byte[length];
-	}
+	public DataBlock(uint length) => Data = new byte[length];
 
 	/// <summary>
 	/// Gets or sets the <see cref="Byte" /> at the specified index.
@@ -59,20 +53,14 @@ public class DataBlock
 	/// </summary>
 	/// <param name="offset">The offset.</param>
 	/// <returns></returns>
-	public char GetChar(uint offset)
-	{
-		return (char)Data[offset];
-	}
+	public char GetChar(uint offset) => (char)Data[offset];
 
 	/// <summary>
 	/// Sets the char.
 	/// </summary>
 	/// <param name="offset">The offset.</param>
 	/// <param name="value">The value.</param>
-	public void SetChar(uint offset, char value)
-	{
-		Data[offset] = (byte)value;
-	}
+	public void SetChar(uint offset, char value) => Data[offset] = (byte)value;
 
 	/// <summary>
 	/// Gets the chars.
@@ -83,8 +71,8 @@ public class DataBlock
 	public char[] GetChars(uint offset, uint length)
 	{
 		var value = new char[length];
-
-		for (uint index = 0; index < length; index++) { value[index] = GetChar(offset + index); }
+		for (var index = 0U; index < length; index++)
+			value[index] = GetChar(offset + index);
 
 		return value;
 	}
@@ -98,8 +86,8 @@ public class DataBlock
 	public byte[] GetBytes(uint offset, uint length)
 	{
 		var value = new byte[length];
-
-		for (uint index = 0; index < length; index++) { value[index] = Data[offset + index]; }
+		for (var index = 0U; index < length; index++)
+			value[index] = Data[offset + index];
 
 		return value;
 	}
@@ -111,7 +99,8 @@ public class DataBlock
 	/// <param name="value">The value.</param>
 	public void SetChars(uint offset, char[] value)
 	{
-		for (uint index = 0; index < value.Length; index++) { Data[offset + index] = (byte)value[index]; }
+		for (var index = 0U; index < value.Length; index++)
+			Data[offset + index] = (byte)value[index];
 	}
 
 	/// <summary>
@@ -121,7 +110,8 @@ public class DataBlock
 	/// <param name="value">The value.</param>
 	public void SetString(uint offset, string value)
 	{
-		for (int index = 0; index < value.Length; index++) { Data[offset + index] = (byte)value[index]; }
+		for (var index = 0; index < value.Length; index++)
+			Data[offset + index] = (byte)value[index];
 	}
 
 	/// <summary>
@@ -132,7 +122,8 @@ public class DataBlock
 	/// <param name="length">The length.</param>
 	public void SetString(uint offset, string value, uint length)
 	{
-		for (int index = 0; index < length; index++) { Data[offset + index] = (byte)value[index]; }
+		for (var index = 0; index < length; index++)
+			Data[offset + index] = (byte)value[index];
 	}
 
 	/// <summary>
@@ -324,20 +315,14 @@ public class DataBlock
 	/// </summary>
 	/// <param name="offset">The offset.</param>
 	/// <returns></returns>
-	public byte GetByte(uint offset)
-	{
-		return Data[offset];
-	}
+	public byte GetByte(uint offset) => Data[offset];
 
 	/// <summary>
 	/// Sets the byte.
 	/// </summary>
 	/// <param name="offset">The offset.</param>
 	/// <param name="value">The value.</param>
-	public void SetByte(uint offset, byte value)
-	{
-		Data[offset] = value;
-	}
+	public void SetByte(uint offset, byte value) => Data[offset] = value;
 
 	/// <summary>
 	/// Sets the bytes.
@@ -346,7 +331,8 @@ public class DataBlock
 	/// <param name="value">The value.</param>
 	public void SetBytes(uint offset, byte[] value)
 	{
-		for (uint index = 0; index < value.Length; index++) { Data[offset + index] = value[index]; }
+		for (var index = 0U; index < value.Length; index++)
+			Data[offset + index] = value[index];
 	}
 
 	/// <summary>
@@ -358,7 +344,8 @@ public class DataBlock
 	/// <param name="length">The length.</param>
 	public void SetBytes(uint offset, byte[] value, uint start, uint length)
 	{
-		for (uint index = 0; index < length; index++) { Data[offset + index] = value[start + index]; }
+		for (var index = 0U; index < length; index++)
+			Data[offset + index] = value[start + index];
 	}
 
 	/// <summary>
@@ -369,7 +356,8 @@ public class DataBlock
 	/// <param name="length">The length.</param>
 	public void Fill(uint offset, byte value, uint length)
 	{
-		for (uint index = 0; index < length; index++) { Data[offset + index] = value; }
+		for (var index = 0U; index < length; index++)
+			Data[offset + index] = value;
 	}
 
 	/// <summary>
@@ -378,8 +366,5 @@ public class DataBlock
 	/// <param name="offset">The offset.</param>
 	/// <param name="length">The length.</param>
 	/// <returns></returns>
-	public string GetString(uint offset, uint length)
-	{
-		return Encoding.ASCII.GetString(Data, (int)offset, (int)length);
-	}
+	public string GetString(uint offset, uint length) => Encoding.ASCII.GetString(Data, (int)offset, (int)length);
 }

--- a/Source/Mosa.DeviceSystem/DeviceStatus.cs
+++ b/Source/Mosa.DeviceSystem/DeviceStatus.cs
@@ -34,5 +34,5 @@ public enum DeviceStatus : byte
 
 	Offline,
 
-	Disabled,
+	Disabled
 }

--- a/Source/Mosa.DeviceSystem/DiskDeviceDriver.cs
+++ b/Source/Mosa.DeviceSystem/DiskDeviceDriver.cs
@@ -8,21 +8,6 @@ namespace Mosa.DeviceSystem;
 public class DiskDeviceDriver : BaseDeviceDriver, IDiskDevice
 {
 	/// <summary>
-	/// The disk controller
-	/// </summary>
-	private IDiskControllerDevice diskController;
-
-	/// <summary>
-	/// The drive NBR
-	/// </summary>
-	private uint DriveNbr;
-
-	/// <summary>
-	/// The read only
-	/// </summary>
-	private bool readOnly;
-
-	/// <summary>
 	/// Gets a value indicating whether this instance can write.
 	/// </summary>
 	/// <value><c>true</c> if this instance can write; otherwise, <c>false</c>.</value>
@@ -38,34 +23,50 @@ public class DiskDeviceDriver : BaseDeviceDriver, IDiskDevice
 	/// Gets the size of the block.
 	/// </summary>
 	/// <value>The size of the block.</value>
-	public uint BlockSize => diskController.GetSectorSize(DriveNbr);
+	public uint BlockSize => diskController.GetSectorSize(driveNbr);
+
+	/// <summary>
+	/// The disk controller
+	/// </summary>
+	private IDiskControllerDevice diskController;
+
+	/// <summary>
+	/// The drive NBR
+	/// </summary>
+	private uint driveNbr;
+
+	/// <summary>
+	/// The read only
+	/// </summary>
+	private bool readOnly;
 
 	public override void Initialize()
 	{
-		var configuration = Device.Configuration as DiskDeviceConfiguration;
-
-		DriveNbr = configuration.DriveNbr;
-		readOnly = configuration.ReadOnly;
-
-		Device.ComponentID = DriveNbr;
-		Device.Name = Device.Parent.Name + "/Disk" + DriveNbr;
-
-		diskController = Device.Parent.DeviceDriver as IDiskControllerDevice;
-
-		if (diskController == null)
+		if (Device.Configuration is not DiskDeviceConfiguration configuration)
 		{
 			Device.Status = DeviceStatus.Error;
+			return;
 		}
+
+		driveNbr = configuration.DriveNbr;
+		readOnly = configuration.ReadOnly;
+
+		Device.ComponentID = driveNbr;
+		Device.Name = $"{Device.Parent.Name}/Disk{driveNbr}";
+
+		diskController = Device.Parent.DeviceDriver as IDiskControllerDevice;
+		if (diskController == null)
+			Device.Status = DeviceStatus.Error;
 	}
 
 	public override void Probe() => Device.Status = DeviceStatus.Available;
 
 	public override void Start()
 	{
-		TotalBlocks = diskController.GetTotalSectors(DriveNbr);
+		TotalBlocks = diskController.GetTotalSectors(driveNbr);
 
 		if (!readOnly)
-			readOnly = !diskController.CanWrite(DriveNbr);
+			readOnly = !diskController.CanWrite(driveNbr);
 
 		Device.Status = DeviceStatus.Online;
 	}
@@ -81,7 +82,7 @@ public class DiskDeviceDriver : BaseDeviceDriver, IDiskDevice
 	public byte[] ReadBlock(uint block, uint count)
 	{
 		var data = new byte[count * BlockSize];
-		diskController.ReadBlock(DriveNbr, block, count, data);
+		diskController.ReadBlock(driveNbr, block, count, data);
 		return data;
 	}
 
@@ -92,10 +93,7 @@ public class DiskDeviceDriver : BaseDeviceDriver, IDiskDevice
 	/// <param name="count">The count.</param>
 	/// <param name="data">The data.</param>
 	/// <returns></returns>
-	public bool ReadBlock(uint block, uint count, byte[] data)
-	{
-		return diskController.ReadBlock(DriveNbr, block, count, data);
-	}
+	public bool ReadBlock(uint block, uint count, byte[] data) => diskController.ReadBlock(driveNbr, block, count, data);
 
 	/// <summary>
 	/// Writes the block.
@@ -104,8 +102,5 @@ public class DiskDeviceDriver : BaseDeviceDriver, IDiskDevice
 	/// <param name="count">The count.</param>
 	/// <param name="data">The data.</param>
 	/// <returns></returns>
-	public bool WriteBlock(uint block, uint count, byte[] data)
-	{
-		return diskController.WriteBlock(DriveNbr, block, count, data);
-	}
+	public bool WriteBlock(uint block, uint count, byte[] data) => diskController.WriteBlock(driveNbr, block, count, data);
 }

--- a/Source/Mosa.DeviceSystem/GenericPartition.cs
+++ b/Source/Mosa.DeviceSystem/GenericPartition.cs
@@ -11,10 +11,7 @@ public class GenericPartition
 	/// Initializes a new instance of the <see cref="GenericPartition"/> class.
 	/// </summary>
 	/// <param name="index">The index.</param>
-	public GenericPartition(uint index)
-	{
-		this.Index = index;
-	}
+	public GenericPartition(uint index) => Index = index;
 
 	/// <summary>
 	/// Gets or sets a value indicating whether this <see cref="GenericPartition"/> is bootable.
@@ -26,13 +23,6 @@ public class GenericPartition
 	/// Gets the partition index.
 	/// </summary>
 	/// <value>The partition index.</value>
-
-	/* Unmerged change from project 'Mosa.Utility.FileSystem'
-	Before:
-			public uint Index { get { return index; } }
-	After:
-			public uint Index { get; } }
-	*/
 
 	public uint Index { get; private set; }
 

--- a/Source/Mosa.DeviceSystem/HAL.cs
+++ b/Source/Mosa.DeviceSystem/HAL.cs
@@ -11,25 +11,24 @@ namespace Mosa.DeviceSystem;
 public static class HAL
 {
 	/// <summary>
+	/// Interrupt Delegate
+	/// </summary>
+	/// <param name="irq">The irq.</param>
+	public delegate void HandleInterrupt(byte irq);
+
+	public static PlatformArchitecture PlatformArchitecture => hardwareAbstraction.PlatformArchitecture;
+
+	/// <summary>
 	/// The hardware abstraction
 	/// </summary>
 	private static BaseHardwareAbstraction hardwareAbstraction;
-
-	public static PlatformArchitecture PlatformArchitecture => hardwareAbstraction.PlatformArchitecture;
+	private static HandleInterrupt handleInterrupt;
 
 	/// <summary>
 	/// Sets the hardware abstraction.
 	/// </summary>
 	/// <param name="hardwareAbstraction">The hardware abstraction.</param>
 	public static void Set(BaseHardwareAbstraction hardwareAbstraction) => HAL.hardwareAbstraction = hardwareAbstraction;
-
-	/// <summary>
-	/// Interrupt Delegate
-	/// </summary>
-	/// <param name="irq">The irq.</param>
-	public delegate void HandleInterrupt(byte irq);
-
-	private static HandleInterrupt handleInterrupt;
 
 	/// <summary>
 	/// Sets the interrupt handler.
@@ -101,9 +100,7 @@ public static class HAL
 	public static void Assert(bool condition, string message)
 	{
 		if (!condition)
-		{
 			hardwareAbstraction.Abort(message);
-		}
 	}
 
 	/// <summary>

--- a/Source/Mosa.DeviceSystem/HardwareResources.cs
+++ b/Source/Mosa.DeviceSystem/HardwareResources.cs
@@ -10,51 +10,9 @@ namespace Mosa.DeviceSystem;
 public sealed class HardwareResources
 {
 	/// <summary>
-	/// The address regions
-	/// </summary>
-	private readonly List<AddressRegion> addressRegions;
-
-	/// <summary>
-	/// The io port regions
-	/// </summary>
-	private readonly List<IOPortRegion> ioPortRegions;
-
-	/// <summary>
 	/// The irq
 	/// </summary>
 	public byte IRQ { get; }
-
-	/// <summary>
-	/// Initializes a new instance of the <see cref="HardwareResources" /> class.
-	/// </summary>
-	/// <param name="ioPortRegions">The io port regions.</param>
-	/// <param name="addressRegions">The memory regions.</param>
-	public HardwareResources(List<IOPortRegion> ioPortRegions, List<AddressRegion> addressRegions, byte irq = 0)
-	{
-		this.ioPortRegions = ioPortRegions;
-		this.addressRegions = addressRegions;
-		this.IRQ = irq;
-	}
-
-	/// <summary>
-	/// Gets the IO port region.
-	/// </summary>
-	/// <param name="index">The index.</param>
-	/// <returns></returns>
-	public IOPortRegion GetIOPortRegion(byte index)
-	{
-		return ioPortRegions[index];
-	}
-
-	/// <summary>
-	/// Gets the memory region.
-	/// </summary>
-	/// <param name="index">The index.</param>
-	/// <returns></returns>
-	public AddressRegion GetMemoryRegion(byte index)
-	{
-		return addressRegions[index];
-	}
 
 	/// <summary>
 	/// Gets the IO point region count.
@@ -69,15 +27,41 @@ public sealed class HardwareResources
 	public byte AddressRegionCount => (byte)addressRegions.Count;
 
 	/// <summary>
-	/// Gets the IO port.
+	/// The address regions
 	/// </summary>
-	/// <param name="index">The region.</param>
-	/// <param name="offset">The index.</param>
-	/// <returns></returns>
-	public IOPortReadWrite GetIOPortReadWrite(byte index, ushort offset)
+	private readonly List<AddressRegion> addressRegions;
+
+	/// <summary>
+	/// The io port regions
+	/// </summary>
+	private readonly List<IOPortRegion> ioPortRegions;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="HardwareResources" /> class.
+	/// </summary>
+	/// <param name="ioPortRegions">The io port regions.</param>
+	/// <param name="addressRegions">The memory regions.</param>
+	public HardwareResources(List<IOPortRegion> ioPortRegions, List<AddressRegion> addressRegions, byte irq = 0)
 	{
-		return new IOPortReadWrite((ushort)(ioPortRegions[index].BaseIOPort + offset));
+		IRQ = irq;
+
+		this.ioPortRegions = ioPortRegions;
+		this.addressRegions = addressRegions;
 	}
+
+	/// <summary>
+	/// Gets the IO port region.
+	/// </summary>
+	/// <param name="index">The index.</param>
+	/// <returns></returns>
+	public IOPortRegion GetIOPortRegion(byte index) => ioPortRegions[index];
+
+	/// <summary>
+	/// Gets the memory region.
+	/// </summary>
+	/// <param name="index">The index.</param>
+	/// <returns></returns>
+	public AddressRegion GetMemoryRegion(byte index) => addressRegions[index];
 
 	/// <summary>
 	/// Gets the IO port.
@@ -85,10 +69,8 @@ public sealed class HardwareResources
 	/// <param name="index">The region.</param>
 	/// <param name="offset">The index.</param>
 	/// <returns></returns>
-	public IOPortRead GetIOPortRead(byte index, ushort offset)
-	{
-		return new IOPortRead((ushort)(ioPortRegions[index].BaseIOPort + offset));
-	}
+	public IOPortReadWrite GetIOPortReadWrite(byte index, ushort offset) =>
+		new IOPortReadWrite((ushort)(ioPortRegions[index].BaseIOPort + offset));
 
 	/// <summary>
 	/// Gets the IO port.
@@ -96,18 +78,23 @@ public sealed class HardwareResources
 	/// <param name="index">The region.</param>
 	/// <param name="offset">The index.</param>
 	/// <returns></returns>
-	public IOPortWrite GetIOPortWrite(byte index, ushort offset)
-	{
-		return new IOPortWrite((ushort)(ioPortRegions[index].BaseIOPort + offset));
-	}
+	public IOPortRead GetIOPortRead(byte index, ushort offset) =>
+		new IOPortRead((ushort)(ioPortRegions[index].BaseIOPort + offset));
+
+	/// <summary>
+	/// Gets the IO port.
+	/// </summary>
+	/// <param name="index">The region.</param>
+	/// <param name="offset">The index.</param>
+	/// <returns></returns>
+	public IOPortWrite GetIOPortWrite(byte index, ushort offset) =>
+		new IOPortWrite((ushort)(ioPortRegions[index].BaseIOPort + offset));
 
 	/// <summary>
 	/// Gets the memory.
 	/// </summary>
 	/// <param name="region">The region.</param>
 	/// <returns></returns>
-	public ConstrainedPointer GetMemory(byte region)
-	{
-		return HAL.GetPhysicalMemory(addressRegions[region].Address, addressRegions[region].Size);
-	}
+	public ConstrainedPointer GetMemory(byte region) =>
+		HAL.GetPhysicalMemory(addressRegions[region].Address, addressRegions[region].Size);
 }

--- a/Source/Mosa.DeviceSystem/IOPort.cs
+++ b/Source/Mosa.DeviceSystem/IOPort.cs
@@ -4,7 +4,7 @@ namespace Mosa.DeviceSystem;
 
 public struct IOPortRead
 {
-	public ushort Address { get; private set; }
+	public ushort Address { get; }
 
 	public IOPortRead(ushort address) => Address = address;
 
@@ -17,7 +17,7 @@ public struct IOPortRead
 
 public struct IOPortWrite
 {
-	public ushort Address { get; private set; }
+	public ushort Address { get; }
 
 	public IOPortWrite(ushort address) => Address = address;
 
@@ -30,12 +30,9 @@ public struct IOPortWrite
 
 public struct IOPortReadWrite
 {
-	public ushort Address { get; private set; }
+	public ushort Address { get; }
 
-	public IOPortReadWrite(ushort address)
-	{
-		Address = address;
-	}
+	public IOPortReadWrite(ushort address) => Address = address;
 
 	public byte Read8() => HAL.In8(Address);
 

--- a/Source/Mosa.DeviceSystem/MouseState.cs
+++ b/Source/Mosa.DeviceSystem/MouseState.cs
@@ -4,5 +4,7 @@ namespace Mosa.DeviceSystem;
 
 public enum MouseState
 {
-	None = 0, Left, Right
+	None,
+	Left,
+	Right
 }

--- a/Source/Mosa.DeviceSystem/ServiceManager.cs
+++ b/Source/Mosa.DeviceSystem/ServiceManager.cs
@@ -10,20 +10,19 @@ namespace Mosa.DeviceSystem;
 /// </summary>
 public sealed class ServiceManager
 {
-	private readonly List<BaseService> Services = new List<BaseService>();
-	private readonly List<ServiceEvent> Events = new List<ServiceEvent>();
+	public List<BaseService> Services { get; } = new List<BaseService>();
 
-	public readonly object lockServices = new object();
-	public readonly object lockEvents = new object();
+	public List<ServiceEvent> Events { get; } = new List<ServiceEvent>();
+
+	private readonly object lockServices = new object();
+	private readonly object lockEvents = new object();
 
 	public void AddService(BaseService service)
 	{
 		HAL.DebugWriteLine("ServiceManager:AddService()");
 
 		lock (lockServices)
-		{
 			Services.Add(service);
-		}
 
 		service.Start(this);
 
@@ -35,9 +34,7 @@ public sealed class ServiceManager
 		HAL.DebugWriteLine("ServiceManager:AddEvent()");
 
 		lock (lockEvents)
-		{
 			Events.Add(serviceEvent);
-		}
 
 		SendEvents();
 
@@ -49,15 +46,9 @@ public sealed class ServiceManager
 		var list = new List<T>();
 
 		lock (lockServices)
-		{
 			foreach (var service in Services)
-			{
 				if (service is T s)
-				{
 					list.Add(s);
-				}
-			}
-		}
 
 		return list;
 	}
@@ -65,15 +56,9 @@ public sealed class ServiceManager
 	public T GetFirstService<T>() where T : BaseService
 	{
 		lock (lockServices)
-		{
 			foreach (var service in Services)
-			{
 				if (service is T s)
-				{
 					return s;
-				}
-			}
-		}
 
 		return null;
 	}
@@ -85,9 +70,7 @@ public sealed class ServiceManager
 			var list = new List<BaseService>(Services.Count);
 
 			foreach (var service in Services)
-			{
 				list.Add(service);
-			}
 
 			return list;
 		}

--- a/Source/Mosa.DeviceSystem/Services/DiskDeviceService.cs
+++ b/Source/Mosa.DeviceSystem/Services/DiskDeviceService.cs
@@ -23,7 +23,7 @@ public class DiskDeviceService : BaseService
 
 		var deviceService = device.DeviceService;
 
-		for (uint drive = 0; drive < controller.MaximunDriveCount; drive++)
+		for (var drive = 0U; drive < controller.MaximunDriveCount; drive++)
 		{
 			if (!controller.Open(drive))
 				continue;


### PR DESCRIPTION
This PR mainly focuses on code style refactorings. The following were done:
- Fold functions with only one statement or expression into one-line
- Fold statements and expressions with empty blocks into one-line
- Trailing commas were removed (e.g. in enums)
- Use pattern matching wherever possible
- Braces were removed in blocks that only had one expression (which was put on a new line if not already)
- The "this" reference has been removed in places where it wasn't needed
- The "var" type inference for variables was used in more places were adequate (e.g. it didn't require casting)
- Fields and functions were reordered when needed, so that private ones are always after public ones
- In adequate places, fields were made public and/or into properties (to better indicate that there's an API)
- Some function arguments were renamed if they were pointlessly too long
- Ternary operators were used wherever possible
- String interpolation was used instead of string concatenation wherever possible
- Fields were renamed if they didn't respect the naming conventions
- Fields were made into auto properties wherever possible
- Protected fields were made private wherever possible
- Useless enum values were removed

More specific code style refactorings were also done:
- In MasterBootBlock:
    - The diskDevice field was made readonly
    - The Partitions field was made into a property
    - The data field was made private, and the masterboot field was renamed to DataBlock (and made a property)
- In IOPort, the Address property was made get-only (previously it had both get and private set accesors) since it was useless (it was only set from the constructor which doesn't require the set accessor)
- In BaseService, the SERVICE generic type in the MatchEvent function was renamed to TService to fit naming conventions
- In ServiceManager, the Services and Events fields were made public (and properties), while the lockServices and lockEvents ones were made private