### PR TITLE
Mosa.DeviceDriver: code style refactoring

### DIFF
--- a/Source/Mosa.DeviceDriver/ISA/ACPI/ACPIDriver.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/ACPIDriver.cs
@@ -45,17 +45,13 @@ public unsafe class ACPIDriver : BaseDeviceDriver, IACPI
 	public override void Initialize()
 	{
 		Device.Name = "ACPI";
+		//Setup();
 	}
 
 	/// <summary>
 	/// Probes this instance.
 	/// </summary>
-	public override void Probe()
-	{
-		//Device.Status = DeviceStatus.Available;
-		Device.Status = DeviceStatus.Offline;
-		//Setup();
-	}
+	public override void Probe() => Device.Status = DeviceStatus.Offline; // Future: Should be "Available"
 
 	/// <summary>
 	/// Starts this hardware device.
@@ -216,6 +212,6 @@ public unsafe class ACPIDriver : BaseDeviceDriver, IACPI
 		return Pointer.Zero;
 	}
 
-	private static int CalculateSignatureValue(string signature)
-		=> ((byte)signature[0] & 0xFF) | (((byte)signature[1] & 0xFF) << 8) | (((byte)signature[2] & 0xFF) << 16) | (((byte)signature[3] & 0xFF) << 24);
+	private static int CalculateSignatureValue(string signature) =>
+		((byte)signature[0] & 0xFF) | (((byte)signature[1] & 0xFF) << 8) | (((byte)signature[2] & 0xFF) << 16) | (((byte)signature[3] & 0xFF) << 24);
 }

--- a/Source/Mosa.DeviceDriver/ISA/IDEController.cs
+++ b/Source/Mosa.DeviceDriver/ISA/IDEController.cs
@@ -23,14 +23,14 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 	/// <summary>
 	/// IDE Command
 	/// </summary>
-	internal struct IDECommand
+	private struct IDECommand
 	{
 		internal const byte ReadSectorsWithRetry = 0x20;
 		internal const byte WriteSectorsWithRetry = 0x30;
 		internal const byte IdentifyDrive = 0xEC;
 	}
 
-	internal struct StatusRegister
+	private struct StatusRegister
 	{
 		internal const byte Busy = 1 << 7;
 		internal const byte DriveReady = 1 << 6;
@@ -45,7 +45,7 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 	/// <summary>
 	/// Identify Drive
 	/// </summary>
-	internal struct IdentifyDrive
+	private struct IdentifyDrive
 	{
 		internal const uint GeneralConfig = 0x00;
 		internal const uint LogicalCylinders = 0x02;
@@ -68,81 +68,85 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 	/// <summary>
 	/// The drives per controller
 	/// </summary>
-	public const uint DrivesPerConroller = 2; // the maximum supported
+	public const uint DrivesPerController = 2; // The maximum supported
 
 	/// <summary>
 	/// The data port
 	/// </summary>
-	protected IOPortReadWrite DataPort;
+	private IOPortReadWrite dataPort;
 
 	/// <summary>
 	/// The feature port
 	/// </summary>
-	protected IOPortReadWrite FeaturePort;
+	private IOPortReadWrite featurePort;
 
 	/// <summary>
 	/// The error port
 	/// </summary>
-	protected IOPortRead ErrorPort;
+	private IOPortRead errorPort;
 
 	/// <summary>
 	/// The sector count port
 	/// </summary>
-	protected IOPortReadWrite SectorCountPort;
+	private IOPortReadWrite sectorCountPort;
 
 	/// <summary>
 	/// The lba low port
 	/// </summary>
-	protected IOPortReadWrite LBALowPort;
+	private IOPortReadWrite lbaLowPort;
 
 	/// <summary>
 	/// The lba mid port
 	/// </summary>
-	protected IOPortReadWrite LBAMidPort;
+	private IOPortReadWrite lbaMidPort;
 
 	/// <summary>
 	/// The lba high port
 	/// </summary>
-	protected IOPortReadWrite LBAHighPort;
+	private IOPortReadWrite lbaHighPort;
 
 	/// <summary>
 	/// The device head port
 	/// </summary>
-	protected IOPortReadWrite DeviceHeadPort;
+	private IOPortReadWrite deviceHeadPort;
 
 	/// <summary>
 	/// The status port
 	/// </summary>
-	protected IOPortRead StatusPort;
+	private IOPortRead statusPort;
 
 	/// <summary>
 	/// The command port
 	/// </summary>
-	protected IOPortWrite CommandPort;
+	private IOPortWrite commandPort;
 
 	/// <summary>
 	/// The bus control register port
 	/// </summary>
-	protected IOPortWrite ControlPort;
+	private IOPortWrite controlPort;
 
 	/// <summary>
 	/// The status port
 	/// </summary>
-	protected IOPortRead AltStatusPort;
+	private IOPortRead altStatusPort;
 
-	/// <summary>
-	/// Gets the maximum drive count.
-	/// </summary>
-	/// <value>The drive count.</value>
-	public uint MaximumDriveCount { get; private set; }
+	private enum AddressingMode
+	{
+		NotSupported,
+		LBA28,
+		LBA48
+	}
 
-	public enum AddressingMode
-	{ NotSupported, LBA28, LBA48 }
+	private enum SectorOperation
+	{
+		Read,
+		Write
+	}
 
 	/// <summary>
 	/// Drive Info
 	/// </summary>
-	protected struct DriveInfo
+	private struct DriveInfo
 	{
 		/// <summary>
 		/// The present
@@ -163,29 +167,29 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 	/// <summary>
 	/// The drive information
 	/// </summary>
-	protected DriveInfo[] driveInfo = new DriveInfo[DrivesPerConroller];
+	private readonly DriveInfo[] driveInfo = new DriveInfo[DrivesPerController];
 
 	public override void Initialize()
 	{
 		Device.Name = "IDE_0x" + Device.Resources.IOPortRegions[0].BaseIOPort.ToString("X");
 		Device.ComponentID = Device.Resources.IOPortRegions[0].BaseIOPort;
 
-		DataPort = Device.Resources.GetIOPortReadWrite(0, 0);
-		ErrorPort = Device.Resources.GetIOPortRead(0, 1);
-		FeaturePort = Device.Resources.GetIOPortReadWrite(0, 1);
-		SectorCountPort = Device.Resources.GetIOPortReadWrite(0, 2);
-		LBALowPort = Device.Resources.GetIOPortReadWrite(0, 3);
-		LBAMidPort = Device.Resources.GetIOPortReadWrite(0, 4);
-		LBAHighPort = Device.Resources.GetIOPortReadWrite(0, 5);
-		DeviceHeadPort = Device.Resources.GetIOPortReadWrite(0, 6);
-		CommandPort = Device.Resources.GetIOPortWrite(0, 7);
-		StatusPort = Device.Resources.GetIOPortRead(0, 7);
-		ControlPort = Device.Resources.GetIOPortWrite(1, 0);
-		AltStatusPort = Device.Resources.GetIOPortRead(1, 6);
+		dataPort = Device.Resources.GetIOPortReadWrite(0, 0);
+		errorPort = Device.Resources.GetIOPortRead(0, 1);
+		featurePort = Device.Resources.GetIOPortReadWrite(0, 1);
+		sectorCountPort = Device.Resources.GetIOPortReadWrite(0, 2);
+		lbaLowPort = Device.Resources.GetIOPortReadWrite(0, 3);
+		lbaMidPort = Device.Resources.GetIOPortReadWrite(0, 4);
+		lbaHighPort = Device.Resources.GetIOPortReadWrite(0, 5);
+		deviceHeadPort = Device.Resources.GetIOPortReadWrite(0, 6);
+		commandPort = Device.Resources.GetIOPortWrite(0, 7);
+		statusPort = Device.Resources.GetIOPortRead(0, 7);
+		controlPort = Device.Resources.GetIOPortWrite(1, 0);
+		altStatusPort = Device.Resources.GetIOPortRead(1, 6);
 
 		MaximumDriveCount = 2;
 
-		for (var drive = 0; drive < DrivesPerConroller; drive++)
+		for (var drive = 0; drive < DrivesPerController; drive++)
 		{
 			driveInfo[drive].Present = false;
 			driveInfo[drive].MaxLBA = 0;
@@ -194,21 +198,18 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 
 	public override void Probe()
 	{
-		LBALowPort.Write8(0x88);
-
-		var found = LBALowPort.Read8() == 0x88;
+		lbaLowPort.Write8(0x88);
+		var found = lbaLowPort.Read8() == 0x88;
 
 		Device.Status = found ? DeviceStatus.Available : DeviceStatus.NotFound;
 	}
 
 	public override void Start()
 	{
-		ControlPort.Write8(0);
+		controlPort.Write8(0);
 
 		for (byte drive = 0; drive < MaximumDriveCount; drive++)
-		{
 			DoIdentifyDrive(drive);
-		}
 
 		Device.Status = DeviceStatus.Online;
 	}
@@ -218,67 +219,52 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 		driveInfo[index].Present = false;
 
 		//Send the identify command to the selected drive
-		DeviceHeadPort.Write8((byte)(index == 0 ? 0xA0 : 0xB0));
-		SectorCountPort.Write8(0);
-		LBALowPort.Write8(0);
-		LBAMidPort.Write8(0);
-		LBAHighPort.Write8(0);
-		CommandPort.Write8(IDECommand.IdentifyDrive);
+		deviceHeadPort.Write8((byte)(index == 0 ? 0xA0 : 0xB0));
+		sectorCountPort.Write8(0);
+		lbaLowPort.Write8(0);
+		lbaMidPort.Write8(0);
+		lbaHighPort.Write8(0);
+		commandPort.Write8(IDECommand.IdentifyDrive);
 
-		if (StatusPort.Read8() == 0)
-		{
-			//Drive doesn't exist
-			return;
-		}
+		if (statusPort.Read8() == 0)
+			return; // Drive doesn't exist
 
-		//Wait until a ready status is present
+		// Wait until a ready status is present
 		if (!WaitForReadyStatus())
-		{
-			return; //There's no ready status, this drive doesn't exist
-		}
+			return; // There's no ready status, this drive doesn't exist
 
-		if (LBAMidPort.Read8() != 0 && LBAHighPort.Read8() != 0) //Check if the drive is ATA
-		{
-			//In this case the drive is ATAPI
-			//HAL.DebugWriteLine("Device " + index.ToString() + " not ATA");
-			return;
-		}
+		// Check if the drive is ATA
+		if (lbaMidPort.Read8() != 0 && lbaHighPort.Read8() != 0)
+			return; // In this case the drive is ATAPI
 
-		//Wait until the identify data is present (256x16 bits)
+		// Wait until the identify data is present (256x16 bits)
 		if (!WaitForIdentifyData())
-		{
-			//HAL.DebugWriteLine("Device " + index.ToString() + " ID error");
-			return;
-		}
+			return; // ID Error
 
-		//An ATA drive is present
+		// An ATA drive is present
 		driveInfo[index].Present = true;
 
-		//Read the identification info
+		// Read the identification info
 		var info = new DataBlock(512);
-		for (uint ix = 0; ix < 256; ix++)
-		{
-			info.SetUShort(ix * 2, DataPort.Read16());
-		}
+		for (var ix = 0U; ix < 256; ix++)
+			info.SetUShort(ix * 2, dataPort.Read16());
 
-		//Find the addressing mode
+		// Find the addressing mode
 		var lba28SectorCount = info.GetUInt32(IdentifyDrive.MaxLBA28);
 
 		AddressingMode aMode = AddressingMode.NotSupported;
-		if ((info.GetUShort(IdentifyDrive.CommandSetSupported83) & 0x200) == 0x200) //Check the LBA48 support bit
+		if ((info.GetUShort(IdentifyDrive.CommandSetSupported83) & 0x200) == 0x200) // Check the LBA48 support bit
 		{
 			aMode = AddressingMode.LBA48;
 			driveInfo[index].MaxLBA = info.GetUInt32(IdentifyDrive.MaxLBA48);
 		}
-		else if (lba28SectorCount > 0) //LBA48 not supported, check LBA28
+		else if (lba28SectorCount > 0) // LBA48 not supported, check LBA28
 		{
 			aMode = AddressingMode.LBA28;
 			driveInfo[index].MaxLBA = lba28SectorCount;
 		}
 
 		driveInfo[index].AddressingMode = aMode;
-
-		//HAL.DebugWriteLine("Device " + index.ToString() + " present - MaxLBA=" + driveInfo[index].MaxLBA.ToString());
 	}
 
 	/// <summary>
@@ -296,13 +282,13 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 		byte status;
 		do
 		{
-			status = StatusPort.Read8();
+			status = statusPort.Read8();
 		}
 		while ((status & StatusRegister.Busy) == StatusRegister.Busy);
 
 		return true;
 
-		//TODO: Timeout -> return false
+		// TODO: Timeout -> return false
 	}
 
 	/// <summary>
@@ -314,7 +300,7 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 		byte status;
 		do
 		{
-			status = StatusPort.Read8();
+			status = statusPort.Read8();
 		}
 		while ((status & StatusRegister.DataRequest) != StatusRegister.DataRequest && (status & StatusRegister.Error) != StatusRegister.Error);
 
@@ -327,8 +313,7 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 	/// <returns>True if the cache flush command is successful, false if not.</returns>
 	private bool DoCacheFlush()
 	{
-		CommandPort.Write8(0xE7);
-
+		commandPort.Write8(0xE7);
 		return WaitForReadyStatus();
 	}
 
@@ -337,18 +322,7 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 	/// </summary>
 	/// <param name="drive">The drive.</param>
 	/// <returns></returns>
-	public bool Open(uint drive)
-	{
-		//HAL.DebugWriteLine("Open()" + drive.ToString() + " : " + MaximumDriveCount.ToString() + " : " + (driveInfo[drive].Present ? "Y" : "N"));
-
-		if (drive >= MaximumDriveCount || !driveInfo[drive].Present)
-			return false;
-
-		return true;
-	}
-
-	protected enum SectorOperation
-	{ Read, Write }
+	public bool Open(uint drive) => drive < MaximumDriveCount && driveInfo[drive].Present;
 
 	/// <summary>
 	/// Performs the LBA28.
@@ -359,42 +333,37 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 	/// <param name="data">The data.</param>
 	/// <param name="offset">The offset.</param>
 	/// <returns></returns>
-	protected bool PerformLBA28(SectorOperation operation, uint drive, uint lba, byte[] data, uint offset)
+	private bool PerformLBA28(SectorOperation operation, uint drive, uint lba, byte[] data, uint offset)
 	{
 		if (drive >= MaximumDriveCount || !driveInfo[drive].Present)
 			return false;
 
-		DeviceHeadPort.Write8((byte)(0xE0 | (drive << 4) | ((lba >> 24) & 0x0F)));
-		FeaturePort.Write8(0);
-		SectorCountPort.Write8(1);
-		LBAHighPort.Write8((byte)((lba >> 16) & 0xFF));
-		LBAMidPort.Write8((byte)((lba >> 8) & 0xFF));
-		LBALowPort.Write8((byte)(lba & 0xFF));
+		deviceHeadPort.Write8((byte)(0xE0 | (drive << 4) | ((lba >> 24) & 0x0F)));
+		featurePort.Write8(0);
+		sectorCountPort.Write8(1);
+		lbaHighPort.Write8((byte)((lba >> 16) & 0xFF));
+		lbaMidPort.Write8((byte)((lba >> 8) & 0xFF));
+		lbaLowPort.Write8((byte)(lba & 0xFF));
 
-		CommandPort.Write8(operation == SectorOperation.Write ? IDECommand.WriteSectorsWithRetry : IDECommand.ReadSectorsWithRetry);
+		commandPort.Write8(operation == SectorOperation.Write ? IDECommand.WriteSectorsWithRetry : IDECommand.ReadSectorsWithRetry);
 
 		if (!WaitForReadyStatus())
 			return false;
 
 		var sector = new DataBlock(data);
 
-		//TODO: Don't use PIO
 		if (operation == SectorOperation.Read)
 		{
-			for (uint index = 0; index < 256; index++)
-			{
-				sector.SetUShort(offset + index * 2, DataPort.Read16());
-			}
+			for (var index = 0U; index < 256; index++)
+				sector.SetUShort(offset + index * 2, dataPort.Read16());
 		}
 		else
 		{
-			//NOTE: Transferring 16bits at a time seems to fail(?) to write each second 16bits - transferring 32bits seems to fix this (???)
-			for (uint index = 0; index < 128; index++)
-			{
-				DataPort.Write32(sector.GetUInt32(offset + index * 4));
-			}
+			// NOTE: Transferring 16bits at a time seems to fail(?) to write each second 16bits - transferring 32bits seems to fi
+			// this (???)
+			for (var index = 0U; index < 128; index++)
+				dataPort.Write32(sector.GetUInt32(offset + index * 4));
 
-			//Cache flush
 			DoCacheFlush();
 		}
 
@@ -410,47 +379,46 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 	/// <param name="data">The data.</param>
 	/// <param name="offset">The offset.</param>
 	/// <returns></returns>
-	protected bool PerformLBA48(SectorOperation operation, uint drive, uint lba, byte[] data, uint offset)
+	private bool PerformLBA48(SectorOperation operation, uint drive, uint lba, byte[] data, uint offset)
 	{
 		if (drive >= MaximumDriveCount || !driveInfo[drive].Present)
 			return false;
 
-		DeviceHeadPort.Write8((byte)(0x40 | (drive << 4)));
-		SectorCountPort.Write8(0);
+		deviceHeadPort.Write8((byte)(0x40 | (drive << 4)));
+		sectorCountPort.Write8(0);
 
-		LBALowPort.Write8((byte)((lba >> 24) & 0xFF));
-		LBAMidPort.Write8((byte)((lba >> 32) & 0xFF));
-		LBAHighPort.Write8((byte)((lba >> 40) & 0xFF));
+		lbaLowPort.Write8((byte)((lba >> 24) & 0xFF));
+		lbaMidPort.Write8((byte)((lba >> 32) & 0xFF));
+		lbaHighPort.Write8((byte)((lba >> 40) & 0xFF));
 
-		SectorCountPort.Write8(1);
+		sectorCountPort.Write8(1);
 
-		LBALowPort.Write8((byte)(lba & 0xFF));
-		LBAMidPort.Write8((byte)((lba >> 8) & 0xFF));
-		LBAHighPort.Write8((byte)((lba >> 16) & 0xFF));
+		lbaLowPort.Write8((byte)(lba & 0xFF));
+		lbaMidPort.Write8((byte)((lba >> 8) & 0xFF));
+		lbaHighPort.Write8((byte)((lba >> 16) & 0xFF));
 
-		FeaturePort.Write8(0);
-		FeaturePort.Write8(0);
+		featurePort.Write8(0);
+		featurePort.Write8(0);
 
-		CommandPort.Write8((byte)(operation == SectorOperation.Write ? 0x34 : 0x24));
+		commandPort.Write8((byte)(operation == SectorOperation.Write ? 0x34 : 0x24));
 
 		if (!WaitForReadyStatus())
 			return false;
 
 		var sector = new DataBlock(data);
 
-		//TODO: Don't use PIO
 		if (operation == SectorOperation.Read)
 		{
-			for (uint index = 0; index < 256; index++)
+			for (var index = 0U; index < 256; index++)
 			{
-				sector.SetUShort(offset + index * 2, DataPort.Read16());
+				sector.SetUShort(offset + index * 2, dataPort.Read16());
 			}
 		}
 		else
 		{
-			for (uint index = 0; index < 128; index++)
+			for (var index = 0U; index < 128; index++)
 			{
-				DataPort.Write32(sector.GetUInt32(offset + index * 4));
+				dataPort.Write32(sector.GetUInt32(offset + index * 4));
 			}
 
 			//Cache flush
@@ -461,6 +429,12 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 	}
 
 	#region IDiskControllerDevice
+
+	/// <summary>
+	/// Gets the maximum drive count.
+	/// </summary>
+	/// <value>The drive count.</value>
+	public uint MaximumDriveCount { get; private set; }
 
 	/// <summary>
 	/// Releases the specified drive.
@@ -481,13 +455,7 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 	/// </summary>
 	/// <param name="drive">The drive NBR.</param>
 	/// <returns></returns>
-	public uint GetTotalSectors(uint drive)
-	{
-		if (drive >= MaximumDriveCount || !driveInfo[drive].Present)
-			return 0;
-
-		return driveInfo[drive].MaxLBA;
-	}
+	public uint GetTotalSectors(uint drive) => drive >= MaximumDriveCount || !driveInfo[drive].Present ? 0 : driveInfo[drive].MaxLBA;
 
 	/// <summary>
 	/// Determines whether this instance can write to the specified drive.
@@ -496,11 +464,7 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 	/// <returns>
 	/// 	<c>true</c> if this instance can write to the specified drive; otherwise, <c>false</c>.
 	/// </returns>
-	public bool CanWrite(uint drive)
-	{
-		// TODO
-		return true;
-	}
+	public bool CanWrite(uint drive) => true; // TODO
 
 	/// <summary>
 	/// Reads the block.
@@ -520,8 +484,7 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 
 		lock (DriverLock)
 		{
-			for (uint index = 0; index < count; index++)
-			{
+			for (var index = 0U; index < count; index++)
 				switch (driveInfo[drive].AddressingMode)
 				{
 					case AddressingMode.LBA28:
@@ -531,7 +494,6 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 
 							break;
 						}
-
 					case AddressingMode.LBA48:
 						{
 							if (!PerformLBA48(SectorOperation.Read, drive, block + index, data, index * 512))
@@ -540,7 +502,7 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 							break;
 						}
 				}
-			}
+
 			return true;
 		}
 	}
@@ -563,25 +525,25 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 
 		lock (DriverLock)
 		{
-			for (uint index = 0; index < count; index++)
-			{
+			for (var index = 0U; index < count; index++)
 				switch (driveInfo[drive].AddressingMode)
 				{
 					case AddressingMode.LBA28:
-						if (!PerformLBA28(SectorOperation.Write, drive, block + index, data, index * 512))
 						{
-							return false;
-						}
-						break;
+							if (!PerformLBA28(SectorOperation.Write, drive, block + index, data, index * 512))
+								return false;
 
-					case AddressingMode.LBA48:
-						if (!PerformLBA48(SectorOperation.Write, drive, block + index, data, index * 512))
-						{
-							return false;
+							break;
 						}
-						break;
+					case AddressingMode.LBA48:
+						{
+							if (!PerformLBA48(SectorOperation.Write, drive, block + index, data, index * 512))
+								return false;
+
+							break;
+						}
 				}
-			}
+
 			return true;
 		}
 	}

--- a/Source/Mosa.DeviceDriver/ISA/PCIController.cs
+++ b/Source/Mosa.DeviceDriver/ISA/PCIController.cs
@@ -43,7 +43,6 @@ public sealed class PCIController : BaseDeviceDriver, IPCIControllerLegacy, IPCI
 	public override void Probe()
 	{
 		configAddress.Write32(BaseValue);
-
 		var found = configAddress.Read32() == BaseValue;
 
 		Device.Status = found ? DeviceStatus.Available : DeviceStatus.NotFound;
@@ -52,9 +51,7 @@ public sealed class PCIController : BaseDeviceDriver, IPCIControllerLegacy, IPCI
 	public override void Start()
 	{
 		if (Device.Status == DeviceStatus.Available)
-		{
 			Device.Status = DeviceStatus.Online;
-		}
 	}
 
 	/// <summary>
@@ -80,7 +77,7 @@ public sealed class PCIController : BaseDeviceDriver, IPCIControllerLegacy, IPCI
 			   | (uint)(register & 0xFC);
 	}
 
-	#region IPCIController
+	#region IPCIControllerLegacy
 
 	/// <summary>
 	/// Reads from configuration space
@@ -166,9 +163,9 @@ public sealed class PCIController : BaseDeviceDriver, IPCIControllerLegacy, IPCI
 		configData.Write8(value);
 	}
 
-	#endregion IPCIController
+	#endregion IPCIControllerLegacy
 
-	#region IPCIController v2
+	#region IPCIController
 
 	/// <summary>
 	/// Reads from configuration space
@@ -242,5 +239,5 @@ public sealed class PCIController : BaseDeviceDriver, IPCIControllerLegacy, IPCI
 		configData.Write8(value);
 	}
 
-	#endregion IPCIController v2
+	#endregion IPCIController
 }

--- a/Source/Mosa.DeviceDriver/ISA/StandardMouse.cs
+++ b/Source/Mosa.DeviceDriver/ISA/StandardMouse.cs
@@ -141,24 +141,20 @@ public class StandardMouse : BaseDeviceDriver, IMouseDevice
 
 	private void Wait(byte type)
 	{
-		int timeOut = 100000;
+		var timeout = 100000;
 
 		if (type == 0)
 		{
-			for (; timeOut > 0; timeOut--)
+			for (; timeout > 0; timeout--)
 				if ((command.Read8() & 1) == 1)
 					return;
 
 			return;
 		}
-		else
-		{
-			for (; timeOut > 0; timeOut--)
-				if ((command.Read8() & 2) == 0)
-					return;
 
-			return;
-		}
+		for (; timeout > 0; timeout--)
+			if ((command.Read8() & 2) == 0)
+				return;
 	}
 
 	private void WriteRegister(byte value)

--- a/Source/Mosa.DeviceDriver/PCI/GenericHostBridgeController.cs
+++ b/Source/Mosa.DeviceDriver/PCI/GenericHostBridgeController.cs
@@ -14,10 +14,7 @@ public class GenericHostBridgeController : BaseDeviceDriver, IHostBridgeControll
 	private byte resetAddress;
 	private byte resetValue;
 
-	public override void Initialize()
-	{
-		Device.Name = "GenericHostBridgeController";
-	}
+	public override void Initialize() => Device.Name = "GenericHostBridgeController";
 
 	public override void Probe() => Device.Status = DeviceStatus.Available;
 

--- a/Source/Mosa.DeviceDriver/PCI/Intel/Intel440FX.cs
+++ b/Source/Mosa.DeviceDriver/PCI/Intel/Intel440FX.cs
@@ -1,19 +1,14 @@
 ﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
 
-
+namespace Mosa.DeviceDriver.PCI.Intel;
 
 // Intel® 440FX PCIset 82441FX (PMC) and 82442FX (DBX)
-// http://download.intel.com/design/chipsets/specupdt/29765406.pdf
-
-namespace Mosa.DeviceDriver.PCI.Intel;
+//http://download.intel.com/design/chipsets/specupdt/29765406.pdf
 
 /// <summary>
 /// </summary>
 //[PCIDeviceDriver(VendorID = 0x8086, DeviceID = 0x1237, Platforms = PlatformArchitecture.X86AndX64)]
 public class Intel440FX : GenericHostBridgeController
 {
-	public override void Initialize()
-	{
-		Device.Name = "Intel440FX";
-	}
+	public override void Initialize() => Device.Name = "Intel440FX";
 }

--- a/Source/Mosa.DeviceDriver/PCI/Intel/Intel4SeriesChipsetDRAMController.cs
+++ b/Source/Mosa.DeviceDriver/PCI/Intel/Intel4SeriesChipsetDRAMController.cs
@@ -9,8 +9,5 @@ namespace Mosa.DeviceDriver.PCI.Intel;
 /// </summary>
 public class Intel4SeriesChipsetDRAMController : BaseDeviceDriver
 {
-	public override void Initialize()
-	{
-		Device.Name = "Intel4SeriesChipsetDRAMController";
-	}
+	public override void Initialize() => Device.Name = "Intel4SeriesChipsetDRAMController";
 }

--- a/Source/Mosa.DeviceDriver/PCI/Intel/Intel4SeriesChipsetIntegratedGraphicsController.cs
+++ b/Source/Mosa.DeviceDriver/PCI/Intel/Intel4SeriesChipsetIntegratedGraphicsController.cs
@@ -9,8 +9,5 @@ namespace Mosa.DeviceDriver.PCI.Intel;
 /// </summary>
 public class Intel4SeriesChipsetIntegratedGraphicsController : BaseDeviceDriver
 {
-	public override void Initialize()
-	{
-		Device.Name = "Intel4SeriesChipsetIntegratedGraphicsController";
-	}
+	public override void Initialize() => Device.Name = "Intel4SeriesChipsetIntegratedGraphicsController";
 }

--- a/Source/Mosa.DeviceDriver/PCI/Intel/Intel4SeriesChipsetIntegratedGraphicsController2E13.cs
+++ b/Source/Mosa.DeviceDriver/PCI/Intel/Intel4SeriesChipsetIntegratedGraphicsController2E13.cs
@@ -9,8 +9,5 @@ namespace Mosa.DeviceDriver.PCI.Intel;
 /// </summary>
 public class Intel4SeriesChipsetIntegratedGraphicsController2E13 : BaseDeviceDriver
 {
-	public override void Initialize()
-	{
-		Device.Name = "Intel4SeriesChipsetIntegratedGraphicsController2E13";
-	}
+	public override void Initialize() => Device.Name = "Intel4SeriesChipsetIntegratedGraphicsController2E13";
 }

--- a/Source/Mosa.DeviceDriver/PCI/Intel/Intel4SeriesChipsetPCIExpressRootPort.cs
+++ b/Source/Mosa.DeviceDriver/PCI/Intel/Intel4SeriesChipsetPCIExpressRootPort.cs
@@ -9,8 +9,5 @@ namespace Mosa.DeviceDriver.PCI.Intel;
 /// </summary>
 public class Intel4SeriesChipsetPCIExpressRootPort : BaseDeviceDriver
 {
-	public override void Initialize()
-	{
-		Device.Name = "Intel4SeriesChipsetPCIExpressRootPort";
-	}
+	public override void Initialize() => Device.Name = "Intel4SeriesChipsetPCIExpressRootPort";
 }

--- a/Source/Mosa.DeviceDriver/PCI/Intel/IntelPIIX3.cs
+++ b/Source/Mosa.DeviceDriver/PCI/Intel/IntelPIIX3.cs
@@ -2,18 +2,15 @@
 
 using Mosa.DeviceSystem.Framework;
 
-// PCI ISA IDE Xcelerator (PIIX3)
-// http://download.intel.com/design/intarch/datashts/29055002.pdf
-
 namespace Mosa.DeviceDriver.PCI.Intel;
+
+// PCI ISA IDE Xcelerator (PIIX3)
+//http://download.intel.com/design/intarch/datashts/29055002.pdf
 
 /// <summary>
 /// </summary>
 //[PCIDeviceDriver(VendorID = 0x8086, DeviceID = 0x7000, Platforms = PlatformArchitecture.X86AndX64)]
 public class IntelPIIX3 : BaseDeviceDriver
 {
-	public override void Initialize()
-	{
-		Device.Name = "IntelPIIX3";
-	}
+	public override void Initialize() => Device.Name = "IntelPIIX3";
 }

--- a/Source/Mosa.DeviceDriver/PCI/Intel/IntelPIIX4.cs
+++ b/Source/Mosa.DeviceDriver/PCI/Intel/IntelPIIX4.cs
@@ -2,18 +2,15 @@
 
 using Mosa.DeviceSystem.Framework;
 
-// PCI ISA IDE Xcelerator (PIIX4)
-// http://www.intel.com/assets/pdf/datasheet/290562.pdf
-
 namespace Mosa.DeviceDriver.PCI.Intel;
+
+// PCI ISA IDE Xcelerator (PIIX4)
+//http://www.intel.com/assets/pdf/datasheet/290562.pdf
 
 /// <summary>
 /// </summary>
 //[PCIDeviceDriver(VendorID = 0x8086, DeviceID = 0x7113, Platforms = PlatformArchitecture.X86AndX64)]
 public class IntelPIIX4 : BaseDeviceDriver
 {
-	public override void Initialize()
-	{
-		Device.Name = "IntelPIIX4";
-	}
+	public override void Initialize() => Device.Name = "IntelPIIX4";
 }

--- a/Source/Mosa.DeviceDriver/PCI/Intel/PCIIDEInterface.cs
+++ b/Source/Mosa.DeviceDriver/PCI/Intel/PCIIDEInterface.cs
@@ -2,10 +2,10 @@
 
 using Mosa.DeviceSystem.Framework;
 
-// PCI ISA IDE Xcelerator (PIIX4)
-// http://www.intel.com/assets/pdf/datasheet/290562.pdf
-
 namespace Mosa.DeviceDriver.PCI.Intel;
+
+// PCI ISA IDE Xcelerator (PIIX4)
+//http://www.intel.com/assets/pdf/datasheet/290562.pdf
 
 /// <summary>
 /// </summary>
@@ -15,8 +15,5 @@ namespace Mosa.DeviceDriver.PCI.Intel;
 //Programming Interface: 80h= Capable of IDE bus master operation.
 public class PCIIDEInterface : BaseDeviceDriver
 {
-	public override void Initialize()
-	{
-		Device.Name = "IDEInterface";
-	}
+	public override void Initialize() => Device.Name = "IDEInterface";
 }

--- a/Source/Mosa.DeviceDriver/PCI/Intel/QuarkSoC/IntelGPIOController.cs
+++ b/Source/Mosa.DeviceDriver/PCI/Intel/QuarkSoC/IntelGPIOController.cs
@@ -2,17 +2,14 @@
 
 using Mosa.DeviceSystem.Framework;
 
-// http://download.intel.com/support/processors/quark/sb/quarkdatasheetrev02.pdf
-
 namespace Mosa.DeviceDriver.PCI.Intel.QuarkSoC;
+
+//http://download.intel.com/support/processors/quark/sb/quarkdatasheetrev02.pdf
 
 /// <summary>
 /// </summary>
 //[PCIDeviceDriver(VendorID = 0x8086, DeviceID = 0x0934, ClassCode = 0X0C, SubClassCode = 0x80, ProgIF = 0x00, RevisionID = 0x10, Platforms = PlatformArchitecture.X86AndX64)]
 public class IntelGPIOController : BaseDeviceDriver
 {
-	public override void Initialize()
-	{
-		Device.Name = "IntelGPIOController";
-	}
+	public override void Initialize() => Device.Name = "IntelGPIOController";
 }

--- a/Source/Mosa.DeviceDriver/PCI/Intel/QuarkSoC/IntelHSUART.cs
+++ b/Source/Mosa.DeviceDriver/PCI/Intel/QuarkSoC/IntelHSUART.cs
@@ -2,17 +2,14 @@
 
 using Mosa.DeviceSystem.Framework;
 
-// http://download.intel.com/support/processors/quark/sb/quarkdatasheetrev02.pdf
-
 namespace Mosa.DeviceDriver.PCI.Intel.QuarkSoC;
+
+//http://download.intel.com/support/processors/quark/sb/quarkdatasheetrev02.pdf
 
 /// <summary>
 /// </summary>
 //[PCIDeviceDriver(VendorID = 0x8086, DeviceID = 0x0936, ClassCode = 0X07, SubClassCode = 0x80, ProgIF = 0x02, RevisionID = 0x10, Platforms = PlatformArchitecture.X86AndX64)]
 public class IntelHSUART : BaseDeviceDriver
 {
-	public override void Initialize()
-	{
-		Device.Name = "IntelHSUART";
-	}
+	public override void Initialize() => Device.Name = "IntelHSUART";
 }

--- a/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOGPU.cs
+++ b/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOGPU.cs
@@ -46,7 +46,7 @@ public class VirtIOGPU : BaseDeviceDriver, IGraphicsDevice
 		public const byte Size = 24;
 	}
 
-	private VirtIODevice virtIoDevice;
+	private VirtIODevice virtIODevice;
 	private Pointer resourceHeader;
 	private Pointer backingHeader;
 	private Pointer linkHeader;
@@ -59,25 +59,23 @@ public class VirtIOGPU : BaseDeviceDriver, IGraphicsDevice
 	{
 		Device.Name = "VIRTIO_GPU";
 
-		virtIoDevice = new VirtIODevice(Device);
-		virtIoDevice.StartInitialize();
+		virtIODevice = new VirtIODevice(Device);
+		virtIODevice.StartInitialize();
 
 		var deviceFeatures = (uint)VirtIOFeatures.Version1;
+		if ((virtIODevice.DeviceFeatures & VirtIOFeatures.InOrder) != 0) deviceFeatures |= VirtIOFeatures.InOrder;
 
-		if ((virtIoDevice.DeviceFeatures & VirtIOFeatures.InOrder) != 0) deviceFeatures |= VirtIOFeatures.InOrder;
+		virtIODevice.SelectFeatures(deviceFeatures);
+		virtIODevice.EndInitialize();
 
-		virtIoDevice.SelectFeatures(deviceFeatures);
-		virtIoDevice.EndInitialize();
-
-		var scanOuts = virtIoDevice.DeviceConfigurationPointer.Read32(virtIoDevice.DeviceConfigurationOffset + Configuration.NumScanOuts);
-
+		var scanOuts = virtIODevice.DeviceConfigurationPointer.Read32(virtIODevice.DeviceConfigurationOffset + Configuration.NumScanOuts);
 		if (scanOuts > 1)
 		{
 			HAL.DebugWriteLine("Detected more than 1 scan out!");
 			return;
 		}
 
-		virtIoDevice.Start();
+		virtIODevice.Start();
 
 		resourceHeader = GC.AllocateObject(40); // FIXME - Not a GC object
 		backingHeader = GC.AllocateObject(48); // FIXME
@@ -105,7 +103,7 @@ public class VirtIOGPU : BaseDeviceDriver, IGraphicsDevice
 		resourceHeader.Store32(28, 1); // Format
 		resourceHeader.Store32(32, width);
 		resourceHeader.Store32(36, height);
-		virtIoDevice.SendHeader(Queues.ControlQueue, resourceHeader, 40);
+		virtIODevice.SendHeader(Queues.ControlQueue, resourceHeader, 40);
 
 		// Allocate framebuffer
 		var frameBufferSize = width * height * 4;
@@ -118,7 +116,7 @@ public class VirtIOGPU : BaseDeviceDriver, IGraphicsDevice
 		backingHeader.Store32(28, 1);
 		backingHeader.Store64(32, frameBuffer.ToUInt64());
 		backingHeader.Store32(40, frameBufferSize);
-		virtIoDevice.SendHeader(Queues.ControlQueue, backingHeader, 48);
+		virtIODevice.SendHeader(Queues.ControlQueue, backingHeader, 48);
 
 		// Link the scan out
 		linkHeader.Store32(ControlHeader.Type, 0x0103);
@@ -128,14 +126,12 @@ public class VirtIOGPU : BaseDeviceDriver, IGraphicsDevice
 		linkHeader.Store32(36, height);
 		linkHeader.Store32(40, 0);
 		linkHeader.Store32(44, 1);
-		virtIoDevice.SendHeader(Queues.ControlQueue, linkHeader, 48);
+		virtIODevice.SendHeader(Queues.ControlQueue, linkHeader, 48);
 	}
 
-	public void Disable()
-	{ }
+	public void Disable() { }
 
-	public void Enable()
-	{ }
+	public void Enable() { }
 
 	public void Update(uint x, uint y, uint width, uint height)
 	{
@@ -147,7 +143,7 @@ public class VirtIOGPU : BaseDeviceDriver, IGraphicsDevice
 		transferHeader.Store32(36, height);
 		transferHeader.Store64(40, 0UL);
 		transferHeader.Store32(48, 1);
-		virtIoDevice.SendHeader(Queues.ControlQueue, transferHeader, 56);
+		virtIODevice.SendHeader(Queues.ControlQueue, transferHeader, 56);
 
 		// Flush resource
 		flushHeader.Store32(ControlHeader.Type, 0x0104);
@@ -156,26 +152,14 @@ public class VirtIOGPU : BaseDeviceDriver, IGraphicsDevice
 		flushHeader.Store32(32, width);
 		flushHeader.Store32(36, height);
 		flushHeader.Store32(40, 1);
-		virtIoDevice.SendHeader(Queues.ControlQueue, flushHeader, 48);
+		virtIODevice.SendHeader(Queues.ControlQueue, flushHeader, 48);
 	}
 
-	public void CopyRectangle(uint x, uint y, uint newX, uint newY, uint width, uint height)
-	{
-		throw new NotImplementedException();
-	}
+	public void CopyRectangle(uint x, uint y, uint newX, uint newY, uint width, uint height) => throw new NotImplementedException();
 
-	public bool SupportsHardwareCursor()
-	{
-		return false;
-	}
+	public bool SupportsHardwareCursor() => false;
 
-	public void DefineCursor(FrameBuffer32 image)
-	{
-		throw new NotImplementedException();
-	}
+	public void DefineCursor(FrameBuffer32 image) => throw new NotImplementedException();
 
-	public void SetCursor(bool visible, uint x, uint y)
-	{
-		throw new NotImplementedException();
-	}
+	public void SetCursor(bool visible, uint x, uint y) => throw new NotImplementedException();
 }

--- a/Source/Mosa.DeviceDriver/ScanCodeMap/HU.cs
+++ b/Source/Mosa.DeviceDriver/ScanCodeMap/HU.cs
@@ -9,48 +9,31 @@ namespace Mosa.DeviceDriver.ScanCodeMap;
 /// </summary>
 public class HU : IScanCodeMap
 {
-	private bool _shifted;
-	private bool _alted;
-
-	/// <summary>
-	/// Initializes a new instance of the <see cref="HU"/> class.
-	/// </summary>
-	public HU()
-	{
-		_shifted = false;
-		_alted = false;
-	}
+	private bool shift, alt;
 
 	private char TransformCharacter(char c)
 	{
-		if (_alted)
+		if (!alt) return shift ? char.ToUpper(c) : c;
+
+		return c switch
 		{
-			switch (c)
-			{
-				case 'q': return '\\';
-				case 'w': return '|';
-
-				case 'f': return '[';
-				case 'g': return ']';
-				case 'é': return '$';
-
-				case 'í': return '<';
-				case 'y': return '>';
-				case 'x': return '#';
-				case 'c': return '&';
-				case 'v': return '@';
-				case 'b': return '{';
-				case 'n': return '}';
-				case ',': return ';';
-				case '.': return '>';
-				case '-': return '*';
-			}
-		}
-
-		if (_shifted)
-			return char.ToUpper(c);
-
-		return c;
+			'q' => '\\',
+			'w' => '|',
+			'f' => '[',
+			'g' => ']',
+			'é' => '$',
+			'í' => '<',
+			'y' => '>',
+			'x' => '#',
+			'c' => '&',
+			'v' => '@',
+			'b' => '{',
+			'n' => '}',
+			',' => ';',
+			'.' => '>',
+			'-' => '*',
+			_ => shift ? char.ToUpper(c) : c
+		};
 	}
 
 	/// <summary>
@@ -71,15 +54,15 @@ public class HU : IScanCodeMap
 		switch (scancode & 0x7F)
 		{
 			case 1: key.Character = (char)27; break;
-			case 2: key.Character = _shifted ? '\'' : '1'; break;
-			case 3: key.Character = _shifted ? '"' : '2'; break;
-			case 4: key.Character = _shifted ? '+' : '3'; break;
-			case 5: key.Character = _shifted ? '!' : '4'; break;
-			case 6: key.Character = _shifted ? '%' : '5'; break;
-			case 7: key.Character = _shifted ? '/' : '6'; break;
-			case 8: key.Character = _shifted ? '=' : '7'; break;
-			case 9: key.Character = _shifted ? '(' : '8'; break;
-			case 10: key.Character = _shifted ? ')' : '9'; break;
+			case 2: key.Character = shift ? '\'' : '1'; break;
+			case 3: key.Character = shift ? '"' : '2'; break;
+			case 4: key.Character = shift ? '+' : '3'; break;
+			case 5: key.Character = shift ? '!' : '4'; break;
+			case 6: key.Character = shift ? '%' : '5'; break;
+			case 7: key.Character = shift ? '/' : '6'; break;
+			case 8: key.Character = shift ? '=' : '7'; break;
+			case 9: key.Character = shift ? '(' : '8'; break;
+			case 10: key.Character = shift ? ')' : '9'; break;
 			case 11: key.Character = TransformCharacter('ö'); break;
 			case 12: key.Character = TransformCharacter('ü'); break;
 			case 13: key.Character = TransformCharacter('ó'); break;
@@ -120,11 +103,10 @@ public class HU : IScanCodeMap
 			case 48: key.Character = TransformCharacter('b'); break;
 			case 49: key.Character = TransformCharacter('n'); break;
 			case 50: key.Character = TransformCharacter('m'); break;
-			case 51: key.Character = _shifted ? '?' : ','; break;
-			case 52: key.Character = _shifted ? ':' : '.'; break;
-			case 53: key.Character = _shifted ? '_' : '-'; break;
+			case 51: key.Character = shift ? '?' : ','; break;
+			case 52: key.Character = shift ? ':' : '.'; break;
+			case 53: key.Character = shift ? '_' : '-'; break;
 			case 54: key.KeyType = KeyType.RightShift; break;
-
 			case 56: key.KeyType = KeyType.LeftAlt; break;
 			case 57: key.Character = ' '; break;
 			case 58: key.KeyType = KeyType.CapsLock; break;
@@ -145,7 +127,6 @@ public class HU : IScanCodeMap
 			case 73: key.KeyType = KeyType.PageUp; break;
 			case 74: key.Character = '-'; break;
 			case 75: key.KeyType = KeyType.LeftArrow; break;
-
 			case 77: key.KeyType = KeyType.RightArrow; break;
 			case 78: key.Character = '+'; break;
 			case 79: key.KeyType = KeyType.End; break;
@@ -153,21 +134,30 @@ public class HU : IScanCodeMap
 			case 81: key.KeyType = KeyType.PageDown; break;
 			case 82: key.KeyType = KeyType.Insert; break;
 			case 83: key.KeyType = KeyType.Delete; break;
-
 			case 86: key.Character = TransformCharacter('<'); break;
 			case 87: key.KeyType = KeyType.F11; break;
 			case 88: key.KeyType = KeyType.F12; break;
-
-			default: //Unmapped buttons (which doesn't exist on a hungarian keyboard)
-				return new KeyEvent();
+			default: return new KeyEvent(); // Unmapped buttons (which doesn't exist on a hungarian keyboard)
 		}
 
-		if (key.KeyType is KeyType.LeftShift or KeyType.RightShift)
-			_shifted = key.KeyPress == KeyEvent.KeyPressType.Make;
-		if (key.KeyType == KeyType.CapsLock)
-			_shifted = !_shifted;
-		if (key.KeyType == KeyType.LeftAlt)
-			_alted = key.KeyPress == KeyEvent.KeyPressType.Make;
+		switch (key.KeyType)
+		{
+			case KeyType.LeftShift or KeyType.RightShift:
+				{
+					shift = key.KeyPress == KeyEvent.KeyPressType.Make;
+					break;
+				}
+			case KeyType.CapsLock:
+				{
+					shift = !shift;
+					break;
+				}
+			case KeyType.LeftAlt:
+				{
+					alt = key.KeyPress == KeyEvent.KeyPressType.Make;
+					break;
+				}
+		}
 
 		return key;
 	}

--- a/Source/Mosa.DeviceDriver/ScanCodeMap/US.cs
+++ b/Source/Mosa.DeviceDriver/ScanCodeMap/US.cs
@@ -10,17 +10,14 @@ namespace Mosa.DeviceDriver.ScanCodeMap;
 public class US : IScanCodeMap
 {
 	private enum KeyState
-	{ Normal, Escaped, Espaced2, EscapeBreak };
-
-	private KeyState keyState;
-
-	/// <summary>
-	/// Initializes a new instance of the <see cref="US"/> class.
-	/// </summary>
-	public US()
 	{
-		keyState = KeyState.Normal;
+		Normal,
+		Escaped,
+		Espaced2,
+		EscapeBreak
 	}
+
+	private KeyState keyState = KeyState.Normal;
 
 	/// <summary>
 	/// Convert can code into a key
@@ -34,255 +31,241 @@ public class US : IScanCodeMap
 		if (scancode == 0)
 			return key;
 
-		if (keyState == KeyState.Normal)
+		switch (keyState)
 		{
-			if (scancode == 0xE0)
-			{
-				keyState = KeyState.Escaped;
-				return key;
-			}
-
-			key.KeyPress = (scancode & 0x80) != 0 ? KeyEvent.KeyPressType.Break : key.KeyPress = KeyEvent.KeyPressType.Make;
-
-			key.KeyType = KeyType.RegularKey;
-
-			switch (scancode)
-			{
-				case 1: key.Character = (char)27; break;
-				case 2: key.Character = '1'; break;
-				case 3: key.Character = '2'; break;
-				case 4: key.Character = '3'; break;
-				case 5: key.Character = '4'; break;
-				case 6: key.Character = '5'; break;
-				case 7: key.Character = '6'; break;
-				case 8: key.Character = '7'; break;
-				case 9: key.Character = '8'; break;
-				case 10: key.Character = '9'; break;
-				case 11: key.Character = '0'; break;
-				case 12: key.Character = '-'; break;
-				case 13: key.Character = '='; break;
-				case 14: key.Character = '\b'; break;
-				case 15: key.Character = '\t'; break;
-				case 16: key.Character = 'q'; break;
-				case 17: key.Character = 'w'; break;
-				case 18: key.Character = 'e'; break;
-				case 19: key.Character = 'r'; break;
-				case 20: key.Character = 't'; break;
-				case 21: key.Character = 'y'; break;
-				case 22: key.Character = 'u'; break;
-				case 23: key.Character = 'i'; break;
-				case 24: key.Character = 'o'; break;
-				case 25: key.Character = 'p'; break;
-				case 26: key.Character = '['; break;
-				case 27: key.Character = ']'; break;
-				case 28: key.Character = '\n'; break;
-				case 29: key.KeyType = KeyType.LeftControl; break;
-				case 30: key.Character = 'a'; break;
-				case 31: key.Character = 's'; break;
-				case 32: key.Character = 'd'; break;
-				case 33: key.Character = 'f'; break;
-				case 34: key.Character = 'g'; break;
-				case 35: key.Character = 'h'; break;
-				case 36: key.Character = 'j'; break;
-				case 37: key.Character = 'k'; break;
-				case 38: key.Character = 'l'; break;
-				case 39: key.Character = ';'; break;
-				case 40: key.Character = '\''; break;
-				case 41: key.Character = '`'; break;
-				case 42: key.KeyType = KeyType.LeftShift; break;
-				case 43: key.Character = '\\'; break;
-				case 44: key.Character = 'z'; break;
-				case 45: key.Character = 'x'; break;
-				case 46: key.Character = 'c'; break;
-				case 47: key.Character = 'v'; break;
-				case 48: key.Character = 'b'; break;
-				case 49: key.Character = 'n'; break;
-				case 50: key.Character = 'm'; break;
-				case 51: key.Character = ','; break;
-				case 52: key.Character = '.'; break;
-				case 53: key.Character = '/'; break;
-				case 54: key.KeyType = KeyType.RightShift; break;
-				case 55: key.Character = '*'; break;
-				case 56: key.KeyType = KeyType.LeftAlt; break;
-				case 57: key.Character = ' '; break;
-				case 58: key.KeyType = KeyType.CapsLock; break;
-				case 59: key.KeyType = KeyType.F1; break;
-				case 60: key.KeyType = KeyType.F2; break;
-				case 61: key.KeyType = KeyType.F3; break;
-				case 62: key.KeyType = KeyType.F4; break;
-				case 63: key.KeyType = KeyType.F5; break;
-				case 64: key.KeyType = KeyType.F6; break;
-				case 65: key.KeyType = KeyType.F7; break;
-				case 66: key.KeyType = KeyType.F8; break;
-				case 67: key.KeyType = KeyType.F9; break;
-				case 68: key.KeyType = KeyType.F10; break;
-				case 69: key.KeyType = KeyType.NumLock; break;
-				case 70: key.KeyType = KeyType.ScrollLock; break;
-				case 71: key.KeyType = KeyType.Home; break;
-				case 72: key.KeyType = KeyType.UpArrow; break;
-				case 73: key.KeyType = KeyType.PageUp; break;
-				case 74: key.Character = '-'; break;
-				case 75: key.KeyType = KeyType.LeftArrow; break;
-				case 76: key.Character = (char)0; break;
-				case 77: key.KeyType = KeyType.RightArrow; break;
-				case 78: key.Character = '+'; break;
-				case 79: key.KeyType = KeyType.End; break;
-				case 80: key.KeyType = KeyType.DownArrow; break;
-				case 81: key.KeyType = KeyType.PageDown; break;
-				case 82: key.KeyType = KeyType.Insert; break;
-				case 83: key.KeyType = KeyType.Delete; break;
-				case 86: key.Character = '\\'; break;
-				case 87: key.KeyType = KeyType.F11; break;
-				case 88: key.KeyType = KeyType.F12; break;
-				case 129: key.Character = (char)27; break;
-				case 130: key.Character = '!'; break;
-				case 131: key.Character = '@'; break;
-				case 132: key.Character = '#'; break;
-				case 133: key.Character = '$'; break;
-				case 134: key.Character = '%'; break;
-				case 135: key.Character = '^'; break;
-				case 136: key.Character = '&'; break;
-				case 137: key.Character = '*'; break;
-				case 138: key.Character = '('; break;
-				case 139: key.Character = ')'; break;
-				case 140: key.Character = '_'; break;
-				case 141: key.Character = '+'; break;
-				case 142: key.Character = '\b'; break;
-				case 143: key.Character = '\t'; break;
-				case 144: key.Character = 'Q'; break;
-				case 145: key.Character = 'W'; break;
-				case 146: key.Character = 'E'; break;
-				case 147: key.Character = 'R'; break;
-				case 148: key.Character = 'T'; break;
-				case 149: key.Character = 'Y'; break;
-				case 150: key.Character = 'U'; break;
-				case 151: key.Character = 'I'; break;
-				case 152: key.Character = 'O'; break;
-				case 153: key.Character = 'P'; break;
-				case 154: key.Character = '{'; break;
-				case 155: key.Character = '}'; break;
-				case 156: key.Character = '\n'; break;
-				case 157: key.KeyType = KeyType.RightControl; break;
-				case 158: key.Character = 'A'; break;
-				case 159: key.Character = 'S'; break;
-				case 160: key.Character = 'D'; break;
-				case 161: key.Character = 'F'; break;
-				case 162: key.Character = 'G'; break;
-				case 163: key.Character = 'H'; break;
-				case 164: key.Character = 'J'; break;
-				case 165: key.Character = 'K'; break;
-				case 166: key.Character = 'L'; break;
-				case 167: key.Character = ':'; break;
-				case 168: key.Character = '"'; break;
-				case 169: key.Character = '~'; break;
-				case 170: key.KeyType = KeyType.LeftShift; break;
-				case 171: key.Character = '|'; break;
-				case 172: key.Character = 'Z'; break;
-				case 173: key.Character = 'X'; break;
-				case 174: key.Character = 'C'; break;
-				case 175: key.Character = 'V'; break;
-				case 176: key.Character = 'B'; break;
-				case 177: key.Character = 'N'; break;
-				case 178: key.Character = 'M'; break;
-				case 179: key.Character = '<'; break;
-				case 180: key.Character = '>'; break;
-				case 181: key.Character = '?'; break;
-				case 182: key.KeyType = KeyType.RightShift; break;
-				case 183: key.Character = '*'; break;
-				case 184: key.KeyType = KeyType.RightAlt; break;
-				case 185: key.Character = ' '; break;
-				case 186: key.KeyType = KeyType.CapsLock; break;
-				case 187: key.KeyType = KeyType.F1; break;
-				case 188: key.KeyType = KeyType.F2; break;
-				case 189: key.KeyType = KeyType.F3; break;
-				case 190: key.KeyType = KeyType.F4; break;
-				case 191: key.KeyType = KeyType.F5; break;
-				case 192: key.KeyType = KeyType.F6; break;
-				case 193: key.KeyType = KeyType.F7; break;
-				case 194: key.KeyType = KeyType.F8; break;
-				case 195: key.KeyType = KeyType.F9; break;
-				case 196: key.KeyType = KeyType.F10; break;
-				case 197: key.KeyType = KeyType.NumLock; break;
-				case 198: key.KeyType = KeyType.ScrollLock; break;
-				case 199: key.KeyType = KeyType.Home; break;
-				case 200: key.KeyType = KeyType.UpArrow; break;
-				case 201: key.KeyType = KeyType.PageUp; break;
-				case 202: key.Character = '-'; break;
-				case 203: key.KeyType = KeyType.LeftArrow; break;
-				case 205: key.KeyType = KeyType.RightArrow; break;
-				case 206: key.Character = '+'; break;
-				case 207: key.KeyType = KeyType.End; break;
-				case 208: key.KeyType = KeyType.DownArrow; break;
-				case 209: key.KeyType = KeyType.PageDown; break;
-				case 210: key.KeyType = KeyType.Insert; break;
-				case 211: key.KeyType = KeyType.Delete; break;
-				case 214: key.Character = '|'; break;
-				case 215: key.KeyType = KeyType.F11; break;
-				case 216: key.KeyType = KeyType.F12; break;
-			}
-
-			keyState = KeyState.Normal;
-			return key;
-		}
-		else if (keyState is KeyState.Escaped or KeyState.EscapeBreak)
-		{
-			if (scancode == 0xE0)
-			{
-				key.KeyType = KeyType.RegularKey;
-
-				key.KeyPress = (scancode & 0x80) != 0 || keyState == KeyState.EscapeBreak ? key.KeyPress = KeyEvent.KeyPressType.Break : key.KeyPress = KeyEvent.KeyPressType.Make;
-
-				if (scancode == 0xF0)
+			case KeyState.Normal when scancode == 0xE0:
 				{
-					keyState = KeyState.EscapeBreak;
+					keyState = KeyState.Escaped;
 					return key;
 				}
-
-				switch (scancode)
+			case KeyState.Normal:
 				{
-					case 0x1C: key.Character = '\n'; break;
-					case 0x1D: key.KeyType = KeyType.LeftControl; break;
-					case 0x2A: key.KeyType = KeyType.LeftShift; break;
-					case 0x35: key.Character = '/'; break;
-					case 0x36: key.KeyType = KeyType.RightShift; break;
+					key.KeyPress = (scancode & 0x80) != 0 ? KeyEvent.KeyPressType.Break : KeyEvent.KeyPressType.Make;
+					key.KeyType = KeyType.RegularKey;
 
-					case 0x37: key.KeyType = KeyType.ControlPrintScreen; break;
-					case 0x38: key.KeyType = KeyType.LeftAlt; break; // ?
+					switch (scancode)
+					{
+						case 1: key.Character = (char)27; break;
+						case 2: key.Character = '1'; break;
+						case 3: key.Character = '2'; break;
+						case 4: key.Character = '3'; break;
+						case 5: key.Character = '4'; break;
+						case 6: key.Character = '5'; break;
+						case 7: key.Character = '6'; break;
+						case 8: key.Character = '7'; break;
+						case 9: key.Character = '8'; break;
+						case 10: key.Character = '9'; break;
+						case 11: key.Character = '0'; break;
+						case 12: key.Character = '-'; break;
+						case 13: key.Character = '='; break;
+						case 14: key.Character = '\b'; break;
+						case 15: key.Character = '\t'; break;
+						case 16: key.Character = 'q'; break;
+						case 17: key.Character = 'w'; break;
+						case 18: key.Character = 'e'; break;
+						case 19: key.Character = 'r'; break;
+						case 20: key.Character = 't'; break;
+						case 21: key.Character = 'y'; break;
+						case 22: key.Character = 'u'; break;
+						case 23: key.Character = 'i'; break;
+						case 24: key.Character = 'o'; break;
+						case 25: key.Character = 'p'; break;
+						case 26: key.Character = '['; break;
+						case 27: key.Character = ']'; break;
+						case 28: key.Character = '\n'; break;
+						case 29: key.KeyType = KeyType.LeftControl; break;
+						case 30: key.Character = 'a'; break;
+						case 31: key.Character = 's'; break;
+						case 32: key.Character = 'd'; break;
+						case 33: key.Character = 'f'; break;
+						case 34: key.Character = 'g'; break;
+						case 35: key.Character = 'h'; break;
+						case 36: key.Character = 'j'; break;
+						case 37: key.Character = 'k'; break;
+						case 38: key.Character = 'l'; break;
+						case 39: key.Character = ';'; break;
+						case 40: key.Character = '\''; break;
+						case 41: key.Character = '`'; break;
+						case 42: key.KeyType = KeyType.LeftShift; break;
+						case 43: key.Character = '\\'; break;
+						case 44: key.Character = 'z'; break;
+						case 45: key.Character = 'x'; break;
+						case 46: key.Character = 'c'; break;
+						case 47: key.Character = 'v'; break;
+						case 48: key.Character = 'b'; break;
+						case 49: key.Character = 'n'; break;
+						case 50: key.Character = 'm'; break;
+						case 51: key.Character = ','; break;
+						case 52: key.Character = '.'; break;
+						case 53: key.Character = '/'; break;
+						case 54: key.KeyType = KeyType.RightShift; break;
+						case 55: key.Character = '*'; break;
+						case 56: key.KeyType = KeyType.LeftAlt; break;
+						case 57: key.Character = ' '; break;
+						case 58: key.KeyType = KeyType.CapsLock; break;
+						case 59: key.KeyType = KeyType.F1; break;
+						case 60: key.KeyType = KeyType.F2; break;
+						case 61: key.KeyType = KeyType.F3; break;
+						case 62: key.KeyType = KeyType.F4; break;
+						case 63: key.KeyType = KeyType.F5; break;
+						case 64: key.KeyType = KeyType.F6; break;
+						case 65: key.KeyType = KeyType.F7; break;
+						case 66: key.KeyType = KeyType.F8; break;
+						case 67: key.KeyType = KeyType.F9; break;
+						case 68: key.KeyType = KeyType.F10; break;
+						case 69: key.KeyType = KeyType.NumLock; break;
+						case 70: key.KeyType = KeyType.ScrollLock; break;
+						case 71: key.KeyType = KeyType.Home; break;
+						case 72: key.KeyType = KeyType.UpArrow; break;
+						case 73: key.KeyType = KeyType.PageUp; break;
+						case 74: key.Character = '-'; break;
+						case 75: key.KeyType = KeyType.LeftArrow; break;
+						case 76: key.Character = (char)0; break;
+						case 77: key.KeyType = KeyType.RightArrow; break;
+						case 78: key.Character = '+'; break;
+						case 79: key.KeyType = KeyType.End; break;
+						case 80: key.KeyType = KeyType.DownArrow; break;
+						case 81: key.KeyType = KeyType.PageDown; break;
+						case 82: key.KeyType = KeyType.Insert; break;
+						case 83: key.KeyType = KeyType.Delete; break;
+						case 86: key.Character = '\\'; break;
+						case 87: key.KeyType = KeyType.F11; break;
+						case 88: key.KeyType = KeyType.F12; break;
+						case 129: key.Character = (char)27; break;
+						case 130: key.Character = '!'; break;
+						case 131: key.Character = '@'; break;
+						case 132: key.Character = '#'; break;
+						case 133: key.Character = '$'; break;
+						case 134: key.Character = '%'; break;
+						case 135: key.Character = '^'; break;
+						case 136: key.Character = '&'; break;
+						case 137: key.Character = '*'; break;
+						case 138: key.Character = '('; break;
+						case 139: key.Character = ')'; break;
+						case 140: key.Character = '_'; break;
+						case 141: key.Character = '+'; break;
+						case 142: key.Character = '\b'; break;
+						case 143: key.Character = '\t'; break;
+						case 144: key.Character = 'Q'; break;
+						case 145: key.Character = 'W'; break;
+						case 146: key.Character = 'E'; break;
+						case 147: key.Character = 'R'; break;
+						case 148: key.Character = 'T'; break;
+						case 149: key.Character = 'Y'; break;
+						case 150: key.Character = 'U'; break;
+						case 151: key.Character = 'I'; break;
+						case 152: key.Character = 'O'; break;
+						case 153: key.Character = 'P'; break;
+						case 154: key.Character = '{'; break;
+						case 155: key.Character = '}'; break;
+						case 156: key.Character = '\n'; break;
+						case 157: key.KeyType = KeyType.RightControl; break;
+						case 158: key.Character = 'A'; break;
+						case 159: key.Character = 'S'; break;
+						case 160: key.Character = 'D'; break;
+						case 161: key.Character = 'F'; break;
+						case 162: key.Character = 'G'; break;
+						case 163: key.Character = 'H'; break;
+						case 164: key.Character = 'J'; break;
+						case 165: key.Character = 'K'; break;
+						case 166: key.Character = 'L'; break;
+						case 167: key.Character = ':'; break;
+						case 168: key.Character = '"'; break;
+						case 169: key.Character = '~'; break;
+						case 170: key.KeyType = KeyType.LeftShift; break;
+						case 171: key.Character = '|'; break;
+						case 172: key.Character = 'Z'; break;
+						case 173: key.Character = 'X'; break;
+						case 174: key.Character = 'C'; break;
+						case 175: key.Character = 'V'; break;
+						case 176: key.Character = 'B'; break;
+						case 177: key.Character = 'N'; break;
+						case 178: key.Character = 'M'; break;
+						case 179: key.Character = '<'; break;
+						case 180: key.Character = '>'; break;
+						case 181: key.Character = '?'; break;
+						case 182: key.KeyType = KeyType.RightShift; break;
+						case 183: key.Character = '*'; break;
+						case 184: key.KeyType = KeyType.RightAlt; break;
+						case 185: key.Character = ' '; break;
+						case 186: key.KeyType = KeyType.CapsLock; break;
+						case 187: key.KeyType = KeyType.F1; break;
+						case 188: key.KeyType = KeyType.F2; break;
+						case 189: key.KeyType = KeyType.F3; break;
+						case 190: key.KeyType = KeyType.F4; break;
+						case 191: key.KeyType = KeyType.F5; break;
+						case 192: key.KeyType = KeyType.F6; break;
+						case 193: key.KeyType = KeyType.F7; break;
+						case 194: key.KeyType = KeyType.F8; break;
+						case 195: key.KeyType = KeyType.F9; break;
+						case 196: key.KeyType = KeyType.F10; break;
+						case 197: key.KeyType = KeyType.NumLock; break;
+						case 198: key.KeyType = KeyType.ScrollLock; break;
+						case 199: key.KeyType = KeyType.Home; break;
+						case 200: key.KeyType = KeyType.UpArrow; break;
+						case 201: key.KeyType = KeyType.PageUp; break;
+						case 202: key.Character = '-'; break;
+						case 203: key.KeyType = KeyType.LeftArrow; break;
+						case 205: key.KeyType = KeyType.RightArrow; break;
+						case 206: key.Character = '+'; break;
+						case 207: key.KeyType = KeyType.End; break;
+						case 208: key.KeyType = KeyType.DownArrow; break;
+						case 209: key.KeyType = KeyType.PageDown; break;
+						case 210: key.KeyType = KeyType.Insert; break;
+						case 211: key.KeyType = KeyType.Delete; break;
+						case 214: key.Character = '|'; break;
+						case 215: key.KeyType = KeyType.F11; break;
+						case 216: key.KeyType = KeyType.F12; break;
+					}
 
-					case 0x46: key.KeyType = KeyType.ScrollLock; break;
-					case 0x47: key.KeyType = KeyType.Home; break;
-					case 0x48: key.KeyType = KeyType.UpArrow; break;
-					case 0x49: key.KeyType = KeyType.PageUp; break;
-					case 0x4B: key.KeyType = KeyType.LeftArrow; break;
-					case 0x4D: key.KeyType = KeyType.RightArrow; break;
-
-					case 0x4F: key.KeyType = KeyType.End; break;
-					case 0x50: key.KeyType = KeyType.DownArrow; break;
-					case 0x51: key.KeyType = KeyType.PageDown; break;
-					case 0x52: key.KeyType = KeyType.Insert; break;
-					case 0x53: key.KeyType = KeyType.Delete; break;
-
-					case 0x5B: key.KeyType = KeyType.LeftWindow; break;
-					case 0x5C: key.KeyType = KeyType.RightWindow; break;
-					case 0x5D: key.KeyType = KeyType.Menu; break;
-
-					//case 0x37: key.KeyType = Key.Special.Power; break;
-					//case 0x3F: key.KeyType = Key.Special.Sleep; break;
-					//case 0x5E: key.KeyType = Key.Special.Wake; break;
-
-					default: break;
+					keyState = KeyState.Normal;
+					return key;
 				}
+			case KeyState.Escaped or KeyState.EscapeBreak when scancode == 0xE0:
+				{
+					key.KeyType = KeyType.RegularKey;
+					key.KeyPress = (scancode & 0x80) != 0 || keyState == KeyState.EscapeBreak ? KeyEvent.KeyPressType.Break : key.KeyPress = KeyEvent.KeyPressType.Make;
 
-				keyState = KeyState.Normal;
-				return key;
-			}
-			else if (keyState == KeyState.Espaced2)
-			{
-				keyState = KeyState.Normal;
-				return key;
-			}
+					if (scancode == 0xF0)
+					{
+						keyState = KeyState.EscapeBreak;
+						return key;
+					}
+
+					switch (scancode)
+					{
+						case 0x1C: key.Character = '\n'; break;
+						case 0x1D: key.KeyType = KeyType.LeftControl; break;
+						case 0x2A: key.KeyType = KeyType.LeftShift; break;
+						case 0x35: key.Character = '/'; break;
+						case 0x36: key.KeyType = KeyType.RightShift; break;
+						case 0x37: key.KeyType = KeyType.ControlPrintScreen; break;
+						case 0x38: key.KeyType = KeyType.LeftAlt; break; // ?
+						case 0x46: key.KeyType = KeyType.ScrollLock; break;
+						case 0x47: key.KeyType = KeyType.Home; break;
+						case 0x48: key.KeyType = KeyType.UpArrow; break;
+						case 0x49: key.KeyType = KeyType.PageUp; break;
+						case 0x4B: key.KeyType = KeyType.LeftArrow; break;
+						case 0x4D: key.KeyType = KeyType.RightArrow; break;
+						case 0x4F: key.KeyType = KeyType.End; break;
+						case 0x50: key.KeyType = KeyType.DownArrow; break;
+						case 0x51: key.KeyType = KeyType.PageDown; break;
+						case 0x52: key.KeyType = KeyType.Insert; break;
+						case 0x53: key.KeyType = KeyType.Delete; break;
+						case 0x5B: key.KeyType = KeyType.LeftWindow; break;
+						case 0x5C: key.KeyType = KeyType.RightWindow; break;
+						case 0x5D: key.KeyType = KeyType.Menu; break;
+					}
+
+					keyState = KeyState.Normal;
+					return key;
+				}
+			case KeyState.Escaped or KeyState.EscapeBreak when keyState == KeyState.Espaced2:
+				{
+					keyState = KeyState.Normal;
+					return key;
+				}
+			default: return key;
 		}
-
-		return key;
 	}
 }

--- a/Source/Mosa.DeviceDriver/Setup.cs
+++ b/Source/Mosa.DeviceDriver/Setup.cs
@@ -10,245 +10,242 @@ namespace Mosa.DeviceDriver;
 
 public static class Setup
 {
-	public static List<DeviceDriverRegistryEntry> GetDeviceDriverRegistryEntries()
+	public static List<DeviceDriverRegistryEntry> GetDeviceDriverRegistryEntries() => new List<DeviceDriverRegistryEntry>
 	{
-		return new List<DeviceDriverRegistryEntry>
+		//new ISADeviceDriverRegistryEntry
+		//{
+		//	Name = "ACPI",
+		//	Platform = PlatformArchitecture.X86AndX64 | PlatformArchitecture.ARM32,
+		//	AutoLoad = true,
+		//	Factory = () => new ISA.ACPI.ACPIDriver()
+		//},
+
+		new ISADeviceDriverRegistryEntry
 		{
-			new ISADeviceDriverRegistryEntry
-			{
-				Name = "StandardKeyboard",
-				Platform = PlatformArchitecture.X86AndX64,
-				AutoLoad = true,
-				BasePort = 0x60,
-				PortRange = 1,
-				AltBasePort = 0x64,
-				AltPortRange = 1,
-				IRQ = 1,
-				Factory = () => new ISA.StandardKeyboard()
-			},
+			Name = "StandardKeyboard",
+			Platform = PlatformArchitecture.X86AndX64,
+			AutoLoad = true,
+			BasePort = 0x60,
+			PortRange = 1,
+			AltBasePort = 0x64,
+			AltPortRange = 1,
+			IRQ = 1,
+			Factory = () => new ISA.StandardKeyboard()
+		},
 
-			new ISADeviceDriverRegistryEntry
-			{
-				Name = "StandardMouse",
-				Platform = PlatformArchitecture.X86AndX64,
-				AutoLoad = true,
-				BasePort = 0x60,
-				PortRange = 1,
-				AltBasePort = 0x64,
-				AltPortRange = 1,
-				IRQ = 12,
-				Factory = () => new ISA.StandardMouse()
-			},
+		new ISADeviceDriverRegistryEntry
+		{
+			Name = "StandardMouse",
+			Platform = PlatformArchitecture.X86AndX64,
+			AutoLoad = true,
+			BasePort = 0x60,
+			PortRange = 1,
+			AltBasePort = 0x64,
+			AltPortRange = 1,
+			IRQ = 12,
+			Factory = () => new ISA.StandardMouse()
+		},
 
-			new ISADeviceDriverRegistryEntry
-			{
-				Name = "PCIController",
-				Platform = PlatformArchitecture.X86AndX64,
-				AutoLoad = true,
-				BasePort = 0x0CF8,
-				PortRange = 8,
-				Factory = () => new ISA.PCIController()
-			},
+		new ISADeviceDriverRegistryEntry
+		{
+			Name = "PCIController",
+			Platform = PlatformArchitecture.X86AndX64,
+			AutoLoad = true,
+			BasePort = 0x0CF8,
+			PortRange = 8,
+			Factory = () => new ISA.PCIController()
+		},
 
-			new PCIDeviceDriverRegistryEntry
-			{
-				Name = "PCIGenericHostBridge",
-				Platform = PlatformArchitecture.X86AndX64,
-				BusType = DeviceBusType.PCI,
-				ClassCode = 0x06,
-				SubClassCode = 0x00,
-				PCIFields =  PCIField.ClassCode | PCIField.SubClassCode,
-				Factory = () => new PCI.GenericHostBridgeController()
-			},
+		new PCIDeviceDriverRegistryEntry
+		{
+			Name = "PCIGenericHostBridge",
+			Platform = PlatformArchitecture.X86AndX64,
+			BusType = DeviceBusType.PCI,
+			ClassCode = 0x06,
+			SubClassCode = 0x00,
+			PCIFields =  PCIField.ClassCode | PCIField.SubClassCode,
+			Factory = () => new PCI.GenericHostBridgeController()
+		},
 
-			new ISADeviceDriverRegistryEntry
-			{
-				Name = "IDEController",
-				Platform = PlatformArchitecture.X86AndX64,
-				AutoLoad = true,
-				BasePort = 0x1F0,
-				PortRange = 8,
-				AltBasePort = 0x3F6,
-				AltPortRange = 8,
-				Factory = () => new ISA.IDEController()
-			},
+		new ISADeviceDriverRegistryEntry
+		{
+			Name = "IDEController",
+			Platform = PlatformArchitecture.X86AndX64,
+			AutoLoad = true,
+			BasePort = 0x1F0,
+			PortRange = 8,
+			AltBasePort = 0x3F6,
+			AltPortRange = 8,
+			Factory = () => new ISA.IDEController()
+		},
 
-			new ISADeviceDriverRegistryEntry
-			{
-				Name = "IDEController (Secondary)",
-				Platform = PlatformArchitecture.X86AndX64,
-				AutoLoad = true,
-				BasePort = 0x170,
-				PortRange = 8,
-				AltBasePort = 0x376,
-				AltPortRange = 8,
-				ForceOption = "ide2",
-				Factory = () => new ISA.IDEController()
-			},
+		new ISADeviceDriverRegistryEntry
+		{
+			Name = "IDEController (Secondary)",
+			Platform = PlatformArchitecture.X86AndX64,
+			AutoLoad = true,
+			BasePort = 0x170,
+			PortRange = 8,
+			AltBasePort = 0x376,
+			AltPortRange = 8,
+			ForceOption = "ide2",
+			Factory = () => new ISA.IDEController()
+		},
 
-			new PCIDeviceDriverRegistryEntry
-			{
-				Name = "Intel4SeriesChipsetDRAMController",
-				Platform = PlatformArchitecture.X86AndX64,
-				BusType = DeviceBusType.PCI,
-				VendorID = 0x8086,
-				DeviceID = 0x2E10,
-				PCIFields = PCIField.VendorID | PCIField.DeviceID,
-				Factory = () => new PCI.Intel.Intel4SeriesChipsetDRAMController()
-			},
+		new PCIDeviceDriverRegistryEntry
+		{
+			Name = "Intel4SeriesChipsetDRAMController",
+			Platform = PlatformArchitecture.X86AndX64,
+			BusType = DeviceBusType.PCI,
+			VendorID = 0x8086,
+			DeviceID = 0x2E10,
+			PCIFields = PCIField.VendorID | PCIField.DeviceID,
+			Factory = () => new PCI.Intel.Intel4SeriesChipsetDRAMController()
+		},
 
-			new PCIDeviceDriverRegistryEntry
-			{
-				Name = "Intel4SeriesChipsetIntegratedGraphicsController",
-				Platform = PlatformArchitecture.X86AndX64,
-				BusType = DeviceBusType.PCI,
-				VendorID = 0x8086,
-				DeviceID = 0x2E10,
-				PCIFields = PCIField.VendorID | PCIField.DeviceID,
-				Factory = () => new PCI.Intel.Intel4SeriesChipsetIntegratedGraphicsController()
-			},
+		new PCIDeviceDriverRegistryEntry
+		{
+			Name = "Intel4SeriesChipsetIntegratedGraphicsController",
+			Platform = PlatformArchitecture.X86AndX64,
+			BusType = DeviceBusType.PCI,
+			VendorID = 0x8086,
+			DeviceID = 0x2E10,
+			PCIFields = PCIField.VendorID | PCIField.DeviceID,
+			Factory = () => new PCI.Intel.Intel4SeriesChipsetIntegratedGraphicsController()
+		},
 
-			new PCIDeviceDriverRegistryEntry
-			{
-				Name = "Intel4SeriesChipsetIntegratedGraphicsController2E13",
-				Platform = PlatformArchitecture.X86AndX64,
-				BusType = DeviceBusType.PCI,
-				VendorID = 0x8086,
-				DeviceID = 0x2E10,
-				PCIFields = PCIField.VendorID | PCIField.DeviceID,
-				Factory = () => new PCI.Intel.Intel4SeriesChipsetIntegratedGraphicsController2E13()
-			},
+		new PCIDeviceDriverRegistryEntry
+		{
+			Name = "Intel4SeriesChipsetIntegratedGraphicsController2E13",
+			Platform = PlatformArchitecture.X86AndX64,
+			BusType = DeviceBusType.PCI,
+			VendorID = 0x8086,
+			DeviceID = 0x2E10,
+			PCIFields = PCIField.VendorID | PCIField.DeviceID,
+			Factory = () => new PCI.Intel.Intel4SeriesChipsetIntegratedGraphicsController2E13()
+		},
 
-			new PCIDeviceDriverRegistryEntry
-			{
-				Name = "Intel4SeriesChipsetPCIExpressRootPort",
-				Platform = PlatformArchitecture.X86AndX64,
-				BusType = DeviceBusType.PCI,
-				VendorID = 0x8086,
-				DeviceID = 0x2E10,
-				PCIFields = PCIField.VendorID | PCIField.DeviceID,
-				Factory = () => new PCI.Intel.Intel4SeriesChipsetPCIExpressRootPort()
-			},
+		new PCIDeviceDriverRegistryEntry
+		{
+			Name = "Intel4SeriesChipsetPCIExpressRootPort",
+			Platform = PlatformArchitecture.X86AndX64,
+			BusType = DeviceBusType.PCI,
+			VendorID = 0x8086,
+			DeviceID = 0x2E10,
+			PCIFields = PCIField.VendorID | PCIField.DeviceID,
+			Factory = () => new PCI.Intel.Intel4SeriesChipsetPCIExpressRootPort()
+		},
 
-			new PCIDeviceDriverRegistryEntry
-			{
-				Name = "Intel4SeriesChipsetPCIExpressRootPort",
-				Platform = PlatformArchitecture.X86AndX64,
-				BusType = DeviceBusType.PCI,
-				VendorID = 0x8086,
-				DeviceID = 0x2E10,
-				PCIFields = PCIField.VendorID | PCIField.DeviceID,
-				Factory = () => new PCI.Intel.Intel4SeriesChipsetPCIExpressRootPort()
-			},
+		new PCIDeviceDriverRegistryEntry
+		{
+			Name = "Intel4SeriesChipsetPCIExpressRootPort",
+			Platform = PlatformArchitecture.X86AndX64,
+			BusType = DeviceBusType.PCI,
+			VendorID = 0x8086,
+			DeviceID = 0x2E10,
+			PCIFields = PCIField.VendorID | PCIField.DeviceID,
+			Factory = () => new PCI.Intel.Intel4SeriesChipsetPCIExpressRootPort()
+		},
 
-			new PCIDeviceDriverRegistryEntry
-			{
-				Name = "Intel440FX",
-				Platform = PlatformArchitecture.X86AndX64,
-				BusType = DeviceBusType.PCI,
-				VendorID = 0x8086,
-				DeviceID = 0x1237,
-				ClassCode = 0x06,
-				SubClassCode = 0x00,
-				PCIFields = PCIField.VendorID | PCIField.DeviceID | PCIField.ClassCode | PCIField.SubClassCode,
-				Factory = () => new PCI.Intel.Intel440FX()
-			},
+		new PCIDeviceDriverRegistryEntry
+		{
+			Name = "Intel440FX",
+			Platform = PlatformArchitecture.X86AndX64,
+			BusType = DeviceBusType.PCI,
+			VendorID = 0x8086,
+			DeviceID = 0x1237,
+			ClassCode = 0x06,
+			SubClassCode = 0x00,
+			PCIFields = PCIField.VendorID | PCIField.DeviceID | PCIField.ClassCode | PCIField.SubClassCode,
+			Factory = () => new PCI.Intel.Intel440FX()
+		},
 
-			new PCIDeviceDriverRegistryEntry
-			{
-				Name = "IntelPIIX3",
-				Platform = PlatformArchitecture.X86AndX64,
-				BusType = DeviceBusType.PCI,
-				VendorID = 0x8086,
-				DeviceID = 0x7000,
-				PCIFields = PCIField.VendorID | PCIField.DeviceID,
-				Factory = () => new PCI.Intel.IntelPIIX3()
-			},
+		new PCIDeviceDriverRegistryEntry
+		{
+			Name = "IntelPIIX3",
+			Platform = PlatformArchitecture.X86AndX64,
+			BusType = DeviceBusType.PCI,
+			VendorID = 0x8086,
+			DeviceID = 0x7000,
+			PCIFields = PCIField.VendorID | PCIField.DeviceID,
+			Factory = () => new PCI.Intel.IntelPIIX3()
+		},
 
-			new PCIDeviceDriverRegistryEntry
-			{
-				Name = "IntelPIIX4",
-				Platform = PlatformArchitecture.X86AndX64,
-				BusType = DeviceBusType.PCI,
-				VendorID = 0x8086,
-				DeviceID = 0x7113,
-				PCIFields = PCIField.VendorID | PCIField.DeviceID,
-				Factory = () => new PCI.Intel.IntelPIIX4()
-			},
+		new PCIDeviceDriverRegistryEntry
+		{
+			Name = "IntelPIIX4",
+			Platform = PlatformArchitecture.X86AndX64,
+			BusType = DeviceBusType.PCI,
+			VendorID = 0x8086,
+			DeviceID = 0x7113,
+			PCIFields = PCIField.VendorID | PCIField.DeviceID,
+			Factory = () => new PCI.Intel.IntelPIIX4()
+		},
 
-			new PCIDeviceDriverRegistryEntry
-			{
-				Name = "IntelGPIOController",
-				Platform = PlatformArchitecture.X86AndX64,
-				BusType = DeviceBusType.PCI,
-				VendorID = 0x8086,
-				DeviceID = 0x0934,
-				ClassCode = 0X0C,
-				SubClassCode = 0x80,
-				ProgIF = 0x00,
-				RevisionID = 0x10,
-				PCIFields = PCIField.VendorID | PCIField.DeviceID | PCIField.ClassCode | PCIField.SubClassCode | PCIField.ProgIF | PCIField.RevisionID,
-				Factory = () => new PCI.Intel.QuarkSoC.IntelGPIOController()
-			},
+		new PCIDeviceDriverRegistryEntry
+		{
+			Name = "IntelGPIOController",
+			Platform = PlatformArchitecture.X86AndX64,
+			BusType = DeviceBusType.PCI,
+			VendorID = 0x8086,
+			DeviceID = 0x0934,
+			ClassCode = 0X0C,
+			SubClassCode = 0x80,
+			ProgIF = 0x00,
+			RevisionID = 0x10,
+			PCIFields = PCIField.VendorID | PCIField.DeviceID | PCIField.ClassCode | PCIField.SubClassCode | PCIField.ProgIF | PCIField.RevisionID,
+			Factory = () => new PCI.Intel.QuarkSoC.IntelGPIOController()
+		},
 
-			new PCIDeviceDriverRegistryEntry
-			{
-				Name = "IntelHSUART",
-				Platform = PlatformArchitecture.X86AndX64,
-				BusType = DeviceBusType.PCI,
-				VendorID = 0x8086,
-				DeviceID = 0x0936,
-				ClassCode = 0X07,
-				SubClassCode = 0x80,
-				ProgIF = 0x02,
-				RevisionID = 0x10,
-				PCIFields = PCIField.VendorID | PCIField.DeviceID | PCIField.ClassCode | PCIField.SubClassCode | PCIField.ProgIF | PCIField.RevisionID,
-				Factory = () => new PCI.Intel.QuarkSoC.IntelHSUART()
-			},
+		new PCIDeviceDriverRegistryEntry
+		{
+			Name = "IntelHSUART",
+			Platform = PlatformArchitecture.X86AndX64,
+			BusType = DeviceBusType.PCI,
+			VendorID = 0x8086,
+			DeviceID = 0x0936,
+			ClassCode = 0X07,
+			SubClassCode = 0x80,
+			ProgIF = 0x02,
+			RevisionID = 0x10,
+			PCIFields = PCIField.VendorID | PCIField.DeviceID | PCIField.ClassCode | PCIField.SubClassCode | PCIField.ProgIF | PCIField.RevisionID,
+			Factory = () => new PCI.Intel.QuarkSoC.IntelHSUART()
+		},
 
-			new PCIDeviceDriverRegistryEntry
-			{
-				Name = "PCIIDEInterface",
-				Platform = PlatformArchitecture.X86AndX64,
-				BusType = DeviceBusType.PCI,
-				VendorID = 0x8086,
-				DeviceID = 0x7010,
-				ClassCode = 0X01,
-				SubClassCode = 0x01,
-				ProgIF = 0x80,
-				PCIFields = PCIField.VendorID | PCIField.DeviceID | PCIField.ClassCode | PCIField.SubClassCode | PCIField.ProgIF,
-				Factory = () => new PCI.Intel.PCIIDEInterface()
-			},
+		new PCIDeviceDriverRegistryEntry
+		{
+			Name = "PCIIDEInterface",
+			Platform = PlatformArchitecture.X86AndX64,
+			BusType = DeviceBusType.PCI,
+			VendorID = 0x8086,
+			DeviceID = 0x7010,
+			ClassCode = 0X01,
+			SubClassCode = 0x01,
+			ProgIF = 0x80,
+			PCIFields = PCIField.VendorID | PCIField.DeviceID | PCIField.ClassCode | PCIField.SubClassCode | PCIField.ProgIF,
+			Factory = () => new PCI.Intel.PCIIDEInterface()
+		},
 
-			new PCIDeviceDriverRegistryEntry
-			{
-				Name = "VirtIOGPU",
-				Platform = PlatformArchitecture.X86AndX64 | PlatformArchitecture.ARM32,
-				BusType = DeviceBusType.PCI,
-				VendorID = 0x1AF4,
-				DeviceID = 0x1050,
-				PCIFields = PCIField.VendorID | PCIField.DeviceID,
-				Factory = () => new PCI.VirtIO.VirtIOGPU()
-			},
+		new PCIDeviceDriverRegistryEntry
+		{
+			Name = "VirtIOGPU",
+			Platform = PlatformArchitecture.X86AndX64 | PlatformArchitecture.ARM32,
+			BusType = DeviceBusType.PCI,
+			VendorID = 0x1AF4,
+			DeviceID = 0x1050,
+			PCIFields = PCIField.VendorID | PCIField.DeviceID,
+			Factory = () => new PCI.VirtIO.VirtIOGPU()
+		},
 
-			new PCIDeviceDriverRegistryEntry
-			{
-				Name = "VMwareSVGA2",
-				Platform = PlatformArchitecture.X86AndX64,
-				BusType = DeviceBusType.PCI,
-				VendorID = 0x15AD,
-				DeviceID = 0x0405,
-				PCIFields = PCIField.VendorID | PCIField.DeviceID,
-				Factory = () => new PCI.VMware.VMwareSVGA2()
-			},
-
-			//new ISADeviceDriverRegistryEntry
-			//{
-			//	Name = "ACPI",
-			//	Platform = PlatformArchitecture.X86AndX64 | PlatformArchitecture.ARM32,
-			//	AutoLoad = true,
-			//	Factory = () => new ISA.ACPI.ACPIDriver()
-			//},
-		};
-	}
+		new PCIDeviceDriverRegistryEntry
+		{
+			Name = "VMwareSVGA2",
+			Platform = PlatformArchitecture.X86AndX64,
+			BusType = DeviceBusType.PCI,
+			VendorID = 0x15AD,
+			DeviceID = 0x0405,
+			PCIFields = PCIField.VendorID | PCIField.DeviceID,
+			Factory = () => new PCI.VMware.VMwareSVGA2()
+		}
+	};
 }

--- a/Source/Mosa.DeviceDriver/X86System.cs
+++ b/Source/Mosa.DeviceDriver/X86System.cs
@@ -11,22 +11,15 @@ namespace Mosa.DeviceDriver;
 /// </summary>
 public class X86System : BaseDeviceDriver
 {
-	public override void Initialize()
-	{
-		Device.Name = "X86System";
-	}
+	public override void Initialize() => Device.Name = "X86System";
 
-	public override void Probe()
-	{
-		Device.Status = DeviceStatus.Available;
-	}
+	public override void Probe() => Device.Status = DeviceStatus.Available;
 
 	public override void Start()
 	{
 		HAL.DebugWriteLine("X86System:Start()");
 
 		CreateISABusDevices();
-
 		Device.Status = DeviceStatus.Online;
 
 		HAL.DebugWriteLine("X86System:Start() [Exit]");
@@ -34,7 +27,7 @@ public class X86System : BaseDeviceDriver
 
 	public override bool OnInterrupt() => true;
 
-	protected void CreateISABusDevices()
+	private void CreateISABusDevices()
 	{
 		HAL.DebugWriteLine("X86System:CreateISABusDevices()");
 

--- a/Source/Mosa.DeviceSystem/Services/PCService.cs
+++ b/Source/Mosa.DeviceSystem/Services/PCService.cs
@@ -14,10 +14,7 @@ public class PCService : BaseService
 	private DeviceService deviceService;
 	private IACPI ACPI;
 
-	protected override void Initialize()
-	{
-		deviceService = ServiceManager.GetFirstService<DeviceService>();
-	}
+	protected override void Initialize() => deviceService = ServiceManager.GetFirstService<DeviceService>();
 
 	public bool Reset()
 	{


### PR DESCRIPTION
This PR focuses on refactoring the code style throughout the project. The following changes were done, wherever possible:
- Fold functions into expression bodies (one line)
- Put expression body arrow on the previous line if it's split in multiple
- Make protected and internal structs, fields and functions private (and those were appropriately renamed to fit naming conventions)
- Fields were made readonly
- Enums were unfolded into multiple lines
- Braces of single line blocks were removed
- Braces of empty blocks were put onto the same line as the statement/expression
- The "var" type inference was used for defining variables
- Some commented code was removed (mostly debug printing code)
- A space was prepended to the contents of comments explaining something, whereas spaces were removed (if any) if the comments only redirected to a link
- Pattern matching was used
- Functions, fields, function arguments and variables were renamed if they had redundant naming (e.g. ISABus: StartISADevices() => StartDevices())
- Redundant else branches and returns were removed
- Comments containing reference links for drivers were moved after the namespace declaration
- Conditions were inverted to reduce nesting
- Conditions were transformed into switch statements where appropriate
- Switch expressions were used instead of switch statements

Additionally, the following specific changes were done:
- IDEController:
  - DrivesPerConroller => DrivesPerController
  - MaximumDriveCount was moved inside the IDiskControllerInterface region for consistency
- PCIController:
  - region "IPCIController" => "IPCIControllerLegacy"
  - region "IPCIController v2" => "IPCIController"