### PR TITLE
Mosa.DeviceDriver: various improvements

### DIFF
--- a/Source/Mosa.DeviceDriver/ISA/ACPI/ACPISDTHeader.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/ACPISDTHeader.cs
@@ -4,9 +4,9 @@ using Mosa.Runtime;
 
 namespace Mosa.DeviceDriver.ISA.ACPI;
 
-public struct ACPISDTHeader
+public readonly struct ACPISDTHeader
 {
-	public Pointer Pointer;
+	public readonly Pointer Pointer;
 
 	public const uint Size = Offset.Size;
 

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/ACPISDTHeader.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/ACPISDTHeader.cs
@@ -6,9 +6,9 @@ namespace Mosa.DeviceDriver.ISA.ACPI;
 
 public struct ACPISDTHeader
 {
-	public readonly Pointer Pointer;
+	public Pointer Pointer;
 
-	public readonly uint Size = Offset.Size;
+	public const uint Size = Offset.Size;
 
 	internal static class Offset
 	{
@@ -26,21 +26,21 @@ public struct ACPISDTHeader
 
 	public ACPISDTHeader(Pointer entry) => Pointer = entry;
 
-	public readonly uint Signature => Pointer.Load32(Offset.Signature);
+	public uint Signature => Pointer.Load32(Offset.Signature);
 
-	public readonly uint Length => Pointer.Load32(Offset.Length);
+	public uint Length => Pointer.Load32(Offset.Length);
 
-	public readonly byte Revision => Pointer.Load8(Offset.Revision);
+	public byte Revision => Pointer.Load8(Offset.Revision);
 
-	public readonly byte Checksum => Pointer.Load8(Offset.Checksum);
+	public byte Checksum => Pointer.Load8(Offset.Checksum);
 
 	public byte GetOEMID(int index) => Pointer.Load8(Offset.OEMID + index);
 
 	public byte GetOEMTableID(int index) => Pointer.Load8(Offset.OEMTableID + index);
 
-	public readonly uint OEMRevision => Pointer.Load32(Offset.OEMRevision);
+	public uint OEMRevision => Pointer.Load32(Offset.OEMRevision);
 
-	public readonly uint CreatorID => Pointer.Load32(Offset.CreatorID);
+	public uint CreatorID => Pointer.Load32(Offset.CreatorID);
 
-	public readonly uint CreatorRevision => Pointer.Load32(Offset.CreatorRevision);
+	public uint CreatorRevision => Pointer.Load32(Offset.CreatorRevision);
 }

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/FADT.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/FADT.cs
@@ -6,11 +6,11 @@ namespace Mosa.DeviceDriver.ISA.ACPI;
 
 public struct FADT
 {
-	public readonly Pointer Pointer;
+	public Pointer Pointer;
 
-	public readonly uint Size = Offset.Size;
+	public const uint Size = Offset.Size;
 
-	internal static class Offset
+	private static class Offset
 	{
 		public const int h = 0;
 		public const int FirmwareCtrl = h + ACPISDTHeader.Offset.Size;
@@ -69,7 +69,7 @@ public struct FADT
 
 	public FADT(Pointer entry) => Pointer = entry;
 
-	public readonly ACPISDTHeader ACPISDTHeader => new ACPISDTHeader(Pointer + Offset.h);
+	public ACPISDTHeader ACPISDTHeader => new ACPISDTHeader(Pointer + Offset.h);
 
 	public GenericAddressStructure ResetReg => new GenericAddressStructure(Pointer + Offset.ResetReg);
 
@@ -77,85 +77,85 @@ public struct FADT
 
 	public GenericAddressStructure X_PM1bControlBlock => new GenericAddressStructure(Pointer + Offset.X_PM1bControlBlock);
 
-	public readonly uint FirmwareCtrl => Pointer.Load32(Offset.FirmwareCtrl);
+	public uint FirmwareCtrl => Pointer.Load32(Offset.FirmwareCtrl);
 
-	public readonly uint Dsdt => Pointer.Load32(Offset.Dsdt);
+	public uint Dsdt => Pointer.Load32(Offset.Dsdt);
 
-	public readonly byte Reserved => Pointer.Load8(Offset.Reserved);
+	public byte Reserved => Pointer.Load8(Offset.Reserved);
 
-	public readonly byte PreferredPowerManagementProfile => Pointer.Load8(Offset.PreferredPowerManagementProfile);
+	public byte PreferredPowerManagementProfile => Pointer.Load8(Offset.PreferredPowerManagementProfile);
 
-	public readonly ushort SCI_Interrupt => Pointer.Load16(Offset.SCI_Interrupt);
+	public ushort SCI_Interrupt => Pointer.Load16(Offset.SCI_Interrupt);
 
-	public readonly uint SMI_CommandPort => Pointer.Load32(Offset.SMI_CommandPort);
+	public uint SMI_CommandPort => Pointer.Load32(Offset.SMI_CommandPort);
 
-	public readonly byte AcpiEnable => Pointer.Load8(Offset.AcpiEnable);
+	public byte AcpiEnable => Pointer.Load8(Offset.AcpiEnable);
 
-	public readonly byte AcpiDisable => Pointer.Load8(Offset.AcpiDisable);
+	public byte AcpiDisable => Pointer.Load8(Offset.AcpiDisable);
 
-	public readonly byte S4BIOS_REQ => Pointer.Load8(Offset.S4BIOS_REQ);
+	public byte S4BIOS_REQ => Pointer.Load8(Offset.S4BIOS_REQ);
 
-	public readonly byte PSTATE_Control => Pointer.Load8(Offset.PSTATE_Control);
+	public byte PSTATE_Control => Pointer.Load8(Offset.PSTATE_Control);
 
-	public readonly uint PM1aEventBlock => Pointer.Load32(Offset.PM1aEventBlock);
+	public uint PM1aEventBlock => Pointer.Load32(Offset.PM1aEventBlock);
 
-	public readonly uint PM1bEventBlock => Pointer.Load32(Offset.PM1bEventBlock);
+	public uint PM1bEventBlock => Pointer.Load32(Offset.PM1bEventBlock);
 
-	public readonly uint PM1aControlBlock => Pointer.Load32(Offset.PM1aControlBlock);
+	public uint PM1aControlBlock => Pointer.Load32(Offset.PM1aControlBlock);
 
-	public readonly uint PM1bControlBlock => Pointer.Load32(Offset.PM1bControlBlock);
+	public uint PM1bControlBlock => Pointer.Load32(Offset.PM1bControlBlock);
 
-	public readonly uint PM2ControlBlock => Pointer.Load32(Offset.PM2ControlBlock);
+	public uint PM2ControlBlock => Pointer.Load32(Offset.PM2ControlBlock);
 
-	public readonly uint PMTimerBlock => Pointer.Load32(Offset.PMTimerBlock);
+	public uint PMTimerBlock => Pointer.Load32(Offset.PMTimerBlock);
 
-	public readonly uint GPE0Block => Pointer.Load32(Offset.GPE0Block);
+	public uint GPE0Block => Pointer.Load32(Offset.GPE0Block);
 
-	public readonly uint GPE1Block => Pointer.Load32(Offset.GPE1Block);
+	public uint GPE1Block => Pointer.Load32(Offset.GPE1Block);
 
-	public readonly byte PM1EventLength => Pointer.Load8(Offset.PM1EventLength);
+	public byte PM1EventLength => Pointer.Load8(Offset.PM1EventLength);
 
-	public readonly byte PM1ControlLength => Pointer.Load8(Offset.PM1ControlLength);
+	public byte PM1ControlLength => Pointer.Load8(Offset.PM1ControlLength);
 
-	public readonly byte PM2ControlLength => Pointer.Load8(Offset.PM2ControlLength);
+	public byte PM2ControlLength => Pointer.Load8(Offset.PM2ControlLength);
 
-	public readonly byte PMTimerLength => Pointer.Load8(Offset.PMTimerLength);
+	public byte PMTimerLength => Pointer.Load8(Offset.PMTimerLength);
 
-	public readonly byte GPE0Length => Pointer.Load8(Offset.GPE0Length);
+	public byte GPE0Length => Pointer.Load8(Offset.GPE0Length);
 
-	public readonly byte GPE1Length => Pointer.Load8(Offset.GPE1Length);
+	public byte GPE1Length => Pointer.Load8(Offset.GPE1Length);
 
-	public readonly byte GPE1Base => Pointer.Load8(Offset.GPE1Base);
+	public byte GPE1Base => Pointer.Load8(Offset.GPE1Base);
 
-	public readonly byte CStateControl => Pointer.Load8(Offset.CStateControl);
+	public byte CStateControl => Pointer.Load8(Offset.CStateControl);
 
-	public readonly ushort WorstC2Latency => Pointer.Load16(Offset.WorstC2Latency);
+	public ushort WorstC2Latency => Pointer.Load16(Offset.WorstC2Latency);
 
-	public readonly ushort WorstC3Latency => Pointer.Load16(Offset.WorstC3Latency);
+	public ushort WorstC3Latency => Pointer.Load16(Offset.WorstC3Latency);
 
-	public readonly ushort FlushSize => Pointer.Load16(Offset.FlushSize);
+	public ushort FlushSize => Pointer.Load16(Offset.FlushSize);
 
-	public readonly ushort FlushStride => Pointer.Load16(Offset.FlushStride);
+	public ushort FlushStride => Pointer.Load16(Offset.FlushStride);
 
-	public readonly byte DutyOffset => Pointer.Load8(Offset.DutyOffset);
+	public byte DutyOffset => Pointer.Load8(Offset.DutyOffset);
 
-	public readonly byte DutyWidth => Pointer.Load8(Offset.DutyWidth);
+	public byte DutyWidth => Pointer.Load8(Offset.DutyWidth);
 
-	public readonly byte DayAlarm => Pointer.Load8(Offset.DayAlarm);
+	public byte DayAlarm => Pointer.Load8(Offset.DayAlarm);
 
-	public readonly byte MonthAlarm => Pointer.Load8(Offset.MonthAlarm);
+	public byte MonthAlarm => Pointer.Load8(Offset.MonthAlarm);
 
-	public readonly byte Century => Pointer.Load8(Offset.Century);
+	public byte Century => Pointer.Load8(Offset.Century);
 
-	public readonly ushort BootArchitectureFlags => Pointer.Load16(Offset.BootArchitectureFlags);
+	public ushort BootArchitectureFlags => Pointer.Load16(Offset.BootArchitectureFlags);
 
-	public readonly byte Reserved2 => Pointer.Load8(Offset.Reserved2);
+	public byte Reserved2 => Pointer.Load8(Offset.Reserved2);
 
-	public readonly uint Flags => Pointer.Load32(Offset.Flags);
+	public uint Flags => Pointer.Load32(Offset.Flags);
 
-	public readonly byte ResetValue => Pointer.Load8(Offset.ResetValue);
+	public byte ResetValue => Pointer.Load8(Offset.ResetValue);
 
-	public readonly ulong X_FirmwareControl => Pointer.Load64(Offset.X_FirmwareControl);
+	public ulong X_FirmwareControl => Pointer.Load64(Offset.X_FirmwareControl);
 
-	public readonly ulong X_Dsdt => Pointer.Load64(Offset.X_Dsdt);
+	public ulong X_Dsdt => Pointer.Load64(Offset.X_Dsdt);
 }

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/FADT.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/FADT.cs
@@ -4,9 +4,9 @@ using Mosa.Runtime;
 
 namespace Mosa.DeviceDriver.ISA.ACPI;
 
-public struct FADT
+public readonly struct FADT
 {
-	public Pointer Pointer;
+	public readonly Pointer Pointer;
 
 	public const uint Size = Offset.Size;
 

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/GenericAddressStructure.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/GenericAddressStructure.cs
@@ -2,18 +2,13 @@
 
 using Mosa.Runtime;
 
-// Portions of this code are from Cosmos
-
-//https://wiki.osdev.org/ACPI
-//https://wiki.osdev.org/MADT
-
 namespace Mosa.DeviceDriver.ISA.ACPI;
 
 public struct GenericAddressStructure
 {
-	public readonly Pointer Pointer;
+	public Pointer Pointer;
 
-	public readonly uint Size = Offset.Size;
+	public const uint Size = Offset.Size;
 
 	internal static class Offset
 	{
@@ -27,13 +22,13 @@ public struct GenericAddressStructure
 
 	public GenericAddressStructure(Pointer entry) => Pointer = entry;
 
-	public readonly byte AddressSpace => Pointer.Load8(Offset.AddressSpace);
+	public byte AddressSpace => Pointer.Load8(Offset.AddressSpace);
 
-	public readonly byte BitWidth => Pointer.Load8(Offset.BitWidth);
+	public byte BitWidth => Pointer.Load8(Offset.BitWidth);
 
-	public readonly byte BitOffset => Pointer.Load8(Offset.BitOffset);
+	public byte BitOffset => Pointer.Load8(Offset.BitOffset);
 
-	public readonly byte AccessSize => Pointer.Load8(Offset.AccessSize);
+	public byte AccessSize => Pointer.Load8(Offset.AccessSize);
 
-	public readonly ulong Address => Pointer.Load32(Offset.Address);
+	public ulong Address => Pointer.Load32(Offset.Address);
 }

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/GenericAddressStructure.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/GenericAddressStructure.cs
@@ -4,9 +4,9 @@ using Mosa.Runtime;
 
 namespace Mosa.DeviceDriver.ISA.ACPI;
 
-public struct GenericAddressStructure
+public readonly struct GenericAddressStructure
 {
-	public Pointer Pointer;
+	public readonly Pointer Pointer;
 
 	public const uint Size = Offset.Size;
 

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/IOAPICEntry.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/IOAPICEntry.cs
@@ -6,11 +6,11 @@ namespace Mosa.DeviceDriver.ISA.ACPI;
 
 public struct IOAPICEntry
 {
-	public readonly Pointer Pointer;
+	public Pointer Pointer;
 
-	public readonly uint Size = Offset.Size;
+	public const uint Size = Offset.Size;
 
-	internal static class Offset
+	private static class Offset
 	{
 		public const int MADTEntry = 0;
 		public const int ApicID = MADTEntry + 2;
@@ -22,13 +22,13 @@ public struct IOAPICEntry
 
 	public IOAPICEntry(Pointer entry) => Pointer = entry;
 
-	public readonly MADTEntry MADTEntry => new(Pointer + Offset.MADTEntry);
+	public MADTEntry MADTEntry => new MADTEntry(Pointer + Offset.MADTEntry);
 
-	public readonly byte ApicID => Pointer.Load8(Offset.ApicID);
+	public byte ApicID => Pointer.Load8(Offset.ApicID);
 
-	public readonly byte Reserved => Pointer.Load8(Offset.Reserved);
+	public byte Reserved => Pointer.Load8(Offset.Reserved);
 
-	public readonly uint ApicAddress => Pointer.Load8(Offset.ApicAddress);
+	public uint ApicAddress => Pointer.Load8(Offset.ApicAddress);
 
-	public readonly uint GlobalSystemInterruptBase => Pointer.Load8(Offset.GlobalSystemInterruptBase);
+	public uint GlobalSystemInterruptBase => Pointer.Load8(Offset.GlobalSystemInterruptBase);
 }

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/IOAPICEntry.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/IOAPICEntry.cs
@@ -4,9 +4,9 @@ using Mosa.Runtime;
 
 namespace Mosa.DeviceDriver.ISA.ACPI;
 
-public struct IOAPICEntry
+public readonly struct IOAPICEntry
 {
-	public Pointer Pointer;
+	public readonly Pointer Pointer;
 
 	public const uint Size = Offset.Size;
 

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/LongLocalAPICEntry.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/LongLocalAPICEntry.cs
@@ -6,23 +6,23 @@ namespace Mosa.DeviceDriver.ISA.ACPI;
 
 public struct LongLocalAPICEntry
 {
-	public readonly Pointer Pointer;
+	public Pointer Pointer;
 
-	public readonly uint Size = Offset.Size;
+	public const uint Size = Offset.Size;
 
-	internal static class Offset
+	private static class Offset
 	{
 		public const int Entry = 0;
-		public const int Reserved = Entry + ACPI.MADTEntry.Offset.Size;
+		public const int Reserved = Entry + MADTEntry.Offset.Size;
 		public const int ApicAddress = Reserved + 1;
 		public const int Size = ApicAddress + 8;
 	}
 
 	public LongLocalAPICEntry(Pointer entry) => Pointer = entry;
 
-	public readonly MADTEntry MADTEntry => new(Pointer + Offset.Entry);
+	public MADTEntry MADTEntry => new MADTEntry(Pointer + Offset.Entry);
 
-	public readonly byte Reserved => Pointer.Load8(Offset.Reserved);
+	public byte Reserved => Pointer.Load8(Offset.Reserved);
 
-	public readonly uint ApicAddress => Pointer.Load8(Offset.ApicAddress);
+	public uint ApicAddress => Pointer.Load8(Offset.ApicAddress);
 }

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/LongLocalAPICEntry.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/LongLocalAPICEntry.cs
@@ -4,9 +4,9 @@ using Mosa.Runtime;
 
 namespace Mosa.DeviceDriver.ISA.ACPI;
 
-public struct LongLocalAPICEntry
+public readonly struct LongLocalAPICEntry
 {
-	public Pointer Pointer;
+	public readonly Pointer Pointer;
 
 	public const uint Size = Offset.Size;
 

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/MADT.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/MADT.cs
@@ -6,11 +6,11 @@ namespace Mosa.DeviceDriver.ISA.ACPI;
 
 public struct MADT
 {
-	public readonly Pointer Pointer;
+	public Pointer Pointer;
 
-	public readonly uint Size => Offset.Size;
+	public const uint Size = Offset.Size;
 
-	internal static class Offset
+	private static class Offset
 	{
 		public const int ACPISDTHeader = 0;
 		public const int LocalApicAddress = ACPISDTHeader + ACPI.ACPISDTHeader.Offset.Size;
@@ -20,9 +20,9 @@ public struct MADT
 
 	public MADT(Pointer entry) => Pointer = entry;
 
-	public readonly ACPISDTHeader ACPISDTHeader => new(Pointer + Offset.ACPISDTHeader);
+	public ACPISDTHeader ACPISDTHeader => new ACPISDTHeader(Pointer + Offset.ACPISDTHeader);
 
-	public readonly uint LocalApicAddress => Pointer.Load32(Offset.LocalApicAddress);
+	public uint LocalApicAddress => Pointer.Load32(Offset.LocalApicAddress);
 
-	public readonly uint Flags => Pointer.Load32(Offset.Flags);
+	public uint Flags => Pointer.Load32(Offset.Flags);
 }

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/MADT.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/MADT.cs
@@ -4,9 +4,9 @@ using Mosa.Runtime;
 
 namespace Mosa.DeviceDriver.ISA.ACPI;
 
-public struct MADT
+public readonly struct MADT
 {
-	public Pointer Pointer;
+	public readonly Pointer Pointer;
 
 	public const uint Size = Offset.Size;
 

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/MADTEntry.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/MADTEntry.cs
@@ -4,9 +4,9 @@ using Mosa.Runtime;
 
 namespace Mosa.DeviceDriver.ISA.ACPI;
 
-public struct MADTEntry
+public readonly struct MADTEntry
 {
-	public Pointer Pointer;
+	public readonly Pointer Pointer;
 
 	public const uint Size = Offset.Size;
 

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/MADTEntry.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/MADTEntry.cs
@@ -6,9 +6,9 @@ namespace Mosa.DeviceDriver.ISA.ACPI;
 
 public struct MADTEntry
 {
-	public readonly Pointer Pointer;
+	public Pointer Pointer;
 
-	public readonly uint Size => Offset.Size;
+	public const uint Size = Offset.Size;
 
 	internal static class Offset
 	{
@@ -19,7 +19,7 @@ public struct MADTEntry
 
 	public MADTEntry(Pointer entry) => Pointer = entry;
 
-	public readonly byte Type => Pointer.Load8(Offset.Type);
+	public byte Type => Pointer.Load8(Offset.Type);
 
-	public readonly byte Length => Pointer.Load8(Offset.Length);
+	public byte Length => Pointer.Load8(Offset.Length);
 }

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/ProcessorLocalAPICEntry.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/ProcessorLocalAPICEntry.cs
@@ -6,11 +6,11 @@ namespace Mosa.DeviceDriver.ISA.ACPI;
 
 public struct ProcessorLocalAPICEntry
 {
-	public readonly Pointer Pointer;
+	public Pointer Pointer;
 
-	public readonly uint Size => Offset.Size;
+	public const uint Size = Offset.Size;
 
-	internal static class Offset
+	private static class Offset
 	{
 		public const int Entry = 0;
 		public const int AcpiProcessorID = MADTEntry.Offset.Size + Entry;
@@ -21,11 +21,11 @@ public struct ProcessorLocalAPICEntry
 
 	public ProcessorLocalAPICEntry(Pointer entry) => Pointer = entry;
 
-	public readonly MADTEntry MADTEntry => new(Pointer + Offset.Entry);
+	public MADTEntry MADTEntry => new MADTEntry(Pointer + Offset.Entry);
 
-	public readonly byte AcpiProcessorID => Pointer.Load8(Offset.AcpiProcessorID);
+	public byte AcpiProcessorID => Pointer.Load8(Offset.AcpiProcessorID);
 
-	public readonly byte ApicID => Pointer.Load8(Offset.ApicID);
+	public byte ApicID => Pointer.Load8(Offset.ApicID);
 
-	public readonly uint Flags => Pointer.Load32(Offset.Flags);
+	public uint Flags => Pointer.Load32(Offset.Flags);
 }

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/ProcessorLocalAPICEntry.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/ProcessorLocalAPICEntry.cs
@@ -4,9 +4,9 @@ using Mosa.Runtime;
 
 namespace Mosa.DeviceDriver.ISA.ACPI;
 
-public struct ProcessorLocalAPICEntry
+public readonly struct ProcessorLocalAPICEntry
 {
-	public Pointer Pointer;
+	public readonly Pointer Pointer;
 
 	public const uint Size = Offset.Size;
 

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/RSDPDescriptor.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/RSDPDescriptor.cs
@@ -4,9 +4,9 @@ using Mosa.Runtime;
 
 namespace Mosa.DeviceDriver.ISA.ACPI;
 
-public struct RSDPDescriptor
+public readonly struct RSDPDescriptor
 {
-	public Pointer Pointer;
+	public readonly Pointer Pointer;
 
 	public const uint Size = Offset.Size;
 

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/RSDPDescriptor.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/RSDPDescriptor.cs
@@ -6,11 +6,11 @@ namespace Mosa.DeviceDriver.ISA.ACPI;
 
 public struct RSDPDescriptor
 {
-	public readonly Pointer Pointer;
+	public Pointer Pointer;
 
-	public readonly uint Size = Offset.Size;
+	public const uint Size = Offset.Size;
 
-	internal static class Offset
+	private static class Offset
 	{
 		public const int Signature = 0;
 		public const int Checksum = Signature + 8;
@@ -22,13 +22,13 @@ public struct RSDPDescriptor
 
 	public RSDPDescriptor(Pointer entry) => Pointer = entry;
 
-	public readonly ulong Signature => Pointer.Load64(Offset.Signature);
+	public ulong Signature => Pointer.Load64(Offset.Signature);
 
-	public readonly byte Checksum => Pointer.Load8(Offset.Checksum);
+	public byte Checksum => Pointer.Load8(Offset.Checksum);
 
-	public readonly byte Revision => Pointer.Load8(Offset.Revision);
+	public byte Revision => Pointer.Load8(Offset.Revision);
 
-	public readonly Pointer RsdtAddress => new(Pointer.Load32(Offset.RsdtAddress));
+	public Pointer RsdtAddress => new Pointer(Pointer.Load32(Offset.RsdtAddress));
 
 	public byte GetSignature(int index) => Pointer.Load8(Offset.Signature + index);
 }

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/RSDPDescriptor20.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/RSDPDescriptor20.cs
@@ -4,9 +4,9 @@ using Mosa.Runtime;
 
 namespace Mosa.DeviceDriver.ISA.ACPI;
 
-public struct RSDPDescriptor20
+public readonly struct RSDPDescriptor20
 {
-	public Pointer Pointer;
+	public readonly Pointer Pointer;
 
 	public const uint Size = Offset.Size;
 

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/RSDPDescriptor20.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/RSDPDescriptor20.cs
@@ -2,18 +2,13 @@
 
 using Mosa.Runtime;
 
-// Portions of this code are from Cosmos
-
-//https://wiki.osdev.org/ACPI
-//https://wiki.osdev.org/MADT
-
 namespace Mosa.DeviceDriver.ISA.ACPI;
 
 public struct RSDPDescriptor20
 {
-	public readonly Pointer Pointer;
+	public Pointer Pointer;
 
-	public readonly uint Size = Offset.Size;
+	public const uint Size = Offset.Size;
 
 	private static class Offset
 	{
@@ -32,15 +27,15 @@ public struct RSDPDescriptor20
 
 	public RSDPDescriptor20(Pointer entry) => Pointer = entry;
 
-	public readonly byte Checksum => Pointer.Load8(Offset.Checksum);
+	public byte Checksum => Pointer.Load8(Offset.Checksum);
 
-	public readonly byte Revision => Pointer.Load8(Offset.Revision);
+	public byte Revision => Pointer.Load8(Offset.Revision);
 
-	public readonly Pointer RsdtAddress => new(Pointer.Load32(Offset.RsdtAddress));
+	public Pointer RsdtAddress => new Pointer(Pointer.Load32(Offset.RsdtAddress));
 
-	public readonly uint Length => Pointer.Load32(Offset.Length);
+	public uint Length => Pointer.Load32(Offset.Length);
 
-	public readonly Pointer XsdtAddress => new(Pointer.Load64(Offset.XsdtAddress));
+	public Pointer XsdtAddress => new Pointer(Pointer.Load64(Offset.XsdtAddress));
 
-	public readonly byte ExtendedChecksum => Pointer.Load8(Offset.ExtendedChecksum);
+	public byte ExtendedChecksum => Pointer.Load8(Offset.ExtendedChecksum);
 }

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/RSDT.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/RSDT.cs
@@ -6,11 +6,11 @@ namespace Mosa.DeviceDriver.ISA.ACPI;
 
 public struct RSDT
 {
-	public readonly Pointer Pointer;
+	public Pointer Pointer;
 
-	public readonly uint Size => Offset.Size;
+	public const uint Size = Offset.Size;
 
-	internal static class Offset
+	private static class Offset
 	{
 		public const int ACPISDTHeader = 0;
 		public const int PointerToOtherSDT = ACPI.ACPISDTHeader.Offset.Size + ACPISDTHeader;
@@ -19,7 +19,7 @@ public struct RSDT
 
 	public RSDT(Pointer entry) => Pointer = entry;
 
-	public readonly ACPISDTHeader ACPISDTHeader => new(Pointer + Offset.ACPISDTHeader);
+	public ACPISDTHeader ACPISDTHeader => new ACPISDTHeader(Pointer + Offset.ACPISDTHeader);
 
-	public Pointer GetPointerToOtherSDT(uint index) => new(Pointer.Load32(Offset.PointerToOtherSDT + 4 * index));
+	public Pointer GetPointerToOtherSDT(uint index) => new Pointer(Pointer.Load32(Offset.PointerToOtherSDT + 4 * index));
 }

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/RSDT.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/RSDT.cs
@@ -4,9 +4,9 @@ using Mosa.Runtime;
 
 namespace Mosa.DeviceDriver.ISA.ACPI;
 
-public struct RSDT
+public readonly struct RSDT
 {
-	public Pointer Pointer;
+	public readonly Pointer Pointer;
 
 	public const uint Size = Offset.Size;
 

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/XSDT.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/XSDT.cs
@@ -4,9 +4,9 @@ using Mosa.Runtime;
 
 namespace Mosa.DeviceDriver.ISA.ACPI;
 
-public struct XSDT
+public readonly struct XSDT
 {
-	public Pointer Pointer;
+	public readonly Pointer Pointer;
 
 	public const uint Size = Offset.Size;
 

--- a/Source/Mosa.DeviceDriver/ISA/ACPI/XSDT.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ACPI/XSDT.cs
@@ -6,11 +6,11 @@ namespace Mosa.DeviceDriver.ISA.ACPI;
 
 public struct XSDT
 {
-	public readonly Pointer Pointer;
+	public Pointer Pointer;
 
-	public readonly uint Size => Offset.Size;
+	public const uint Size = Offset.Size;
 
-	internal static class Offset
+	private static class Offset
 	{
 		public const int ACPISDTHeader = 0;
 		public const int PointerToOtherSDT = ACPI.ACPISDTHeader.Offset.Size + ACPISDTHeader;
@@ -19,7 +19,7 @@ public struct XSDT
 
 	public XSDT(Pointer entry) => Pointer = entry;
 
-	public readonly ACPISDTHeader ACPISDTHeader => new(Pointer + Offset.ACPISDTHeader);
+	public ACPISDTHeader ACPISDTHeader => new ACPISDTHeader(Pointer + Offset.ACPISDTHeader);
 
-	public Pointer GetPointerToOtherSDT(uint index) => new(Pointer.Load64(Offset.PointerToOtherSDT + 16 * index));
+	public Pointer GetPointerToOtherSDT(uint index) => new Pointer(Pointer.Load64(Offset.PointerToOtherSDT + 16 * index));
 }

--- a/Source/Mosa.DeviceDriver/ISA/IDEController.cs
+++ b/Source/Mosa.DeviceDriver/ISA/IDEController.cs
@@ -1,15 +1,14 @@
 ﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
 
-// References
-// http://www.t13.org/Documents/UploadedDocuments/docs2004/d1572r3-EDD3.pdf
-// http://mirrors.josefsipek.net/www.nondot.org/sabre/os/files/Disk/IDE-tech.html
-
 using Mosa.DeviceSystem.Disks;
 using Mosa.DeviceSystem.Framework;
 using Mosa.DeviceSystem.HardwareAbstraction;
 using Mosa.DeviceSystem.Misc;
 
 namespace Mosa.DeviceDriver.ISA;
+
+// http://www.t13.org/Documents/UploadedDocuments/docs2004/d1572r3-EDD3.pdf
+// http://mirrors.josefsipek.net/www.nondot.org/sabre/os/files/Disk/IDE-tech.html
 
 /// <summary>
 /// IDE Controller
@@ -318,13 +317,6 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 	}
 
 	/// <summary>
-	/// Opens the specified drive.
-	/// </summary>
-	/// <param name="drive">The drive.</param>
-	/// <returns></returns>
-	public bool Open(uint drive) => drive < MaximumDriveCount && driveInfo[drive].Present;
-
-	/// <summary>
 	/// Performs the LBA28.
 	/// </summary>
 	/// <param name="operation">The operation.</param>
@@ -435,6 +427,13 @@ public class IDEController : BaseDeviceDriver, IDiskControllerDevice
 	/// </summary>
 	/// <value>The drive count.</value>
 	public uint MaximumDriveCount { get; private set; }
+
+	/// <summary>
+	/// Opens the specified drive.
+	/// </summary>
+	/// <param name="drive">The drive.</param>
+	/// <returns></returns>
+	public bool Open(uint drive) => drive < MaximumDriveCount && driveInfo[drive].Present;
 
 	/// <summary>
 	/// Releases the specified drive.

--- a/Source/Mosa.DeviceDriver/ISA/ISABus.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ISABus.cs
@@ -13,7 +13,7 @@ namespace Mosa.DeviceDriver.ISA;
 /// </summary>
 public class ISABus : BaseDeviceDriver
 {
-	public override void Initialize() => Device.Name = "ISA-BUS";
+	public override void Initialize() => Device.Name = "ISABus";
 
 	public override void Probe() => Device.Status = DeviceStatus.Available;
 
@@ -27,7 +27,7 @@ public class ISABus : BaseDeviceDriver
 
 	private void StartDevices()
 	{
-		HAL.DebugWriteLine("ISABus:StartISADevices()");
+		HAL.DebugWriteLine("ISABus:StartDevices()");
 
 		// Start ISA Drivers
 		var drivers = DeviceService.GetDeviceDrivers(DeviceBusType.ISA);
@@ -42,7 +42,7 @@ public class ISABus : BaseDeviceDriver
 			StartDevice(entry);
 		}
 
-		HAL.DebugWriteLine("ISABus:StartISADevices() [Exit]");
+		HAL.DebugWriteLine("ISABus:StartDevices() [Exit]");
 	}
 
 	private void StartDevice(ISADeviceDriverRegistryEntry driverEntry)

--- a/Source/Mosa.DeviceDriver/ISA/PCIController.cs
+++ b/Source/Mosa.DeviceDriver/ISA/PCIController.cs
@@ -12,11 +12,7 @@ namespace Mosa.DeviceDriver.ISA;
 //[ISADeviceDriver(AutoLoad = true, BasePort = 0x0CF8, PortRange = 8, Platforms = PlatformArchitecture.X86AndX64)]
 public sealed class PCIController : BaseDeviceDriver, IPCIControllerLegacy, IPCIController
 {
-	#region Definitions
-
 	private const uint BaseValue = 0x80000000;
-
-	#endregion Definitions
 
 	/// <summary>
 	/// The configuration address
@@ -30,7 +26,7 @@ public sealed class PCIController : BaseDeviceDriver, IPCIControllerLegacy, IPCI
 
 	public override void Initialize()
 	{
-		Device.Name = "PCI_0x" + Device.Resources.IOPortRegions[0].BaseIOPort.ToString("X");
+		Device.Name = "PCIController_0x" + Device.Resources.IOPortRegions[0].BaseIOPort.ToString("X");
 
 		configAddress = Device.Resources.GetIOPortReadWrite(0, 0);
 		configData = Device.Resources.GetIOPortReadWrite(0, 4);

--- a/Source/Mosa.DeviceDriver/ISA/StandardKeyboard.cs
+++ b/Source/Mosa.DeviceDriver/ISA/StandardKeyboard.cs
@@ -57,12 +57,14 @@ public class StandardKeyboard : BaseDeviceDriver, IKeyboardDevice
 		{
 			var next = fifoEnd + 1;
 
+			// Check if FIFO buffer is full
 			if (next == FIFOSize)
 				next = 0;
 
-			if (next == fifoStart) // Out of room
+			if (next == fifoStart)
 				return;
 
+			// If not, add the scan code
 			fifoBuffer[next] = scancode;
 			fifoEnd = next;
 		}

--- a/Source/Mosa.DeviceDriver/ISA/StandardMouse.cs
+++ b/Source/Mosa.DeviceDriver/ISA/StandardMouse.cs
@@ -6,126 +6,117 @@ using Mosa.DeviceSystem.HardwareAbstraction;
 using Mosa.DeviceSystem.Mouse;
 
 namespace Mosa.DeviceDriver.ISA;
+
 //https://github.com/nifanfa/MOSA-Core/blob/master/Source/Mosa.External.x86/Driver/Input/PS2Mouse.cs
 //https://forum.osdev.org/viewtopic.php?t=10247
 //https://wiki.osdev.org/Mouse_Input
 
 public class StandardMouse : BaseDeviceDriver, IMouseDevice
 {
+	private enum WaitType
+	{
+		Read,
+		Write
+	}
+
+	private enum PhaseType
+	{
+		HandleAcknowledgeReply,
+		HandleState,
+		HandleXCoordinate,
+		HandleYCoordinate
+	}
+
 	private IOPortReadWrite command, data;
 
 	private const byte SetDefaults = 0xF6, EnableDataReporting = 0xF4, SetSampleRate = 0xF3;
 
 	private uint screenWidth, screenHeight;
-	private int phase, aX, aY;
-
-	private readonly byte[] mData = new byte[3];
+	private PhaseType phase;
 
 	public uint X { get; set; }
 
 	public uint Y { get; set; }
 
-	public MouseState State { get; private set; }
+	public MouseState State { get; private set; } = MouseState.None;
 
 	public override void Initialize()
 	{
 		Device.Name = "StandardMouse";
 
-		data = Device.Resources.GetIOPortReadWrite(0, 0); // 0x60
-		command = Device.Resources.GetIOPortReadWrite(1, 0); // 0x64
+		data = Device.Resources.GetIOPortReadWrite(0, 0);
+		command = Device.Resources.GetIOPortReadWrite(1, 0);
 
 		// Enable the auxiliary mouse device
-		Wait(1);
+		WaitReady(WaitType.Write);
 		command.Write8(0xA8);
 
 		// Enable the interrupts
-		Wait(1);
+		WaitReady(WaitType.Write);
 		command.Write8(0x20);
-		Wait(0);
+		WaitReady(0);
 		var status = (byte)(data.Read8() | 3);
-		Wait(1);
+		WaitReady(WaitType.Write);
 		command.Write8(0x60);
-		Wait(1);
+		WaitReady(WaitType.Write);
 		data.Write8(status);
 
 		WriteRegister(SetDefaults);
 		WriteRegister(EnableDataReporting);
 		WriteRegister(SetSampleRate, 200);
-
-		State = MouseState.None;
 	}
 
-	/// <summary>
-	/// Probes this instance.
-	/// </summary>
-	/// <remarks>
-	/// Override for ISA devices, if example
-	/// </remarks>
 	public override void Probe() => Device.Status = DeviceStatus.Available;
 
-	/// <summary>
-	/// Starts this hardware device.
-	/// </summary>
 	public override void Start() => Device.Status = DeviceStatus.Online;
 
 	public override bool OnInterrupt()
 	{
-		byte D = data.Read8();
+		var b = data.Read8();
 
-		if (phase == 0)
+		switch (phase)
 		{
-			if (D == 0xfa)
-				phase = 1;
-			return true;
+			case PhaseType.HandleAcknowledgeReply:
+				{
+					if (b == 0xFA)
+						phase = PhaseType.HandleState;
+					return true;
+				}
+			case PhaseType.HandleState:
+				{
+					if ((b & (1 << 3)) != 1 << 3)
+						return true;
+
+					State = (b & 0x07) switch
+					{
+						0x01 => MouseState.Left,
+						0x02 => MouseState.Right,
+
+						// TODO: Add scroll wheel
+						_ => MouseState.None
+					};
+
+					phase = PhaseType.HandleXCoordinate;
+					return true;
+				}
+			case PhaseType.HandleXCoordinate:
+				{
+					var xOffset = b > 127 ? -(255 - b) : b;
+					X = (uint)Math.Clamp(X + xOffset, 0, screenWidth);
+
+					phase = PhaseType.HandleYCoordinate;
+					return true;
+				}
+			case PhaseType.HandleYCoordinate:
+				{
+					var yOffset = b > 127 ? -(255 - b) : b;
+					Y = (uint)Math.Clamp(Y - yOffset, 0, screenHeight);
+
+					phase = PhaseType.HandleState;
+					return true;
+				}
+			default: throw new ArgumentOutOfRangeException();
 		}
-
-		if (phase == 1)
-		{
-			if ((D & (1 << 3)) == 1 << 3)
-			{
-				mData[0] = D;
-				phase = 2;
-			}
-			return true;
-		}
-
-		if (phase == 2)
-		{
-			mData[1] = D;
-			phase = 3;
-			return true;
-		}
-
-		if (phase == 3)
-		{
-			mData[2] = D;
-			phase = 1;
-
-			mData[0] &= 0x07;
-			State = mData[0] switch
-			{
-				0x01 => MouseState.Left,
-				0x02 => MouseState.Right,
-
-				// TODO: Add scroll wheel
-				_ => MouseState.None,
-			};
-
-			if (mData[1] > 127)
-				aX = -(255 - mData[1]);
-			else
-				aX = mData[1];
-
-			if (mData[2] > 127)
-				aY = -(255 - mData[2]);
-			else
-				aY = mData[2];
-
-			X = (uint)Math.Clamp(X + aX, 0, screenWidth);
-			Y = (uint)Math.Clamp(Y - aY, 0, screenHeight);
-		}
-
-		return true;
 	}
 
 	public void SetScreenResolution(uint width, uint height)
@@ -139,29 +130,11 @@ public class StandardMouse : BaseDeviceDriver, IMouseDevice
 
 	#region Private
 
-	private void Wait(byte type)
-	{
-		var timeout = 100000;
-
-		if (type == 0)
-		{
-			for (; timeout > 0; timeout--)
-				if ((command.Read8() & 1) == 1)
-					return;
-
-			return;
-		}
-
-		for (; timeout > 0; timeout--)
-			if ((command.Read8() & 2) == 0)
-				return;
-	}
-
 	private void WriteRegister(byte value)
 	{
-		Wait(1);
+		WaitReady(WaitType.Write);
 		command.Write8(0xD4);
-		Wait(1);
+		WaitReady(WaitType.Write);
 		data.Write8(value);
 
 		ReadRegister();
@@ -169,19 +142,41 @@ public class StandardMouse : BaseDeviceDriver, IMouseDevice
 
 	private void WriteRegister(byte cmd, byte value)
 	{
-		Wait(1);
+		WaitReady(WaitType.Write);
 		command.Write8(cmd);
-		Wait(1);
+		WaitReady(WaitType.Write);
 		data.Write8(value);
-		Wait(1);
+		WaitReady(WaitType.Write);
 
 		ReadRegister();
 	}
 
 	private byte ReadRegister()
 	{
-		Wait(0);
+		WaitReady(WaitType.Read);
 		return data.Read8();
+	}
+
+	private void WaitReady(WaitType type)
+	{
+		var timeout = 100000;
+
+		switch (type)
+		{
+			case WaitType.Read:
+				{
+					while (timeout > 0 && (command.Read8() & 1) != 1)
+						timeout--;
+					return;
+				}
+			case WaitType.Write:
+				{
+					while (timeout > 0 && (command.Read8() & 2) != 0)
+						timeout--;
+					return;
+				}
+			default: throw new ArgumentOutOfRangeException(nameof(type));
+		}
 	}
 
 	#endregion Private

--- a/Source/Mosa.DeviceDriver/PCI/VMware/VMwareSVGA2.cs
+++ b/Source/Mosa.DeviceDriver/PCI/VMware/VMwareSVGA2.cs
@@ -197,15 +197,15 @@ public class VMwareSVGA2 : BaseDeviceDriver, IGraphicsDevice
 
 	#endregion Definitions
 
-	private IOPortReadWrite indexPort, valuePort;
-	private uint vramSize, bufferSize, fifoSize, capabilities;
-	private ConstrainedPointer buffer, fifo;
-
 	public FrameBuffer32 FrameBuffer { get; private set; }
+
+	private IOPortReadWrite indexPort, valuePort;
+	private uint bufferSize, fifoSize, capabilities;
+	private ConstrainedPointer buffer, fifo;
 
 	public override void Initialize()
 	{
-		Device.Name = "VMWARE_SVGA2_0x" + Device.Resources.IOPortRegions[0].BaseIOPort.ToString("X");
+		Device.Name = "VMwareSVGA2_0x" + Device.Resources.IOPortRegions[0].BaseIOPort.ToString("X");
 
 		// Doesn't work on VMware Workstation
 		//buffer = Device.Resources.GetMemory(0);
@@ -229,7 +229,6 @@ public class VMwareSVGA2 : BaseDeviceDriver, IGraphicsDevice
 			return;
 		}
 
-		vramSize = ReadRegister(SvgaRegister.VRamSize);
 		fifoSize = ReadRegister(SvgaRegister.MemSize);
 		capabilities = ReadRegister(SvgaRegister.Capabilities);
 

--- a/Source/Mosa.DeviceDriver/ScanCodeMap/HU.cs
+++ b/Source/Mosa.DeviceDriver/ScanCodeMap/HU.cs
@@ -48,7 +48,7 @@ public class HU : IScanCodeMap
 		if (scancode == 0)
 			return key;
 
-		key.KeyPress = (scancode & 0x80) != 0 ? KeyEvent.KeyPressType.Break : key.KeyPress = KeyEvent.KeyPressType.Make;
+		key.KeyPress = (scancode & 0x80) != 0 ? KeyEvent.KeyPressType.Break : KeyEvent.KeyPressType.Make;
 		key.KeyType = KeyType.RegularKey;
 
 		switch (scancode & 0x7F)
@@ -107,6 +107,7 @@ public class HU : IScanCodeMap
 			case 52: key.Character = shift ? ':' : '.'; break;
 			case 53: key.Character = shift ? '_' : '-'; break;
 			case 54: key.KeyType = KeyType.RightShift; break;
+
 			case 56: key.KeyType = KeyType.LeftAlt; break;
 			case 57: key.Character = ' '; break;
 			case 58: key.KeyType = KeyType.CapsLock; break;
@@ -127,6 +128,7 @@ public class HU : IScanCodeMap
 			case 73: key.KeyType = KeyType.PageUp; break;
 			case 74: key.Character = '-'; break;
 			case 75: key.KeyType = KeyType.LeftArrow; break;
+
 			case 77: key.KeyType = KeyType.RightArrow; break;
 			case 78: key.Character = '+'; break;
 			case 79: key.KeyType = KeyType.End; break;
@@ -134,10 +136,13 @@ public class HU : IScanCodeMap
 			case 81: key.KeyType = KeyType.PageDown; break;
 			case 82: key.KeyType = KeyType.Insert; break;
 			case 83: key.KeyType = KeyType.Delete; break;
+
 			case 86: key.Character = TransformCharacter('<'); break;
 			case 87: key.KeyType = KeyType.F11; break;
 			case 88: key.KeyType = KeyType.F12; break;
-			default: return new KeyEvent(); // Unmapped buttons (which doesn't exist on a hungarian keyboard)
+
+			// Unmapped buttons (which doesn't exist on a hungarian keyboard)
+			default: return new KeyEvent();
 		}
 
 		switch (key.KeyType)

--- a/Source/Mosa.DeviceDriver/ScanCodeMap/US.cs
+++ b/Source/Mosa.DeviceDriver/ScanCodeMap/US.cs
@@ -13,17 +13,11 @@ public class US : IScanCodeMap
 	{
 		Normal,
 		Escaped,
-		Espaced2,
 		EscapeBreak
 	}
 
 	private KeyState keyState = KeyState.Normal;
 
-	/// <summary>
-	/// Convert can code into a key
-	/// </summary>
-	/// <param name="scancode">The scancode.</param>
-	/// <returns></returns>
 	public KeyEvent ConvertScanCode(byte scancode)
 	{
 		var key = new KeyEvent();
@@ -43,188 +37,15 @@ public class US : IScanCodeMap
 					key.KeyPress = (scancode & 0x80) != 0 ? KeyEvent.KeyPressType.Break : KeyEvent.KeyPressType.Make;
 					key.KeyType = KeyType.RegularKey;
 
-					switch (scancode)
-					{
-						case 1: key.Character = (char)27; break;
-						case 2: key.Character = '1'; break;
-						case 3: key.Character = '2'; break;
-						case 4: key.Character = '3'; break;
-						case 5: key.Character = '4'; break;
-						case 6: key.Character = '5'; break;
-						case 7: key.Character = '6'; break;
-						case 8: key.Character = '7'; break;
-						case 9: key.Character = '8'; break;
-						case 10: key.Character = '9'; break;
-						case 11: key.Character = '0'; break;
-						case 12: key.Character = '-'; break;
-						case 13: key.Character = '='; break;
-						case 14: key.Character = '\b'; break;
-						case 15: key.Character = '\t'; break;
-						case 16: key.Character = 'q'; break;
-						case 17: key.Character = 'w'; break;
-						case 18: key.Character = 'e'; break;
-						case 19: key.Character = 'r'; break;
-						case 20: key.Character = 't'; break;
-						case 21: key.Character = 'y'; break;
-						case 22: key.Character = 'u'; break;
-						case 23: key.Character = 'i'; break;
-						case 24: key.Character = 'o'; break;
-						case 25: key.Character = 'p'; break;
-						case 26: key.Character = '['; break;
-						case 27: key.Character = ']'; break;
-						case 28: key.Character = '\n'; break;
-						case 29: key.KeyType = KeyType.LeftControl; break;
-						case 30: key.Character = 'a'; break;
-						case 31: key.Character = 's'; break;
-						case 32: key.Character = 'd'; break;
-						case 33: key.Character = 'f'; break;
-						case 34: key.Character = 'g'; break;
-						case 35: key.Character = 'h'; break;
-						case 36: key.Character = 'j'; break;
-						case 37: key.Character = 'k'; break;
-						case 38: key.Character = 'l'; break;
-						case 39: key.Character = ';'; break;
-						case 40: key.Character = '\''; break;
-						case 41: key.Character = '`'; break;
-						case 42: key.KeyType = KeyType.LeftShift; break;
-						case 43: key.Character = '\\'; break;
-						case 44: key.Character = 'z'; break;
-						case 45: key.Character = 'x'; break;
-						case 46: key.Character = 'c'; break;
-						case 47: key.Character = 'v'; break;
-						case 48: key.Character = 'b'; break;
-						case 49: key.Character = 'n'; break;
-						case 50: key.Character = 'm'; break;
-						case 51: key.Character = ','; break;
-						case 52: key.Character = '.'; break;
-						case 53: key.Character = '/'; break;
-						case 54: key.KeyType = KeyType.RightShift; break;
-						case 55: key.Character = '*'; break;
-						case 56: key.KeyType = KeyType.LeftAlt; break;
-						case 57: key.Character = ' '; break;
-						case 58: key.KeyType = KeyType.CapsLock; break;
-						case 59: key.KeyType = KeyType.F1; break;
-						case 60: key.KeyType = KeyType.F2; break;
-						case 61: key.KeyType = KeyType.F3; break;
-						case 62: key.KeyType = KeyType.F4; break;
-						case 63: key.KeyType = KeyType.F5; break;
-						case 64: key.KeyType = KeyType.F6; break;
-						case 65: key.KeyType = KeyType.F7; break;
-						case 66: key.KeyType = KeyType.F8; break;
-						case 67: key.KeyType = KeyType.F9; break;
-						case 68: key.KeyType = KeyType.F10; break;
-						case 69: key.KeyType = KeyType.NumLock; break;
-						case 70: key.KeyType = KeyType.ScrollLock; break;
-						case 71: key.KeyType = KeyType.Home; break;
-						case 72: key.KeyType = KeyType.UpArrow; break;
-						case 73: key.KeyType = KeyType.PageUp; break;
-						case 74: key.Character = '-'; break;
-						case 75: key.KeyType = KeyType.LeftArrow; break;
-						case 76: key.Character = (char)0; break;
-						case 77: key.KeyType = KeyType.RightArrow; break;
-						case 78: key.Character = '+'; break;
-						case 79: key.KeyType = KeyType.End; break;
-						case 80: key.KeyType = KeyType.DownArrow; break;
-						case 81: key.KeyType = KeyType.PageDown; break;
-						case 82: key.KeyType = KeyType.Insert; break;
-						case 83: key.KeyType = KeyType.Delete; break;
-						case 86: key.Character = '\\'; break;
-						case 87: key.KeyType = KeyType.F11; break;
-						case 88: key.KeyType = KeyType.F12; break;
-						case 129: key.Character = (char)27; break;
-						case 130: key.Character = '!'; break;
-						case 131: key.Character = '@'; break;
-						case 132: key.Character = '#'; break;
-						case 133: key.Character = '$'; break;
-						case 134: key.Character = '%'; break;
-						case 135: key.Character = '^'; break;
-						case 136: key.Character = '&'; break;
-						case 137: key.Character = '*'; break;
-						case 138: key.Character = '('; break;
-						case 139: key.Character = ')'; break;
-						case 140: key.Character = '_'; break;
-						case 141: key.Character = '+'; break;
-						case 142: key.Character = '\b'; break;
-						case 143: key.Character = '\t'; break;
-						case 144: key.Character = 'Q'; break;
-						case 145: key.Character = 'W'; break;
-						case 146: key.Character = 'E'; break;
-						case 147: key.Character = 'R'; break;
-						case 148: key.Character = 'T'; break;
-						case 149: key.Character = 'Y'; break;
-						case 150: key.Character = 'U'; break;
-						case 151: key.Character = 'I'; break;
-						case 152: key.Character = 'O'; break;
-						case 153: key.Character = 'P'; break;
-						case 154: key.Character = '{'; break;
-						case 155: key.Character = '}'; break;
-						case 156: key.Character = '\n'; break;
-						case 157: key.KeyType = KeyType.RightControl; break;
-						case 158: key.Character = 'A'; break;
-						case 159: key.Character = 'S'; break;
-						case 160: key.Character = 'D'; break;
-						case 161: key.Character = 'F'; break;
-						case 162: key.Character = 'G'; break;
-						case 163: key.Character = 'H'; break;
-						case 164: key.Character = 'J'; break;
-						case 165: key.Character = 'K'; break;
-						case 166: key.Character = 'L'; break;
-						case 167: key.Character = ':'; break;
-						case 168: key.Character = '"'; break;
-						case 169: key.Character = '~'; break;
-						case 170: key.KeyType = KeyType.LeftShift; break;
-						case 171: key.Character = '|'; break;
-						case 172: key.Character = 'Z'; break;
-						case 173: key.Character = 'X'; break;
-						case 174: key.Character = 'C'; break;
-						case 175: key.Character = 'V'; break;
-						case 176: key.Character = 'B'; break;
-						case 177: key.Character = 'N'; break;
-						case 178: key.Character = 'M'; break;
-						case 179: key.Character = '<'; break;
-						case 180: key.Character = '>'; break;
-						case 181: key.Character = '?'; break;
-						case 182: key.KeyType = KeyType.RightShift; break;
-						case 183: key.Character = '*'; break;
-						case 184: key.KeyType = KeyType.RightAlt; break;
-						case 185: key.Character = ' '; break;
-						case 186: key.KeyType = KeyType.CapsLock; break;
-						case 187: key.KeyType = KeyType.F1; break;
-						case 188: key.KeyType = KeyType.F2; break;
-						case 189: key.KeyType = KeyType.F3; break;
-						case 190: key.KeyType = KeyType.F4; break;
-						case 191: key.KeyType = KeyType.F5; break;
-						case 192: key.KeyType = KeyType.F6; break;
-						case 193: key.KeyType = KeyType.F7; break;
-						case 194: key.KeyType = KeyType.F8; break;
-						case 195: key.KeyType = KeyType.F9; break;
-						case 196: key.KeyType = KeyType.F10; break;
-						case 197: key.KeyType = KeyType.NumLock; break;
-						case 198: key.KeyType = KeyType.ScrollLock; break;
-						case 199: key.KeyType = KeyType.Home; break;
-						case 200: key.KeyType = KeyType.UpArrow; break;
-						case 201: key.KeyType = KeyType.PageUp; break;
-						case 202: key.Character = '-'; break;
-						case 203: key.KeyType = KeyType.LeftArrow; break;
-						case 205: key.KeyType = KeyType.RightArrow; break;
-						case 206: key.Character = '+'; break;
-						case 207: key.KeyType = KeyType.End; break;
-						case 208: key.KeyType = KeyType.DownArrow; break;
-						case 209: key.KeyType = KeyType.PageDown; break;
-						case 210: key.KeyType = KeyType.Insert; break;
-						case 211: key.KeyType = KeyType.Delete; break;
-						case 214: key.Character = '|'; break;
-						case 215: key.KeyType = KeyType.F11; break;
-						case 216: key.KeyType = KeyType.F12; break;
-					}
+					SetKeyCharacteristics(ref key, scancode);
 
 					keyState = KeyState.Normal;
 					return key;
 				}
-			case KeyState.Escaped or KeyState.EscapeBreak when scancode == 0xE0:
+			case KeyState.Escaped or KeyState.EscapeBreak:
 				{
 					key.KeyType = KeyType.RegularKey;
-					key.KeyPress = (scancode & 0x80) != 0 || keyState == KeyState.EscapeBreak ? KeyEvent.KeyPressType.Break : key.KeyPress = KeyEvent.KeyPressType.Make;
+					key.KeyPress = (scancode & 0x80) != 0 || keyState == KeyState.EscapeBreak ? KeyEvent.KeyPressType.Break : KeyEvent.KeyPressType.Make;
 
 					if (scancode == 0xF0)
 					{
@@ -232,40 +53,218 @@ public class US : IScanCodeMap
 						return key;
 					}
 
-					switch (scancode)
-					{
-						case 0x1C: key.Character = '\n'; break;
-						case 0x1D: key.KeyType = KeyType.LeftControl; break;
-						case 0x2A: key.KeyType = KeyType.LeftShift; break;
-						case 0x35: key.Character = '/'; break;
-						case 0x36: key.KeyType = KeyType.RightShift; break;
-						case 0x37: key.KeyType = KeyType.ControlPrintScreen; break;
-						case 0x38: key.KeyType = KeyType.LeftAlt; break; // ?
-						case 0x46: key.KeyType = KeyType.ScrollLock; break;
-						case 0x47: key.KeyType = KeyType.Home; break;
-						case 0x48: key.KeyType = KeyType.UpArrow; break;
-						case 0x49: key.KeyType = KeyType.PageUp; break;
-						case 0x4B: key.KeyType = KeyType.LeftArrow; break;
-						case 0x4D: key.KeyType = KeyType.RightArrow; break;
-						case 0x4F: key.KeyType = KeyType.End; break;
-						case 0x50: key.KeyType = KeyType.DownArrow; break;
-						case 0x51: key.KeyType = KeyType.PageDown; break;
-						case 0x52: key.KeyType = KeyType.Insert; break;
-						case 0x53: key.KeyType = KeyType.Delete; break;
-						case 0x5B: key.KeyType = KeyType.LeftWindow; break;
-						case 0x5C: key.KeyType = KeyType.RightWindow; break;
-						case 0x5D: key.KeyType = KeyType.Menu; break;
-					}
+					SetSpecialKeyCharacteristics(ref key, scancode);
 
 					keyState = KeyState.Normal;
 					return key;
 				}
-			case KeyState.Escaped or KeyState.EscapeBreak when keyState == KeyState.Espaced2:
-				{
-					keyState = KeyState.Normal;
-					return key;
-				}
 			default: return key;
+		}
+	}
+
+	private static void SetKeyCharacteristics(ref KeyEvent key, byte scancode)
+	{
+		switch (scancode)
+		{
+			case 1: key.Character = (char)27; break;
+			case 2: key.Character = '1'; break;
+			case 3: key.Character = '2'; break;
+			case 4: key.Character = '3'; break;
+			case 5: key.Character = '4'; break;
+			case 6: key.Character = '5'; break;
+			case 7: key.Character = '6'; break;
+			case 8: key.Character = '7'; break;
+			case 9: key.Character = '8'; break;
+			case 10: key.Character = '9'; break;
+			case 11: key.Character = '0'; break;
+			case 12: key.Character = '-'; break;
+			case 13: key.Character = '='; break;
+			case 14: key.Character = '\b'; break;
+			case 15: key.Character = '\t'; break;
+			case 16: key.Character = 'q'; break;
+			case 17: key.Character = 'w'; break;
+			case 18: key.Character = 'e'; break;
+			case 19: key.Character = 'r'; break;
+			case 20: key.Character = 't'; break;
+			case 21: key.Character = 'y'; break;
+			case 22: key.Character = 'u'; break;
+			case 23: key.Character = 'i'; break;
+			case 24: key.Character = 'o'; break;
+			case 25: key.Character = 'p'; break;
+			case 26: key.Character = '['; break;
+			case 27: key.Character = ']'; break;
+			case 28: key.Character = '\n'; break;
+			case 29: key.KeyType = KeyType.LeftControl; break;
+			case 30: key.Character = 'a'; break;
+			case 31: key.Character = 's'; break;
+			case 32: key.Character = 'd'; break;
+			case 33: key.Character = 'f'; break;
+			case 34: key.Character = 'g'; break;
+			case 35: key.Character = 'h'; break;
+			case 36: key.Character = 'j'; break;
+			case 37: key.Character = 'k'; break;
+			case 38: key.Character = 'l'; break;
+			case 39: key.Character = ';'; break;
+			case 40: key.Character = '\''; break;
+			case 41: key.Character = '`'; break;
+			case 42: key.KeyType = KeyType.LeftShift; break;
+			case 43: key.Character = '\\'; break;
+			case 44: key.Character = 'z'; break;
+			case 45: key.Character = 'x'; break;
+			case 46: key.Character = 'c'; break;
+			case 47: key.Character = 'v'; break;
+			case 48: key.Character = 'b'; break;
+			case 49: key.Character = 'n'; break;
+			case 50: key.Character = 'm'; break;
+			case 51: key.Character = ','; break;
+			case 52: key.Character = '.'; break;
+			case 53: key.Character = '/'; break;
+			case 54: key.KeyType = KeyType.RightShift; break;
+			case 55: key.Character = '*'; break;
+			case 56: key.KeyType = KeyType.LeftAlt; break;
+			case 57: key.Character = ' '; break;
+			case 58: key.KeyType = KeyType.CapsLock; break;
+			case 59: key.KeyType = KeyType.F1; break;
+			case 60: key.KeyType = KeyType.F2; break;
+			case 61: key.KeyType = KeyType.F3; break;
+			case 62: key.KeyType = KeyType.F4; break;
+			case 63: key.KeyType = KeyType.F5; break;
+			case 64: key.KeyType = KeyType.F6; break;
+			case 65: key.KeyType = KeyType.F7; break;
+			case 66: key.KeyType = KeyType.F8; break;
+			case 67: key.KeyType = KeyType.F9; break;
+			case 68: key.KeyType = KeyType.F10; break;
+			case 69: key.KeyType = KeyType.NumLock; break;
+			case 70: key.KeyType = KeyType.ScrollLock; break;
+			case 71: key.KeyType = KeyType.Home; break;
+			case 72: key.KeyType = KeyType.UpArrow; break;
+			case 73: key.KeyType = KeyType.PageUp; break;
+			case 74: key.Character = '-'; break;
+			case 75: key.KeyType = KeyType.LeftArrow; break;
+			case 76: key.Character = (char)0; break;
+			case 77: key.KeyType = KeyType.RightArrow; break;
+			case 78: key.Character = '+'; break;
+			case 79: key.KeyType = KeyType.End; break;
+			case 80: key.KeyType = KeyType.DownArrow; break;
+			case 81: key.KeyType = KeyType.PageDown; break;
+			case 82: key.KeyType = KeyType.Insert; break;
+			case 83: key.KeyType = KeyType.Delete; break;
+			case 86: key.Character = '\\'; break;
+			case 87: key.KeyType = KeyType.F11; break;
+			case 88: key.KeyType = KeyType.F12; break;
+			case 129: key.Character = (char)27; break;
+			case 130: key.Character = '!'; break;
+			case 131: key.Character = '@'; break;
+			case 132: key.Character = '#'; break;
+			case 133: key.Character = '$'; break;
+			case 134: key.Character = '%'; break;
+			case 135: key.Character = '^'; break;
+			case 136: key.Character = '&'; break;
+			case 137: key.Character = '*'; break;
+			case 138: key.Character = '('; break;
+			case 139: key.Character = ')'; break;
+			case 140: key.Character = '_'; break;
+			case 141: key.Character = '+'; break;
+			case 142: key.Character = '\b'; break;
+			case 143: key.Character = '\t'; break;
+			case 144: key.Character = 'Q'; break;
+			case 145: key.Character = 'W'; break;
+			case 146: key.Character = 'E'; break;
+			case 147: key.Character = 'R'; break;
+			case 148: key.Character = 'T'; break;
+			case 149: key.Character = 'Y'; break;
+			case 150: key.Character = 'U'; break;
+			case 151: key.Character = 'I'; break;
+			case 152: key.Character = 'O'; break;
+			case 153: key.Character = 'P'; break;
+			case 154: key.Character = '{'; break;
+			case 155: key.Character = '}'; break;
+			case 156: key.Character = '\n'; break;
+			case 157: key.KeyType = KeyType.RightControl; break;
+			case 158: key.Character = 'A'; break;
+			case 159: key.Character = 'S'; break;
+			case 160: key.Character = 'D'; break;
+			case 161: key.Character = 'F'; break;
+			case 162: key.Character = 'G'; break;
+			case 163: key.Character = 'H'; break;
+			case 164: key.Character = 'J'; break;
+			case 165: key.Character = 'K'; break;
+			case 166: key.Character = 'L'; break;
+			case 167: key.Character = ':'; break;
+			case 168: key.Character = '"'; break;
+			case 169: key.Character = '~'; break;
+			case 170: key.KeyType = KeyType.LeftShift; break;
+			case 171: key.Character = '|'; break;
+			case 172: key.Character = 'Z'; break;
+			case 173: key.Character = 'X'; break;
+			case 174: key.Character = 'C'; break;
+			case 175: key.Character = 'V'; break;
+			case 176: key.Character = 'B'; break;
+			case 177: key.Character = 'N'; break;
+			case 178: key.Character = 'M'; break;
+			case 179: key.Character = '<'; break;
+			case 180: key.Character = '>'; break;
+			case 181: key.Character = '?'; break;
+			case 182: key.KeyType = KeyType.RightShift; break;
+			case 183: key.Character = '*'; break;
+			case 184: key.KeyType = KeyType.RightAlt; break;
+			case 185: key.Character = ' '; break;
+			case 186: key.KeyType = KeyType.CapsLock; break;
+			case 187: key.KeyType = KeyType.F1; break;
+			case 188: key.KeyType = KeyType.F2; break;
+			case 189: key.KeyType = KeyType.F3; break;
+			case 190: key.KeyType = KeyType.F4; break;
+			case 191: key.KeyType = KeyType.F5; break;
+			case 192: key.KeyType = KeyType.F6; break;
+			case 193: key.KeyType = KeyType.F7; break;
+			case 194: key.KeyType = KeyType.F8; break;
+			case 195: key.KeyType = KeyType.F9; break;
+			case 196: key.KeyType = KeyType.F10; break;
+			case 197: key.KeyType = KeyType.NumLock; break;
+			case 198: key.KeyType = KeyType.ScrollLock; break;
+			case 199: key.KeyType = KeyType.Home; break;
+			case 200: key.KeyType = KeyType.UpArrow; break;
+			case 201: key.KeyType = KeyType.PageUp; break;
+			case 202: key.Character = '-'; break;
+			case 203: key.KeyType = KeyType.LeftArrow; break;
+			case 205: key.KeyType = KeyType.RightArrow; break;
+			case 206: key.Character = '+'; break;
+			case 207: key.KeyType = KeyType.End; break;
+			case 208: key.KeyType = KeyType.DownArrow; break;
+			case 209: key.KeyType = KeyType.PageDown; break;
+			case 210: key.KeyType = KeyType.Insert; break;
+			case 211: key.KeyType = KeyType.Delete; break;
+			case 214: key.Character = '|'; break;
+			case 215: key.KeyType = KeyType.F11; break;
+			case 216: key.KeyType = KeyType.F12; break;
+		}
+	}
+
+	private static void SetSpecialKeyCharacteristics(ref KeyEvent key, byte scancode)
+	{
+		switch (scancode)
+		{
+			case 0x1C: key.Character = '\n'; break;
+			case 0x1D: key.KeyType = KeyType.LeftControl; break;
+			case 0x2A: key.KeyType = KeyType.LeftShift; break;
+			case 0x35: key.Character = '/'; break;
+			case 0x36: key.KeyType = KeyType.RightShift; break;
+			case 0x37: key.KeyType = KeyType.ControlPrintScreen; break;
+			case 0x38: key.KeyType = KeyType.LeftAlt; break;
+			case 0x46: key.KeyType = KeyType.ScrollLock; break;
+			case 0x47: key.KeyType = KeyType.Home; break;
+			case 0x48: key.KeyType = KeyType.UpArrow; break;
+			case 0x49: key.KeyType = KeyType.PageUp; break;
+			case 0x4B: key.KeyType = KeyType.LeftArrow; break;
+			case 0x4D: key.KeyType = KeyType.RightArrow; break;
+			case 0x4F: key.KeyType = KeyType.End; break;
+			case 0x50: key.KeyType = KeyType.DownArrow; break;
+			case 0x51: key.KeyType = KeyType.PageDown; break;
+			case 0x52: key.KeyType = KeyType.Insert; break;
+			case 0x53: key.KeyType = KeyType.Delete; break;
+			case 0x5B: key.KeyType = KeyType.LeftWindow; break;
+			case 0x5C: key.KeyType = KeyType.RightWindow; break;
+			case 0x5D: key.KeyType = KeyType.Menu; break;
 		}
 	}
 }

--- a/Source/Mosa.DeviceDriver/Setup.cs
+++ b/Source/Mosa.DeviceDriver/Setup.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using Mosa.DeviceSystem.Framework;
+using Mosa.DeviceSystem.Framework.Generic;
 using Mosa.DeviceSystem.Framework.ISA;
 using Mosa.DeviceSystem.Framework.PCI;
 using Mosa.DeviceSystem.Misc;
@@ -12,13 +13,12 @@ public static class Setup
 {
 	public static List<DeviceDriverRegistryEntry> GetDeviceDriverRegistryEntries() => new List<DeviceDriverRegistryEntry>
 	{
-		//new ISADeviceDriverRegistryEntry
-		//{
-		//	Name = "ACPI",
-		//	Platform = PlatformArchitecture.X86AndX64 | PlatformArchitecture.ARM32,
-		//	AutoLoad = true,
-		//	Factory = () => new ISA.ACPI.ACPIDriver()
-		//},
+		new GenericDeviceDriverRegistryEntry
+		{
+			Name = "ACPI",
+			Platform = PlatformArchitecture.X86AndX64 | PlatformArchitecture.ARM32,
+			Factory = () => new ISA.ACPI.ACPIDriver()
+		},
 
 		new ISADeviceDriverRegistryEntry
 		{

--- a/Source/Mosa.DeviceSystem/Framework/DeviceBusType.cs
+++ b/Source/Mosa.DeviceSystem/Framework/DeviceBusType.cs
@@ -4,6 +4,7 @@ namespace Mosa.DeviceSystem.Framework;
 
 public enum DeviceBusType
 {
+	None,
 	ISA,
 	PCI
 }

--- a/Source/Mosa.DeviceSystem/Framework/Generic/GenericDeviceDriverRegistryEntry.cs
+++ b/Source/Mosa.DeviceSystem/Framework/Generic/GenericDeviceDriverRegistryEntry.cs
@@ -1,0 +1,7 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+namespace Mosa.DeviceSystem.Framework.Generic;
+
+public class GenericDeviceDriverRegistryEntry : DeviceDriverRegistryEntry
+{
+	public override DeviceBusType BusType => DeviceBusType.None;
+}

--- a/Source/Mosa.DeviceSystem/Services/PCService.cs
+++ b/Source/Mosa.DeviceSystem/Services/PCService.cs
@@ -30,18 +30,9 @@ public class PCService : BaseService
 		if (address.Address == 0)
 			return false;
 
-		// 1st method
 		var value = ACPI.ResetValue;
 		address.Write8(value);
-
-		// 2nd method: write to PCI Configuration Space (we're actually writing on the host bridge controller)
-		// TODO: Fix
-		var controller = deviceService.GetFirstDevice<IHostBridgeController>(DeviceStatus.Online).DeviceDriver as IHostBridgeController;
-		if (controller == null)
-			return false;
-
-		controller.SetCPUResetInformation((byte)address.Address, value);
-		return controller.CPUReset();
+		return true;
 	}
 
 	public bool Shutdown()

--- a/Source/Mosa.Runtime/Pointer.cs
+++ b/Source/Mosa.Runtime/Pointer.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 
 namespace Mosa.Runtime;
 
-public struct Pointer
+public readonly struct Pointer
 {
 	private readonly unsafe void* value;
 


### PR DESCRIPTION
This PR focuses on various improvements (like bug fixes) throughout the Mosa.DeviceDriver project. The following changes were done:

- Put references to links in comments after the namespace
- In PCIController, the Definitions region was removed since it only contained 1 field
- The Mosa.Runtime.Pointer struct was made readonly to fix some potential struct copying for ACPI structs
- In VMwareSVGA2:
	- Private fields were put after the public frame buffer field for consistency
	- The private vramSize field has been removed since it was unused
- In ACPIDriver:
	- Variables and private fields were renamed to better match naming conventions
	- Some if conditions were inverted to reduce nesting
	- The Setup() function was removed and the code was put in the Initialize() function
- In the ACPI sister structs:
	- The readonly modifier was added on a per-struct basis
	- Made the Size field const in each
- Added DeviceBusType.None and GenericDeviceDriverRegistryEntry to deal with ACPI (as it's neither an ISA nor a PCI driver)
- In IDEController, the Open() function was moved into the IDiskControllerDevice region for more consistency
- Runtime device names were changed to better fit naming conventions and their job (e.g. ISA-BUS => ISABus, PCI => PCIController, etc...)
- The code to trigger an ACPI reboot by writing to the PCI configuration space was removed since it never even worked in the first place
- The PS/2 mouse code was almost entirely reworked for better code readability and slightly better performance as well
- The US keyboard map was also reworked to fix bugs mainly related to modifiers