### PR TITLE
Revert previous settings changes + don't recursively search for file

### DIFF
--- a/Source/Mosa.Compiler.Framework/MosaCompiler.cs
+++ b/Source/Mosa.Compiler.Framework/MosaCompiler.cs
@@ -37,7 +37,10 @@ public sealed class MosaCompiler
 
 	public MosaCompiler(MosaSettings mosaSettings, CompilerHooks compilerHook, IModuleLoader moduleLoader, ITypeResolver typeResolver)
 	{
-		MosaSettings = mosaSettings;
+		MosaSettings = new MosaSettings();
+		MosaSettings.SetDefaultSettings();
+		MosaSettings.Merge(mosaSettings);
+
 		CompilerHooks = compilerHook;
 		ModuleLoader = moduleLoader;
 		TypeResolver = typeResolver;

--- a/Source/Mosa.Utility.Configuration/AppLocationsSettings.cs
+++ b/Source/Mosa.Utility.Configuration/AppLocationsSettings.cs
@@ -424,9 +424,9 @@ public static class AppLocationsSettings
 				if (dir == null)
 					continue;
 
-				var location = SearchSubdirectories(dir, file);
+				var location = Path.Combine(dir, file);
 
-				if (location != null)
+				if (File.Exists(location))
 					return location;
 			}
 		}
@@ -441,9 +441,9 @@ public static class AppLocationsSettings
 		if (dir == null)
 			return null;
 
-		var location = SearchSubdirectories(dir, file);
+		var location = Path.Combine(dir, file);
 
-		if (location != null)
+		if (File.Exists(location))
 			return location;
 
 		return null;

--- a/Source/Mosa.Utility.Launcher/BaseLauncher.cs
+++ b/Source/Mosa.Utility.Launcher/BaseLauncher.cs
@@ -16,7 +16,15 @@ public class BaseLauncher
 	public BaseLauncher(MosaSettings mosaSettings, CompilerHooks compilerHook)
 	{
 		CompilerHooks = compilerHook;
-		MosaSettings = mosaSettings;
+
+		MosaSettings = new MosaSettings();
+		MosaSettings.LoadAppLocations();
+		MosaSettings.SetDefaultSettings();
+		MosaSettings.ResolveDefaults();
+		MosaSettings.Merge(mosaSettings);
+		MosaSettings.NormalizeSettings();
+		MosaSettings.ResolveFileAndPathSettings();
+		MosaSettings.AddStandardPlugs();
 	}
 
 	protected void OutputStatus(string status)

--- a/Source/Mosa.Utility.UnitTests/UnitTestSystem.cs
+++ b/Source/Mosa.Utility.UnitTests/UnitTestSystem.cs
@@ -17,14 +17,7 @@ public static class UnitTestSystem
 	public static int Start(string[] args)
 	{
 		var mosaSettings = new MosaSettings();
-		mosaSettings.LoadAppLocations();
-		mosaSettings.SetDefaultSettings();
 		mosaSettings.LoadArguments(args);
-		mosaSettings.NormalizeSettings();
-		mosaSettings.ResolveDefaults();
-		mosaSettings.ResolveFileAndPathSettings();
-		mosaSettings.AddStandardPlugs();
-		mosaSettings.ExpandSearchPaths();
 
 		var stopwatch = new Stopwatch();
 		stopwatch.Start();


### PR DESCRIPTION
This PR reverts the previous settings changes done in #1189, and fixes a bug where the app location search code would search recursively for the executables, even though we should be defining in which exact directories it should search.