### PR TITLE
Mosa.DeviceDriver: structural refactoring

### DIFF
--- a/Source/Mosa.DeviceDriver/ACPI/ACPIDriver.cs
+++ b/Source/Mosa.DeviceDriver/ACPI/ACPIDriver.cs
@@ -4,7 +4,7 @@ using Mosa.DeviceSystem.Framework;
 using Mosa.DeviceSystem.HardwareAbstraction;
 using Mosa.Runtime;
 
-namespace Mosa.DeviceDriver.ISA.ACPI;
+namespace Mosa.DeviceDriver.ACPI;
 
 // Portions of this code are from Cosmos
 

--- a/Source/Mosa.DeviceDriver/ACPI/ACPISDTHeader.cs
+++ b/Source/Mosa.DeviceDriver/ACPI/ACPISDTHeader.cs
@@ -2,7 +2,7 @@
 
 using Mosa.Runtime;
 
-namespace Mosa.DeviceDriver.ISA.ACPI;
+namespace Mosa.DeviceDriver.ACPI;
 
 public readonly struct ACPISDTHeader
 {

--- a/Source/Mosa.DeviceDriver/ACPI/FADT.cs
+++ b/Source/Mosa.DeviceDriver/ACPI/FADT.cs
@@ -2,7 +2,7 @@
 
 using Mosa.Runtime;
 
-namespace Mosa.DeviceDriver.ISA.ACPI;
+namespace Mosa.DeviceDriver.ACPI;
 
 public readonly struct FADT
 {

--- a/Source/Mosa.DeviceDriver/ACPI/GenericAddressStructure.cs
+++ b/Source/Mosa.DeviceDriver/ACPI/GenericAddressStructure.cs
@@ -2,7 +2,7 @@
 
 using Mosa.Runtime;
 
-namespace Mosa.DeviceDriver.ISA.ACPI;
+namespace Mosa.DeviceDriver.ACPI;
 
 public readonly struct GenericAddressStructure
 {

--- a/Source/Mosa.DeviceDriver/ACPI/IOAPICEntry.cs
+++ b/Source/Mosa.DeviceDriver/ACPI/IOAPICEntry.cs
@@ -2,7 +2,7 @@
 
 using Mosa.Runtime;
 
-namespace Mosa.DeviceDriver.ISA.ACPI;
+namespace Mosa.DeviceDriver.ACPI;
 
 public readonly struct IOAPICEntry
 {

--- a/Source/Mosa.DeviceDriver/ACPI/LongLocalAPICEntry.cs
+++ b/Source/Mosa.DeviceDriver/ACPI/LongLocalAPICEntry.cs
@@ -2,7 +2,7 @@
 
 using Mosa.Runtime;
 
-namespace Mosa.DeviceDriver.ISA.ACPI;
+namespace Mosa.DeviceDriver.ACPI;
 
 public readonly struct LongLocalAPICEntry
 {

--- a/Source/Mosa.DeviceDriver/ACPI/MADT.cs
+++ b/Source/Mosa.DeviceDriver/ACPI/MADT.cs
@@ -2,7 +2,7 @@
 
 using Mosa.Runtime;
 
-namespace Mosa.DeviceDriver.ISA.ACPI;
+namespace Mosa.DeviceDriver.ACPI;
 
 public readonly struct MADT
 {

--- a/Source/Mosa.DeviceDriver/ACPI/MADTEntry.cs
+++ b/Source/Mosa.DeviceDriver/ACPI/MADTEntry.cs
@@ -2,7 +2,7 @@
 
 using Mosa.Runtime;
 
-namespace Mosa.DeviceDriver.ISA.ACPI;
+namespace Mosa.DeviceDriver.ACPI;
 
 public readonly struct MADTEntry
 {

--- a/Source/Mosa.DeviceDriver/ACPI/ProcessorLocalAPICEntry.cs
+++ b/Source/Mosa.DeviceDriver/ACPI/ProcessorLocalAPICEntry.cs
@@ -2,7 +2,7 @@
 
 using Mosa.Runtime;
 
-namespace Mosa.DeviceDriver.ISA.ACPI;
+namespace Mosa.DeviceDriver.ACPI;
 
 public readonly struct ProcessorLocalAPICEntry
 {

--- a/Source/Mosa.DeviceDriver/ACPI/RSDPDescriptor.cs
+++ b/Source/Mosa.DeviceDriver/ACPI/RSDPDescriptor.cs
@@ -2,7 +2,7 @@
 
 using Mosa.Runtime;
 
-namespace Mosa.DeviceDriver.ISA.ACPI;
+namespace Mosa.DeviceDriver.ACPI;
 
 public readonly struct RSDPDescriptor
 {

--- a/Source/Mosa.DeviceDriver/ACPI/RSDPDescriptor20.cs
+++ b/Source/Mosa.DeviceDriver/ACPI/RSDPDescriptor20.cs
@@ -2,7 +2,7 @@
 
 using Mosa.Runtime;
 
-namespace Mosa.DeviceDriver.ISA.ACPI;
+namespace Mosa.DeviceDriver.ACPI;
 
 public readonly struct RSDPDescriptor20
 {

--- a/Source/Mosa.DeviceDriver/ACPI/RSDT.cs
+++ b/Source/Mosa.DeviceDriver/ACPI/RSDT.cs
@@ -2,7 +2,7 @@
 
 using Mosa.Runtime;
 
-namespace Mosa.DeviceDriver.ISA.ACPI;
+namespace Mosa.DeviceDriver.ACPI;
 
 public readonly struct RSDT
 {

--- a/Source/Mosa.DeviceDriver/ACPI/XSDT.cs
+++ b/Source/Mosa.DeviceDriver/ACPI/XSDT.cs
@@ -2,7 +2,7 @@
 
 using Mosa.Runtime;
 
-namespace Mosa.DeviceDriver.ISA.ACPI;
+namespace Mosa.DeviceDriver.ACPI;
 
 public readonly struct XSDT
 {

--- a/Source/Mosa.DeviceDriver/PCI/VirtIO/Devices/VirtIOGPU.cs
+++ b/Source/Mosa.DeviceDriver/PCI/VirtIO/Devices/VirtIOGPU.cs
@@ -5,10 +5,9 @@ using Mosa.DeviceSystem.Framework;
 using Mosa.DeviceSystem.Graphics;
 using Mosa.DeviceSystem.HardwareAbstraction;
 using Mosa.DeviceSystem.Misc;
-using Mosa.DeviceSystem.VirtIO;
 using Mosa.Runtime;
 
-namespace Mosa.DeviceDriver.PCI.VirtIO;
+namespace Mosa.DeviceDriver.PCI.VirtIO.Devices;
 
 public class VirtIOGPU : BaseDeviceDriver, IGraphicsDevice
 {

--- a/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOConfigurationCapabilities.cs
+++ b/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOConfigurationCapabilities.cs
@@ -1,6 +1,6 @@
 // Copyright (c) MOSA Project. Licensed under the New BSD License.
 
-namespace Mosa.DeviceSystem.VirtIO;
+namespace Mosa.DeviceDriver.PCI.VirtIO;
 
 /// <summary>
 /// VirtIO configuration capabilities of a device.

--- a/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIODevice.cs
+++ b/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIODevice.cs
@@ -6,7 +6,7 @@ using Mosa.DeviceSystem.Misc;
 using Mosa.DeviceSystem.PCI;
 using Mosa.Runtime;
 
-namespace Mosa.DeviceSystem.VirtIO;
+namespace Mosa.DeviceDriver.PCI.VirtIO;
 
 /// <summary>
 /// Describes a generic VirtIO device.

--- a/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOFeatures.cs
+++ b/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOFeatures.cs
@@ -1,6 +1,6 @@
 // Copyright (c) MOSA Project. Licensed under the New BSD License.
 
-namespace Mosa.DeviceSystem.VirtIO;
+namespace Mosa.DeviceDriver.PCI.VirtIO;
 
 /// <summary>
 /// Generic VirtIO feature list.

--- a/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOFlags.cs
+++ b/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOFlags.cs
@@ -1,6 +1,6 @@
 // Copyright (c) MOSA Project. Licensed under the New BSD License.
 
-namespace Mosa.DeviceSystem.VirtIO;
+namespace Mosa.DeviceDriver.PCI.VirtIO;
 
 /// <summary>
 /// Generic VirtIO flags to send to a device for initialization.

--- a/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOPCICommonConfiguration.cs
+++ b/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOPCICommonConfiguration.cs
@@ -1,6 +1,6 @@
 // Copyright (c) MOSA Project. Licensed under the New BSD License.
 
-namespace Mosa.DeviceSystem.VirtIO;
+namespace Mosa.DeviceDriver.PCI.VirtIO;
 
 /// <summary>
 /// Generic VirtIO flags to send to a device, most notably for querying data and dealing with virtqueues.

--- a/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOQueue.cs
+++ b/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOQueue.cs
@@ -2,7 +2,7 @@
 
 using Mosa.Runtime;
 
-namespace Mosa.DeviceSystem.VirtIO;
+namespace Mosa.DeviceDriver.PCI.VirtIO;
 
 /// <summary>
 /// Generic VirtIO virtqueue implementation.

--- a/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOQueueAvailableRing.cs
+++ b/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOQueueAvailableRing.cs
@@ -1,6 +1,6 @@
 // Copyright (c) MOSA Project. Licensed under the New BSD License.
 
-namespace Mosa.DeviceSystem.VirtIO;
+namespace Mosa.DeviceDriver.PCI.VirtIO;
 
 /// <summary>
 /// Describes a generic VirtIO virtqueue used ring. It is used by the driver to query filled in data.

--- a/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOQueueDescriptor.cs
+++ b/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOQueueDescriptor.cs
@@ -1,6 +1,6 @@
 // Copyright (c) MOSA Project. Licensed under the New BSD License.
 
-namespace Mosa.DeviceSystem.VirtIO;
+namespace Mosa.DeviceDriver.PCI.VirtIO;
 
 /// <summary>
 /// Describes a generic VirtIO queue descriptor structure.

--- a/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOQueueDescriptorFlags.cs
+++ b/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOQueueDescriptorFlags.cs
@@ -1,6 +1,6 @@
 // Copyright (c) MOSA Project. Licensed under the New BSD License.
 
-namespace Mosa.DeviceSystem.VirtIO;
+namespace Mosa.DeviceDriver.PCI.VirtIO;
 
 /// <summary>
 /// Flags used in a VirtIO descriptor. "HasNext" tells the driver that a next descriptor is available (essentially making it a chain),

--- a/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOQueueUsedRing.cs
+++ b/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIOQueueUsedRing.cs
@@ -1,6 +1,6 @@
 // Copyright (c) MOSA Project. Licensed under the New BSD License.
 
-namespace Mosa.DeviceSystem.VirtIO;
+namespace Mosa.DeviceDriver.PCI.VirtIO;
 
 /// <summary>
 /// Describes a generic VirtIO virtqueue used ring. It is used by the device to fill in data.

--- a/Source/Mosa.DeviceDriver/Setup.cs
+++ b/Source/Mosa.DeviceDriver/Setup.cs
@@ -17,7 +17,7 @@ public static class Setup
 		{
 			Name = "ACPI",
 			Platform = PlatformArchitecture.X86AndX64 | PlatformArchitecture.ARM32,
-			Factory = () => new ISA.ACPI.ACPIDriver()
+			Factory = () => new ACPI.ACPIDriver()
 		},
 
 		new ISADeviceDriverRegistryEntry
@@ -224,7 +224,7 @@ public static class Setup
 			VendorID = 0x1AF4,
 			DeviceID = 0x1050,
 			PCIFields = PCIField.VendorID | PCIField.DeviceID,
-			Factory = () => new PCI.VirtIO.VirtIOGPU()
+			Factory = () => new PCI.VirtIO.Devices.VirtIOGPU()
 		},
 
 		new PCIDeviceDriverRegistryEntry


### PR DESCRIPTION
This PR focuses on refactoring the structure of the Mosa.DeviceDriver project. It's pretty minor, the following changes were done:

- Mosa.DeviceDriver.ISA.ACPI => Mosa.DeviceDriver.ACPI
- Mosa.DeviceDriver.PCI.VirtIO => Mosa.DeviceDriver.PCI.VirtIO.Devices
- Mosa.DeviceSystem.VirtIO => Mosa.DeviceDriver.PCI.VirtIO