### PR TITLE
Mosa.DeviceDriver: remove pointless XML comments

### DIFF
--- a/Source/Mosa.DeviceDriver/ISA/ISABus.cs
+++ b/Source/Mosa.DeviceDriver/ISA/ISABus.cs
@@ -29,7 +29,6 @@ public class ISABus : BaseDeviceDriver
 	{
 		HAL.DebugWriteLine("ISABus:StartDevices()");
 
-		// Start ISA Drivers
 		var drivers = DeviceService.GetDeviceDrivers(DeviceBusType.ISA);
 
 		foreach (var driver in drivers)
@@ -57,19 +56,6 @@ public class ISABus : BaseDeviceDriver
 
 		if (driverEntry.BaseAddress != 0x00)
 			memoryRegions.Add(new AddressRegion(new Pointer(driverEntry.BaseAddress), driverEntry.AddressRange));
-
-		//if (driverEntry.PhysicalMemory != null)
-		//{
-		//	foreach (var physicalMemory in driver.PhysicalMemory)
-		//	{
-		//		if (physicalMemory.MemorySize > 0)
-		//		{
-		//			var memory = HAL.AllocateMemory(physicalMemory.MemorySize, physicalMemory.MemoryAlignment);
-
-		//			memoryRegions.Add(new MemoryRegion(memory.Address, memory.Size));
-		//		}
-		//	}
-		//}
 
 		var hardwareResources = new HardwareResources(ioPortRegions, memoryRegions, driverEntry.IRQ);
 		DeviceService.Initialize(driverEntry, Device, true, null, hardwareResources);

--- a/Source/Mosa.DeviceDriver/ISA/PCIController.cs
+++ b/Source/Mosa.DeviceDriver/ISA/PCIController.cs
@@ -15,15 +15,7 @@ public sealed class PCIController : BaseDeviceDriver, IPCIControllerLegacy, IPCI
 {
 	private const uint BaseValue = 0x80000000;
 
-	/// <summary>
-	/// The configuration address
-	/// </summary>
-	private IOPortReadWrite configAddress;
-
-	/// <summary>
-	/// The configuration data
-	/// </summary>
-	private IOPortReadWrite configData;
+	private IOPortReadWrite configAddress, configData;
 
 	public override void Initialize()
 	{
@@ -33,10 +25,6 @@ public sealed class PCIController : BaseDeviceDriver, IPCIControllerLegacy, IPCI
 		configData = Device.Resources.GetIOPortReadWrite(0, 4);
 	}
 
-	/// <summary>
-	/// Probes for this device.
-	/// </summary>
-	/// <returns></returns>
 	public override void Probe()
 	{
 		configAddress.Write32(BaseValue);
@@ -51,20 +39,8 @@ public sealed class PCIController : BaseDeviceDriver, IPCIControllerLegacy, IPCI
 			Device.Status = DeviceStatus.Online;
 	}
 
-	/// <summary>
-	/// Called when an interrupt is received.
-	/// </summary>
-	/// <returns></returns>
 	public override bool OnInterrupt() => false;
 
-	/// <summary>
-	/// Gets the index.
-	/// </summary>
-	/// <param name="bus">The bus.</param>
-	/// <param name="slot">The slot.</param>
-	/// <param name="function">The function.</param>
-	/// <param name="register">The register.</param>
-	/// <returns></returns>
 	private static uint GetIndex(byte bus, byte slot, byte function, byte register)
 	{
 		return BaseValue
@@ -76,84 +52,36 @@ public sealed class PCIController : BaseDeviceDriver, IPCIControllerLegacy, IPCI
 
 	#region IPCIControllerLegacy
 
-	/// <summary>
-	/// Reads from configuration space
-	/// </summary>
-	/// <param name="bus">The bus.</param>
-	/// <param name="slot">The slot.</param>
-	/// <param name="function">The function.</param>
-	/// <param name="register">The register.</param>
-	/// <returns></returns>
 	public uint ReadConfig32(byte bus, byte slot, byte function, byte register)
 	{
 		configAddress.Write32(GetIndex(bus, slot, function, register));
 		return configData.Read32();
 	}
 
-	/// <summary>
-	/// Reads from configuration space
-	/// </summary>
-	/// <param name="bus">The bus.</param>
-	/// <param name="slot">The slot.</param>
-	/// <param name="function">The function.</param>
-	/// <param name="register">The register.</param>
-	/// <returns></returns>
 	public ushort ReadConfig16(byte bus, byte slot, byte function, byte register)
 	{
 		configAddress.Write32(GetIndex(bus, slot, function, register));
 		return (ushort)((configData.Read32() >> (register % 4 * 8)) & 0xFFFF);
 	}
 
-	/// <summary>
-	/// Reads from configuration space
-	/// </summary>
-	/// <param name="bus">The bus.</param>
-	/// <param name="slot">The slot.</param>
-	/// <param name="function">The function.</param>
-	/// <param name="register">The register.</param>
-	/// <returns></returns>
 	public byte ReadConfig8(byte bus, byte slot, byte function, byte register)
 	{
 		configAddress.Write32(GetIndex(bus, slot, function, register));
 		return (byte)((configData.Read32() >> (register % 4 * 8)) & 0xFF);
 	}
 
-	/// <summary>
-	/// Writes to configuration space
-	/// </summary>
-	/// <param name="bus">The bus.</param>
-	/// <param name="slot">The slot.</param>
-	/// <param name="function">The function.</param>
-	/// <param name="register">The register.</param>
-	/// <param name="value">The value.</param>
 	public void WriteConfig32(byte bus, byte slot, byte function, byte register, uint value)
 	{
 		configAddress.Write32(GetIndex(bus, slot, function, register));
 		configData.Write32(value);
 	}
 
-	/// <summary>
-	/// Writes to configuration space
-	/// </summary>
-	/// <param name="bus">The bus.</param>
-	/// <param name="slot">The slot.</param>
-	/// <param name="function">The function.</param>
-	/// <param name="register">The register.</param>
-	/// <param name="value">The value.</param>
 	public void WriteConfig16(byte bus, byte slot, byte function, byte register, ushort value)
 	{
 		configAddress.Write32(GetIndex(bus, slot, function, register));
 		configData.Write16(value);
 	}
 
-	/// <summary>
-	/// Writes to configuration space
-	/// </summary>
-	/// <param name="bus">The bus.</param>
-	/// <param name="slot">The slot.</param>
-	/// <param name="function">The function.</param>
-	/// <param name="register">The register.</param>
-	/// <param name="value">The value.</param>
 	public void WriteConfig8(byte bus, byte slot, byte function, byte register, byte value)
 	{
 		configAddress.Write32(GetIndex(bus, slot, function, register));
@@ -164,72 +92,36 @@ public sealed class PCIController : BaseDeviceDriver, IPCIControllerLegacy, IPCI
 
 	#region IPCIController
 
-	/// <summary>
-	/// Reads from configuration space
-	/// </summary>
-	/// <param name="pciDevice">The PCI Device.</param>
-	/// <param name="register">The register.</param>
-	/// <returns></returns>
 	public uint ReadConfig32(PCIDevice pciDevice, byte register)
 	{
 		configAddress.Write32(GetIndex(pciDevice.Bus, pciDevice.Slot, pciDevice.Function, register));
 		return configData.Read32();
 	}
 
-	/// <summary>
-	/// Reads from configuration space
-	/// </summary>
-	/// <param name="pciDevice">The PCI Device.</param>
-	/// <param name="register">The register.</param>
-	/// <returns></returns>
 	public ushort ReadConfig16(PCIDevice pciDevice, byte register)
 	{
 		configAddress.Write32(GetIndex(pciDevice.Bus, pciDevice.Slot, pciDevice.Function, register));
 		return (ushort)((configData.Read32() >> (register % 4 * 8)) & 0xFFFF);
 	}
 
-	/// <summary>
-	/// Reads from configuration space
-	/// </summary>
-	/// <param name="pciDevice">The PCI Device.</param>
-	/// <param name="register">The register.</param>
-	/// <returns></returns>
 	public byte ReadConfig8(PCIDevice pciDevice, byte register)
 	{
 		configAddress.Write32(GetIndex(pciDevice.Bus, pciDevice.Slot, pciDevice.Function, register));
 		return (byte)((configData.Read32() >> (register % 4 * 8)) & 0xFF);
 	}
 
-	/// <summary>
-	/// Writes to configuration space
-	/// </summary>
-	/// <param name="pciDevice">The PCI Device.</param>
-	/// <param name="register">The register.</param>
-	/// <param name="value">The value.</param>
 	public void WriteConfig32(PCIDevice pciDevice, byte register, uint value)
 	{
 		configAddress.Write32(GetIndex(pciDevice.Bus, pciDevice.Slot, pciDevice.Function, register));
 		configData.Write32(value);
 	}
 
-	/// <summary>
-	/// Writes to configuration space
-	/// </summary>
-	/// <param name="pciDevice">The PCI Device.</param>
-	/// <param name="register">The register.</param>
-	/// <param name="value">The value.</param>
 	public void WriteConfig16(PCIDevice pciDevice, byte register, ushort value)
 	{
 		configAddress.Write32(GetIndex(pciDevice.Bus, pciDevice.Slot, pciDevice.Function, register));
 		configData.Write16(value);
 	}
 
-	/// <summary>
-	/// Writes to configuration space
-	/// </summary>
-	/// <param name="pciDevice">The PCI Device.</param>
-	/// <param name="register">The register.</param>
-	/// <param name="value">The value.</param>
 	public void WriteConfig8(PCIDevice pciDevice, byte register, byte value)
 	{
 		configAddress.Write32(GetIndex(pciDevice.Bus, pciDevice.Slot, pciDevice.Function, register));

--- a/Source/Mosa.DeviceDriver/ScanCodeMap/HU.cs
+++ b/Source/Mosa.DeviceDriver/ScanCodeMap/HU.cs
@@ -36,11 +36,6 @@ public class HU : IScanCodeMap
 		};
 	}
 
-	/// <summary>
-	/// Convert can code into a key
-	/// </summary>
-	/// <param name="scancode">The scancode.</param>
-	/// <returns></returns>
 	public KeyEvent ConvertScanCode(byte scancode)
 	{
 		var key = new KeyEvent();


### PR DESCRIPTION
This PR removes all pointless XML comments found in the Mosa.DeviceDriver, which were completely forgotten about in my previous PR. (Whoops!)