### PR TITLE
PCI framework refactor: part 3

### DIFF
--- a/Source/Mosa.BareMetal.HelloWorld/Apps/ShowPCI.cs
+++ b/Source/Mosa.BareMetal.HelloWorld/Apps/ShowPCI.cs
@@ -24,10 +24,10 @@ public class ShowPCI : IApp
 			Program.Bullet(ConsoleColor.Yellow);
 			Console.Write(" ");
 
-			var pciDevice = (PCIDevice)device.Parent.DeviceDriver;
+			var pciDevice = (PCIDeviceConfiguration)device.Configuration;
 			var name = device.DeviceDriverRegistryEntry == null ? "UnknownPCIDevice" : device.Name;
 
-			Program.InBrackets(pciDevice.Device.Name + ": " + name + " " + pciDevice.VendorID.ToString("x") + ":" + pciDevice.DeviceID.ToString("x") + " " + pciDevice.SubSystemID.ToString("x") + ":" + pciDevice.SubSystemVendorID.ToString("x") + " (" + pciDevice.ClassCode.ToString("x") + ":" + pciDevice.SubClassCode.ToString("x") + ":" + pciDevice.ProgIF.ToString("x") + ":" + pciDevice.RevisionID.ToString("x") + ")", ConsoleColor.White, ConsoleColor.Green);
+			Program.InBrackets(pciDevice.Name + ": " + name + " " + pciDevice.VendorID.ToString("x") + ":" + pciDevice.DeviceID.ToString("x") + " " + pciDevice.SubSystemID.ToString("x") + ":" + pciDevice.SubSystemVendorID.ToString("x") + " (" + pciDevice.ClassCode.ToString("x") + ":" + pciDevice.SubClassCode.ToString("x") + ":" + pciDevice.ProgIF.ToString("x") + ":" + pciDevice.RevisionID.ToString("x") + ")", ConsoleColor.White, ConsoleColor.Green);
 			Console.WriteLine();
 		}
 	}

--- a/Source/Mosa.DeviceDriver/ISA/PCIController.cs
+++ b/Source/Mosa.DeviceDriver/ISA/PCIController.cs
@@ -51,39 +51,39 @@ public sealed class PCIController : BaseDeviceDriver, IPCIController
 
 	#region IPCIController
 
-	public uint ReadConfig32(PCIDevice pciDevice, byte register)
+	public uint ReadConfig32(PCIDeviceConfiguration configuration, byte register)
 	{
-		configAddress.Write32(GetIndex(pciDevice.Bus, pciDevice.Slot, pciDevice.Function, register));
+		configAddress.Write32(GetIndex(configuration.Bus, configuration.Slot, configuration.Function, register));
 		return configData.Read32();
 	}
 
-	public ushort ReadConfig16(PCIDevice pciDevice, byte register)
+	public ushort ReadConfig16(PCIDeviceConfiguration configuration, byte register)
 	{
-		configAddress.Write32(GetIndex(pciDevice.Bus, pciDevice.Slot, pciDevice.Function, register));
+		configAddress.Write32(GetIndex(configuration.Bus, configuration.Slot, configuration.Function, register));
 		return (ushort)((configData.Read32() >> (register % 4 * 8)) & 0xFFFF);
 	}
 
-	public byte ReadConfig8(PCIDevice pciDevice, byte register)
+	public byte ReadConfig8(PCIDeviceConfiguration configuration, byte register)
 	{
-		configAddress.Write32(GetIndex(pciDevice.Bus, pciDevice.Slot, pciDevice.Function, register));
+		configAddress.Write32(GetIndex(configuration.Bus, configuration.Slot, configuration.Function, register));
 		return (byte)((configData.Read32() >> (register % 4 * 8)) & 0xFF);
 	}
 
-	public void WriteConfig32(PCIDevice pciDevice, byte register, uint value)
+	public void WriteConfig32(PCIDeviceConfiguration configuration, byte register, uint value)
 	{
-		configAddress.Write32(GetIndex(pciDevice.Bus, pciDevice.Slot, pciDevice.Function, register));
+		configAddress.Write32(GetIndex(configuration.Bus, configuration.Slot, configuration.Function, register));
 		configData.Write32(value);
 	}
 
-	public void WriteConfig16(PCIDevice pciDevice, byte register, ushort value)
+	public void WriteConfig16(PCIDeviceConfiguration configuration, byte register, ushort value)
 	{
-		configAddress.Write32(GetIndex(pciDevice.Bus, pciDevice.Slot, pciDevice.Function, register));
+		configAddress.Write32(GetIndex(configuration.Bus, configuration.Slot, configuration.Function, register));
 		configData.Write16(value);
 	}
 
-	public void WriteConfig8(PCIDevice pciDevice, byte register, byte value)
+	public void WriteConfig8(PCIDeviceConfiguration configuration, byte register, byte value)
 	{
-		configAddress.Write32(GetIndex(pciDevice.Bus, pciDevice.Slot, pciDevice.Function, register));
+		configAddress.Write32(GetIndex(configuration.Bus, configuration.Slot, configuration.Function, register));
 		configData.Write8(value);
 	}
 

--- a/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIODevice.cs
+++ b/Source/Mosa.DeviceDriver/PCI/VirtIO/VirtIODevice.cs
@@ -42,7 +42,7 @@ public class VirtIODevice
 
 		if (configuration.RevisionID < 1)
 		{
-			HAL.DebugWriteLine("[" + devName + "] pci revision id mismatch; abort");
+			HAL.DebugWriteLine($"[{devName}] pci revision id mismatch; abort");
 			return;
 		}
 

--- a/Source/Mosa.DeviceSystem/Framework/BaseDeviceConfiguration.cs
+++ b/Source/Mosa.DeviceSystem/Framework/BaseDeviceConfiguration.cs
@@ -1,11 +1,12 @@
 // Copyright (c) MOSA Project. Licensed under the New BSD License.
 
 using Mosa.DeviceSystem.Disks;
+using Mosa.DeviceSystem.PCI;
 
 namespace Mosa.DeviceSystem.Framework;
 
 /// <summary>
-/// The base class for device configurations. See <see cref="DiskDeviceConfiguration"/> and
-/// <see cref="DiskPartitionConfiguration"/> for implementations of this class.
+/// The base class for device configurations. See <see cref="PCIDeviceConfiguration"/>, <see cref="DiskDeviceConfiguration"/>
+/// and <see cref="DiskPartitionConfiguration"/> for implementations of this class.
 /// </summary>
 public abstract class BaseDeviceConfiguration { }

--- a/Source/Mosa.DeviceSystem/HardwareAbstraction/HAL.cs
+++ b/Source/Mosa.DeviceSystem/HardwareAbstraction/HAL.cs
@@ -28,9 +28,9 @@ public static class HAL
 
 	public static ConstrainedPointer GetPhysicalMemory(Pointer address, uint size) => hardwareAbstraction.GetPhysicalMemory(address, size);
 
-	internal static void DisableAllInterrupts() => hardwareAbstraction.DisableInterrupts();
+	public static void DisableAllInterrupts() => hardwareAbstraction.DisableInterrupts();
 
-	internal static void EnableAllInterrupts() => hardwareAbstraction.EnableInterrupts();
+	public static void EnableAllInterrupts() => hardwareAbstraction.EnableInterrupts();
 
 	public static void Sleep(uint milliseconds) => hardwareAbstraction.Sleep(milliseconds);
 

--- a/Source/Mosa.DeviceSystem/PCI/IPCIController.cs
+++ b/Source/Mosa.DeviceSystem/PCI/IPCIController.cs
@@ -7,15 +7,15 @@ namespace Mosa.DeviceSystem.PCI;
 /// </summary>
 public interface IPCIController
 {
-	uint ReadConfig32(PCIDevice pciDevice, byte register);
+	uint ReadConfig32(PCIDeviceConfiguration configuration, byte register);
 
-	ushort ReadConfig16(PCIDevice pciDevice, byte register);
+	ushort ReadConfig16(PCIDeviceConfiguration configuration, byte register);
 
-	byte ReadConfig8(PCIDevice pciDevice, byte register);
+	byte ReadConfig8(PCIDeviceConfiguration configuration, byte register);
 
-	void WriteConfig32(PCIDevice pciDevice, byte register, uint value);
+	void WriteConfig32(PCIDeviceConfiguration configuration, byte register, uint value);
 
-	void WriteConfig16(PCIDevice pciDevice, byte register, ushort value);
+	void WriteConfig16(PCIDeviceConfiguration configuration, byte register, ushort value);
 
-	void WriteConfig8(PCIDevice pciDevice, byte register, byte value);
+	void WriteConfig8(PCIDeviceConfiguration configuration, byte register, byte value);
 }

--- a/Source/Mosa.DeviceSystem/Services/DeviceService.cs
+++ b/Source/Mosa.DeviceSystem/Services/DeviceService.cs
@@ -45,18 +45,14 @@ public sealed class DeviceService : BaseService
 		var platformArchitecture = HAL.PlatformArchitecture;
 
 		foreach (var deviceDriver in deviceDrivers)
-		{
 			if ((deviceDriver.Platform & platformArchitecture) == platformArchitecture)
 				RegisterDeviceDriver(deviceDriver);
-		}
 	}
 
 	public void RegisterDeviceDriver(DeviceDriverRegistryEntry deviceDriver)
 	{
 		lock (sync)
-		{
 			registry.Add(deviceDriver);
-		}
 	}
 
 	public List<DeviceDriverRegistryEntry> GetDeviceDrivers(DeviceBusType busType)
@@ -64,13 +60,9 @@ public sealed class DeviceService : BaseService
 		var drivers = new List<DeviceDriverRegistryEntry>();
 
 		lock (sync)
-		{
 			foreach (var deviceDriver in registry)
-			{
 				if (deviceDriver.BusType == busType)
 					drivers.Add(deviceDriver);
-			}
-		}
 
 		return drivers;
 	}
@@ -182,13 +174,9 @@ public sealed class DeviceService : BaseService
 	public Device GetFirstDevice<T>()
 	{
 		lock (sync)
-		{
 			foreach (var device in devices)
-			{
 				if (device.DeviceDriver is T)
 					return device;
-			}
-		}
 
 		return null;
 	}
@@ -198,13 +186,9 @@ public sealed class DeviceService : BaseService
 		var list = new List<Device>();
 
 		lock (sync)
-		{
 			foreach (var device in devices)
-			{
 				if (device.DeviceDriver is T)
 					list.Add(device);
-			}
-		}
 
 		return list;
 	}
@@ -212,13 +196,9 @@ public sealed class DeviceService : BaseService
 	public Device GetFirstDevice<T>(DeviceStatus status)
 	{
 		lock (sync)
-		{
 			foreach (var device in devices)
-			{
 				if (device.Status == status && device.DeviceDriver is T)
 					return device;
-			}
-		}
 
 		return null;
 	}
@@ -228,13 +208,9 @@ public sealed class DeviceService : BaseService
 		var list = new List<Device>();
 
 		lock (sync)
-		{
 			foreach (var device in devices)
-			{
 				if (device.Status == status && device.DeviceDriver is T)
 					list.Add(device);
-			}
-		}
 
 		return list;
 	}
@@ -244,13 +220,9 @@ public sealed class DeviceService : BaseService
 		var list = new List<Device>();
 
 		lock (sync)
-		{
 			foreach (var device in devices)
-			{
 				if (device.Name == name)
 					list.Add(device);
-			}
-		}
 
 		return list;
 	}
@@ -260,10 +232,8 @@ public sealed class DeviceService : BaseService
 		var list = new List<Device>();
 
 		lock (sync)
-		{
 			foreach (var device in parent.Children)
 				list.Add(device);
-		}
 
 		return list;
 	}
@@ -298,13 +268,9 @@ public sealed class DeviceService : BaseService
 	public bool CheckExists(Device parent, ulong componentID)
 	{
 		lock (sync)
-		{
 			foreach (var device in devices)
-			{
 				if (device.Parent == parent && device.ComponentID == componentID)
 					return true;
-			}
-		}
 
 		return false;
 	}
@@ -336,9 +302,7 @@ public sealed class DeviceService : BaseService
 				return;
 
 			lock (sync)
-			{
 				IRQDispatch[irq].Add(device);
-			}
 		}
 
 		HAL.DebugWriteLine("DeviceService::AddInterruptHandler() [Exit]");
@@ -354,9 +318,7 @@ public sealed class DeviceService : BaseService
 			return;
 
 		lock (sync)
-		{
 			IRQDispatch[irq].Remove(device);
-		}
 	}
 
 	#endregion Interrupts


### PR DESCRIPTION
Hello! This PR is the final part of refactoring the PCI subsystem. This last part focuses on changing the role of the ``PCIDevice`` class to be a configuration instead of a device driver. Some additional, small code style changes were done, as well as 2 encapsulation changes in the ``HAL`` class.