### PR TITLE
Mosa.Tool.Explorer: Port to Avalonia

### DIFF
--- a/Source/Mosa.Linux.sln
+++ b/Source/Mosa.Linux.sln
@@ -236,6 +236,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mosa.Workspace.FileSystem.D
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mosa.Workspace.GDB.Debug", "Mosa.Workspace.GDB.Debug\Mosa.Workspace.GDB.Debug.csproj", "{00512754-29C4-4AA3-8619-8C04120D7B55}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mosa.Tool.Explorer.Avalonia", "Mosa.Tool.Explorer.Avalonia\Mosa.Tool.Explorer.Avalonia.csproj", "{FBC3B0CD-D775-41C6-A735-F59118838397}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1384,6 +1386,24 @@ Global
 		{00512754-29C4-4AA3-8619-8C04120D7B55}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{00512754-29C4-4AA3-8619-8C04120D7B55}.Release|x86.ActiveCfg = Release|Any CPU
 		{00512754-29C4-4AA3-8619-8C04120D7B55}.Release|x86.Build.0 = Release|Any CPU
+		{FBC3B0CD-D775-41C6-A735-F59118838397}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FBC3B0CD-D775-41C6-A735-F59118838397}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FBC3B0CD-D775-41C6-A735-F59118838397}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{FBC3B0CD-D775-41C6-A735-F59118838397}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{FBC3B0CD-D775-41C6-A735-F59118838397}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FBC3B0CD-D775-41C6-A735-F59118838397}.Debug|x86.Build.0 = Debug|Any CPU
+		{FBC3B0CD-D775-41C6-A735-F59118838397}.Description|Any CPU.ActiveCfg = Debug|Any CPU
+		{FBC3B0CD-D775-41C6-A735-F59118838397}.Description|Any CPU.Build.0 = Debug|Any CPU
+		{FBC3B0CD-D775-41C6-A735-F59118838397}.Description|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{FBC3B0CD-D775-41C6-A735-F59118838397}.Description|Mixed Platforms.Build.0 = Debug|Any CPU
+		{FBC3B0CD-D775-41C6-A735-F59118838397}.Description|x86.ActiveCfg = Debug|Any CPU
+		{FBC3B0CD-D775-41C6-A735-F59118838397}.Description|x86.Build.0 = Debug|Any CPU
+		{FBC3B0CD-D775-41C6-A735-F59118838397}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FBC3B0CD-D775-41C6-A735-F59118838397}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FBC3B0CD-D775-41C6-A735-F59118838397}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{FBC3B0CD-D775-41C6-A735-F59118838397}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{FBC3B0CD-D775-41C6-A735-F59118838397}.Release|x86.ActiveCfg = Release|Any CPU
+		{FBC3B0CD-D775-41C6-A735-F59118838397}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1457,6 +1477,7 @@ Global
 		{FDD348E9-AD4A-497E-98A9-FBBD47D51DE4} = {D1C4B715-9764-4430-B3D3-676B0EBCE75A}
 		{00512754-29C4-4AA3-8619-8C04120D7B55} = {D1C4B715-9764-4430-B3D3-676B0EBCE75A}
 		{A4028807-1B21-4D14-9CE3-5FD1AAD9EDD7} = {F0EFF742-92D5-4219-939A-8F6F8DAB24E5}
+		{FBC3B0CD-D775-41C6-A735-F59118838397} = {D032B24A-CE3A-4881-BACE-CC4FE0AFD69D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C22A5C94-6B05-4B1B-845A-A2EA7615E093}

--- a/Source/Mosa.Tool.Explorer.Avalonia/App.axaml
+++ b/Source/Mosa.Tool.Explorer.Avalonia/App.axaml
@@ -1,0 +1,9 @@
+﻿<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Mosa.Tool.Explorer.Avalonia.App"
+             RequestedThemeVariant="Default">
+    <Application.Styles>
+        <SimpleTheme />
+        <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Simple.xaml"/>
+    </Application.Styles>
+</Application>

--- a/Source/Mosa.Tool.Explorer.Avalonia/App.axaml.cs
+++ b/Source/Mosa.Tool.Explorer.Avalonia/App.axaml.cs
@@ -1,0 +1,28 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+
+namespace Mosa.Tool.Explorer.Avalonia;
+
+public partial class App : Application
+{
+	public override void Initialize()
+	{
+		AvaloniaXamlLoader.Load(this);
+	}
+
+	public override void OnFrameworkInitializationCompleted()
+	{
+		if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+		{
+			desktop.Startup += (_, args) =>
+			{
+				var win = new MainWindow();
+				win.Initialize(args.Args);
+				desktop.MainWindow = win;
+			};
+		}
+
+		base.OnFrameworkInitializationCompleted();
+	}
+}

--- a/Source/Mosa.Tool.Explorer.Avalonia/CompilerData.cs
+++ b/Source/Mosa.Tool.Explorer.Avalonia/CompilerData.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using System.Diagnostics;
+
+namespace Mosa.Tool.Explorer.Avalonia;
+
+public class CompilerData
+{
+	public readonly Dictionary<string, List<string>> Logs = new Dictionary<string, List<string>>();
+	public readonly List<string> LogSections = new List<string>();
+
+	public readonly Stopwatch Stopwatch = new Stopwatch();
+
+	public bool DirtyLog = true;
+	public bool DirtyLogSections = true;
+
+	public void ClearAllLogs()
+	{
+		lock (Logs)
+		{
+			Logs.Clear();
+			LogSections.Clear();
+		}
+
+		UpdateLog("Compiler", null);
+	}
+
+	public void UpdateLog(string section, List<string> lines, bool dirty)
+	{
+		lock (Logs)
+		{
+			if (!Logs.TryGetValue(section, out List<string> log))
+			{
+				log = new List<string>(100);
+				Logs.Add(section, log);
+				LogSections.Add(section);
+				DirtyLogSections = true;
+			}
+
+			lock (log)
+			{
+				log.AddRange(lines);
+			}
+
+			DirtyLog = dirty;
+		}
+	}
+
+	private void UpdateLog(string section, string line)
+	{
+		lock (Logs)
+		{
+			if (!Logs.TryGetValue(section, out List<string> log))
+			{
+				log = new List<string>(100);
+				Logs.Add(section, log);
+				LogSections.Add(section);
+				DirtyLogSections = true;
+			}
+
+			lock (log)
+			{
+				log.Add(line);
+			}
+
+			DirtyLog = true;
+		}
+	}
+
+	public List<string> GetLog(string section)
+	{
+		lock (Logs)
+		{
+			return Logs.GetValueOrDefault(section);
+		}
+	}
+
+	public void AddTraceEvent(CompilerEvent compilerEvent, string message, int threadID)
+	{
+		if (compilerEvent == CompilerEvent.Counter)
+		{
+			UpdateLog("Counters", message);
+			return;
+		}
+
+		var part = string.IsNullOrWhiteSpace(message) ? string.Empty : ": " + message;
+		var msg = $"{compilerEvent.ToText()}{part}";
+
+		var timeLog = $"{Stopwatch.Elapsed.TotalSeconds:00.00} | [{threadID}] {msg}";
+
+		if (compilerEvent == CompilerEvent.Error)
+		{
+			UpdateLog("Error", msg);
+			UpdateLog("Compiler", timeLog);
+		}
+		if (compilerEvent == CompilerEvent.Exception)
+		{
+			UpdateLog("Exception", msg);
+			UpdateLog("Compiler", timeLog);
+		}
+		else
+		{
+			UpdateLog("Compiler", timeLog);
+		}
+	}
+
+	public void SortLog(string section)
+	{
+		lock (Logs)
+		{
+			if (!Logs.TryGetValue(section, out List<string> lines))
+				return;
+
+			lines.Sort();
+			Logs[section] = lines;
+		}
+	}
+}

--- a/Source/Mosa.Tool.Explorer.Avalonia/CompilerStage/ExplorerMethodCompileTimeStage.cs
+++ b/Source/Mosa.Tool.Explorer.Avalonia/CompilerStage/ExplorerMethodCompileTimeStage.cs
@@ -1,0 +1,26 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using Mosa.Compiler.Framework;
+using Mosa.Compiler.Framework.CompilerStages;
+
+namespace Mosa.Tool.Explorer.Avalonia.CompilerStage;
+
+/// <summary>
+/// A compilation stage which generates a map file of the built binary file.
+/// </summary>
+/// <seealso cref="Mosa.Compiler.Framework.BaseCompilerStage" />
+public sealed class ExplorerMethodCompileTimeStage : MethodCompileTimeStage
+{
+	protected override void Finalization()
+	{
+		var methods = GetAndSortMethodData();
+		var log = new TraceLog(TraceType.GlobalDebug, null, null, "Compiler Time");
+
+		log.Log("Ticks\tMilliseconds\tCompiler Count\tMethod");
+
+		foreach (var data in methods)
+			log.Log($"{data.ElapsedTicks}{'\t'}{data.ElapsedTicks / TimeSpan.TicksPerMillisecond}{'\t'}{data.Version}{'\t'}{data.Method.FullName}");
+
+		PostTraceLog(log);
+	}
+}

--- a/Source/Mosa.Tool.Explorer.Avalonia/CounterEntry.cs
+++ b/Source/Mosa.Tool.Explorer.Avalonia/CounterEntry.cs
@@ -1,0 +1,5 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+namespace Mosa.Tool.Explorer.Avalonia;
+
+public record CounterEntry(string Name, int Value);

--- a/Source/Mosa.Tool.Explorer.Avalonia/MainWindow.axaml
+++ b/Source/Mosa.Tool.Explorer.Avalonia/MainWindow.axaml
@@ -1,0 +1,223 @@
+﻿<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="Mosa.Tool.Explorer.Avalonia.MainWindow"
+        Title="Managed Operating System Alliance - Explorer"
+        Width="1000" Height="600"
+        WindowStartupLocation="CenterScreen"
+        Loaded="Control_OnLoaded">
+	<Grid RowDefinitions="Auto, Auto, *, Auto">
+		<Menu Grid.Row="0">
+			<MenuItem Header="File">
+				<MenuItem Name="OpenMenuItem" Header="Open..." Click="Open_OnClick"/>
+				<Separator/>
+				<MenuItem Name="Quit" Header="Quit" Click="Quit_OnClick"/>
+			</MenuItem>
+			<MenuItem Header="Compile">
+				<MenuItem Name="CompileNow" Header="Now" Click="Compile_OnClick"/>
+			</MenuItem>
+			<MenuItem Header="Optimizations">
+				<MenuItem Name="EnableAllOptimizations" Header="Enable All" Click="EnableAllOptimizations_OnClick"/>
+				<MenuItem Name="DisableAllOptimizations" Header="Disable All" Click="DisableAllOptimizations_OnClick"/>
+				<Separator/>
+				<MenuItem Name="StaticSingleAssignment" ToggleType="CheckBox" Header="SSA"/>
+				<MenuItem Name="BasicOptimizations" ToggleType="CheckBox" Header="Basic Optimizations"/>
+				<MenuItem Name="ValueNumbering" ToggleType="CheckBox" Header="Value Numbering"/>
+				<MenuItem Name="ConditionalConstantPropagation" ToggleType="CheckBox" Header="Conditional Constant Propagation"/>
+				<MenuItem Name="Devirtualization" ToggleType="CheckBox" Header="Devirtualization"/>
+				<MenuItem Name="Inline" ToggleType="CheckBox" Header="Inline"/>
+				<MenuItem Name="InlineExplicit" ToggleType="CheckBox" Header="Inline Explicit"/>
+				<MenuItem Name="LongExpansion" ToggleType="CheckBox" Header="Long Expansion"/>
+				<MenuItem Name="LoopInvariantCodeMotion" ToggleType="CheckBox" Header="Loop Invariant Code Motion"/>
+				<MenuItem Name="BitTracker" ToggleType="CheckBox" Header="Bit Tracker"/>
+				<MenuItem Name="LoopRangeTracker" ToggleType="CheckBox" Header="Loop Range Tracker"/>
+				<MenuItem Name="TwoOptimizationPasses" ToggleType="CheckBox" Header="Two Optimization Passes"/>
+				<MenuItem Name="PlatformOptimizations" ToggleType="CheckBox" Header="Platform Optimizations"/>
+				<MenuItem Name="BinaryCodeGeneration" ToggleType="CheckBox" Header="Binary Code Generation"/>
+				<MenuItem Name="CodeSizeReduction" ToggleType="CheckBox" Header="Code Size Reduction"/>
+			</MenuItem>
+			<MenuItem Header="Display">
+				<MenuItem Name="ShowOperandTypes" ToggleType="CheckBox" Header="Show Operand Types" Click="DisplayClick"/>
+				<MenuItem Name="PadInstructions" ToggleType="CheckBox" IsChecked="True" Header="Pad Instructions" Click="DisplayClick"/>
+				<MenuItem Name="ShowSizes" ToggleType="CheckBox" IsChecked="True" Header="Show Sizes" Click="ShowSizes_OnClick"/>
+				<MenuItem Name="RemoveIrNop" ToggleType="CheckBox" Header="Remove IR.Nop" Click="DisplayClick"/>
+			</MenuItem>
+			<MenuItem Header="Advanced">
+				<MenuItem Name="MultiThreading" ToggleType="CheckBox" Header="Multi-threading"/>
+				<MenuItem Name="MethodScanner" ToggleType="CheckBox" Header="Method Scanner"/>
+				<MenuItem Name="DebugDiagnostic" ToggleType="CheckBox" Header="Debug Diagnostic"/>
+				<MenuItem Name="DumpAllMethodStages" Header="Dump All Method Stages" Click="DumpAllMethodStages_OnClick"/>
+			</MenuItem>
+		</Menu>
+
+		<StackPanel Grid.Row="1" Name="MainPanel" Orientation="Horizontal">
+			<ComboBox Name="Platform" MinWidth="80" SelectedIndex="0" SelectionChanged="Platform_OnSelectionChanged">
+				<ComboBoxItem>x86</ComboBoxItem>
+				<ComboBoxItem>x64</ComboBoxItem>
+				<ComboBoxItem>ARM32</ComboBoxItem>
+			</ComboBox>
+			<Button Name="Open" Click="Open_OnClick">Open...</Button>
+			<Button Name="Refresh" Click="Refresh_OnClick">Refresh</Button>
+			<Button Name="Compile" Click="Compile_OnClick">Compile</Button>
+		</StackPanel>
+
+		<Grid Grid.Row="2" ColumnDefinitions="Auto, 5, *">
+			<Grid Grid.Column="0" RowDefinitions="Auto, *">
+				<Grid Grid.Row="0" ColumnDefinitions="Auto, *">
+					<Label Grid.Column="0">Filter:</Label>
+					<TextBox Grid.Column="1" Name="TreeFilter" MinWidth="100" TextChanged="TreeFilter_OnTextChanged"/>
+				</Grid>
+
+				<TreeView Grid.Row="1" Name="TreeView" SelectionChanged="TreeView_OnSelectionChanged"/>
+			</Grid>
+
+			<GridSplitter Grid.Column="1"/>
+
+			<TabControl Grid.Column="2" Name="TabControl">
+				<TabItem Header="Instructions" FontSize="15">
+					<Grid RowDefinitions="Auto, *">
+						<StackPanel Grid.Row="0" Orientation="Horizontal">
+							<Grid ColumnDefinitions="Auto, *">
+								<Label Grid.Column="0">Stage:</Label>
+								<ComboBox Grid.Column="1" Name="InstructionsStage" MinWidth="100" SelectionChanged="InstructionsStage_OnSelectionChanged"/>
+							</Grid>
+
+							<Grid ColumnDefinitions="Auto, *">
+								<Label Grid.Column="0">Block:</Label>
+								<ComboBox Grid.Column="1" Name="InstructionsBlock" MinWidth="100" SelectionChanged="InstructionsBlock_OnSelectionChanged"/>
+							</Grid>
+
+							<Button Name="SaveA" Click="SaveA_OnClick">Save A</Button>
+							<Button Name="SaveB" Click="SaveB_OnClick">Save B</Button>
+						</StackPanel>
+
+						<TextBox Grid.Row="1" Name="Instructions" IsReadOnly="True"/>
+					</Grid>
+				</TabItem>
+
+				<TabItem Header="Debug" FontSize="15">
+					<Grid RowDefinitions="Auto, *">
+						<StackPanel Grid.Row="0" Orientation="Horizontal">
+							<Grid ColumnDefinitions="Auto, *">
+								<Label Grid.Column="0">Stage:</Label>
+								<ComboBox Grid.Column="1" Name="DebugStage" MinWidth="100" SelectionChanged="DebugStage_OnSelectionChanged"/>
+							</Grid>
+
+							<CheckBox Name="DisplayGraphviz" IsCheckedChanged="DisplayGraphviz_OnIsCheckedChanged">Display Graphviz</CheckBox>
+						</StackPanel>
+
+						<Grid Grid.Row="1" ColumnDefinitions="*, 5, *">
+							<TextBox Grid.Column="0" Name="Debug" IsReadOnly="True"/>
+							<GridSplitter Grid.Column="1"/>
+							<Panel Grid.Column="2" Name="DebugPanel"/>
+						</Grid>
+					</Grid>
+				</TabItem>
+
+				<TabItem Header="Transforms" FontSize="15">
+					<Grid RowDefinitions="Auto, *">
+						<StackPanel Grid.Row="0" Orientation="Horizontal">
+							<Grid ColumnDefinitions="Auto, *">
+								<Label Grid.Column="0">Stage:</Label>
+								<ComboBox Grid.Column="1" Name="TransformsStage" MinWidth="100" SelectionChanged="TransformsStage_OnSelectionChanged"/>
+							</Grid>
+
+							<Grid ColumnDefinitions="Auto, *">
+								<Label Grid.Column="0">Block:</Label>
+								<ComboBox Grid.Column="1" Name="TransformsBlock" MinWidth="100" SelectionChanged="TransformsBlock_OnSelectionChanged"/>
+							</Grid>
+
+							<Button Name="Save1" Click="Save1_OnClick">Save 1</Button>
+							<Button Name="Save2" Click="Save2_OnClick">Save 2</Button>
+						</StackPanel>
+
+						<Grid Grid.Row="1" ColumnDefinitions="*, 5, *">
+							<Grid Grid.Column="0" RowDefinitions="Auto, *">
+								<StackPanel Grid.Row="0" Orientation="Horizontal">
+									<Button Name="First" Click="First_OnClick">First</Button>
+									<Button Name="Previous" Click="Previous_OnClick">Previous</Button>
+									<Button Name="Next" Click="Next_OnClick">Next</Button>
+									<Button Name="Last" Click="Last_OnClick">Last</Button>
+									<Label Name="Current">##</Label>
+									<Label>/</Label>
+									<Label Name="Total">##</Label>
+								</StackPanel>
+
+								<TextBox Grid.Row="1" Name="Transforms" IsReadOnly="True"/>
+							</Grid>
+
+							<GridSplitter Grid.Column="1"/>
+
+							<Grid Grid.Column="2" RowDefinitions="Auto, *">
+								<StackPanel Grid.Row="0" Orientation="Horizontal">
+									<CheckBox Name="SetBlock" IsCheckedChanged="SetBlock_OnIsCheckedChanged">Set Block</CheckBox>
+								</StackPanel>
+
+								<DataGrid Grid.Row="1" Name="TransformsGrid" AutoGenerateColumns="True" IsReadOnly="True" SelectionChanged="TransformsGrid_OnSelectionChanged"></DataGrid>
+							</Grid>
+						</Grid>
+					</Grid>
+				</TabItem>
+
+				<TabItem Header="Counters" FontSize="15">
+					<TabControl>
+						<TabItem Header="Grid" FontSize="15">
+							<Grid RowDefinitions="Auto, *">
+								<StackPanel Grid.Row="0" Orientation="Horizontal">
+									<Grid ColumnDefinitions="Auto, *">
+										<Label Grid.Column="0">Filter:</Label>
+										<TextBox Grid.Column="1" Name="CountersGridFilter" Width="200" TextChanged="CountersGridFilter_OnTextChanged"/>
+									</Grid>
+								</StackPanel>
+
+								<DataGrid Grid.Row="1" Name="CountersGrid" AutoGenerateColumns="True" IsReadOnly="True"/>
+							</Grid>
+						</TabItem>
+
+						<TabItem Header="Text" FontSize="15">
+							<TextBox Name="Counters" IsReadOnly="True"/>
+						</TabItem>
+					</TabControl>
+				</TabItem>
+
+				<TabItem Header="Compiler Logs" FontSize="15">
+					<Grid RowDefinitions="Auto, *">
+						<StackPanel Grid.Row="0" Orientation="Horizontal">
+							<Grid ColumnDefinitions="Auto, *">
+								<Label Grid.Column="0">Section:</Label>
+								<ComboBox Grid.Column="1" Name="CompilerLogsSection" MinWidth="100" SelectionChanged="CompilerLogsSection_OnSelectionChanged"/>
+							</Grid>
+						</StackPanel>
+
+						<TextBox Grid.Row="1" Name="CompilerLogs" IsReadOnly="True"/>
+					</Grid>
+				</TabItem>
+
+				<TabItem Header="Compiler Counters" FontSize="15">
+					<TabControl>
+						<TabItem Header="Grid" FontSize="15">
+							<Grid RowDefinitions="Auto, *">
+								<StackPanel Grid.Row="0" Orientation="Horizontal">
+									<Grid ColumnDefinitions="Auto, *">
+										<Label Grid.Column="0">Filter:</Label>
+										<TextBox Grid.Column="1" Name="CompilerCountersGridFilter" Width="200" TextChanged="CompilerCountersGridFilter_OnTextChanged"/>
+									</Grid>
+								</StackPanel>
+
+								<DataGrid Grid.Row="1" Name="CompilerCountersGrid" AutoGenerateColumns="True" IsReadOnly="True"/>
+							</Grid>
+						</TabItem>
+
+						<TabItem Header="Text" FontSize="15">
+							<TextBox Name="CompilerCounters" IsReadOnly="True"/>
+						</TabItem>
+					</TabControl>
+				</TabItem>
+			</TabControl>
+		</Grid>
+
+		<Grid Grid.Row="3" ColumnDefinitions="Auto, Auto">
+			<ProgressBar Grid.Column="0" VerticalAlignment="Stretch" MaxWidth="200" Name="ProgressBar"/>
+			<Label Grid.Column="1" Name="Status">00.00 | Ready!</Label>
+		</Grid>
+	</Grid>
+</Window>

--- a/Source/Mosa.Tool.Explorer.Avalonia/MainWindow.axaml.cs
+++ b/Source/Mosa.Tool.Explorer.Avalonia/MainWindow.axaml.cs
@@ -1,0 +1,1217 @@
+﻿using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Text;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using Mosa.Compiler.Common;
+using Mosa.Compiler.Framework;
+using Mosa.Compiler.Framework.CompilerStages;
+using Mosa.Compiler.Framework.Stages;
+using Mosa.Compiler.Framework.Stages.Diagnostic;
+using Mosa.Compiler.MosaTypeSystem;
+using Mosa.Compiler.MosaTypeSystem.CLR;
+using Mosa.Tool.Explorer.Avalonia.CompilerStage;
+using Mosa.Tool.Explorer.Avalonia.Stages;
+using Mosa.Utility.Configuration;
+using DebugInfoStage = Mosa.Tool.Explorer.Avalonia.Stages.DebugInfoStage;
+using GraphVizStage = Mosa.Tool.Explorer.Avalonia.Stages.GraphVizStage;
+using Timer = System.Timers.Timer;
+
+namespace Mosa.Tool.Explorer.Avalonia;
+
+public partial class MainWindow : Window
+{
+	private readonly object statusLock = new object();
+
+	private readonly CompilerData compilerData = new CompilerData();
+	private readonly MethodStore methodStore = new MethodStore();
+
+	private readonly ObservableCollection<CounterEntry> counterCollection = new ObservableCollection<CounterEntry>();
+	private readonly ObservableCollection<CounterEntry> compilerCounterCollection = new ObservableCollection<CounterEntry>();
+
+	private MosaSettings mosaSettings = new MosaSettings();
+
+	private MosaCompiler compiler;
+	private int completedMethods;
+	private string currentLogSection = string.Empty;
+
+	private MosaMethod currentMethod;
+	private MethodData currentMethodData;
+
+	private string status;
+	private int totalMethods, transformStep;
+	private TypeSystemTree typeSystemTree;
+
+	private bool graphvizFound;
+
+	private string lastOpenedFile;
+
+	public MainWindow()
+	{
+		InitializeComponent();
+
+		var timer = new Timer();
+		timer.Elapsed += (_, _) => Dispatcher.UIThread.Post(() =>
+		{
+			UpdateProgressBar();
+			RefreshCompilerSelectionDropDown();
+			RefreshCompilerLog();
+			RefreshStatus();
+		});
+		timer.Start();
+
+		CountersGrid.ItemsSource = counterCollection;
+		CompilerCountersGrid.ItemsSource = compilerCounterCollection;
+
+		ClearAll();
+
+		PlatformRegistry.Add(new Compiler.x86.Architecture());
+		PlatformRegistry.Add(new Compiler.x64.Architecture());
+		PlatformRegistry.Add(new Compiler.ARM32.Architecture());
+		//PlatformRegistry.Add(new Compiler.ARM64.Architecture());
+	}
+
+	private void Control_OnLoaded(object _, RoutedEventArgs e)
+	{
+		SetStatus("Ready!");
+
+		if (mosaSettings.SourceFiles == null || mosaSettings.SourceFiles.Count == 0)
+			return;
+
+		var fileName = Path.GetFullPath(mosaSettings.SourceFiles[0]);
+
+		lastOpenedFile = fileName;
+		UpdateSettings(fileName);
+		LoadAssembly();
+
+		if (mosaSettings.ExplorerStart)
+			Compile_OnClick(null, null);
+	}
+
+	public void Initialize(string[] args)
+	{
+		mosaSettings.SetDefaultSettings();
+		mosaSettings.LoadAppLocations();
+		mosaSettings.LoadArguments(args);
+		mosaSettings.NormalizeSettings();
+		mosaSettings.ResolveDefaults();
+
+		SetRequiredSettings();
+
+		graphvizFound = File.Exists(mosaSettings.GraphwizApp);
+
+		UpdateDisplay();
+	}
+
+	private void SetRequiredSettings()
+	{
+		mosaSettings.TraceLevel = 10;
+		mosaSettings.EmulatorSerial = "none";
+		mosaSettings.LauncherExit = false;
+	}
+
+	private void UpdateDisplay()
+	{
+		Inline.IsChecked = mosaSettings.InlineMethods;
+		StaticSingleAssignment.IsChecked = mosaSettings.SSA;
+		BasicOptimizations.IsChecked = mosaSettings.BasicOptimizations;
+		ConditionalConstantPropagation.IsChecked = mosaSettings.SparseConditionalConstantPropagation;
+		Devirtualization.IsChecked = mosaSettings.Devirtualization;
+		InlineExplicit.IsChecked = mosaSettings.InlineExplicit;
+		PlatformOptimizations.IsChecked = mosaSettings.PlatformOptimizations;
+		LongExpansion.IsChecked = mosaSettings.LongExpansion;
+		TwoOptimizationPasses.IsChecked = mosaSettings.TwoPassOptimization;
+		LoopInvariantCodeMotion.IsChecked = mosaSettings.LoopInvariantCodeMotion;
+		ValueNumbering.IsChecked = mosaSettings.ValueNumbering;
+		BitTracker.IsChecked = mosaSettings.BitTracker;
+		LoopRangeTracker.IsChecked = mosaSettings.LoopRangeTracker;
+		BinaryCodeGeneration.IsChecked = mosaSettings.EmitBinary;
+		MethodScanner.IsChecked = mosaSettings.MethodScanner;
+		MultiThreading.IsChecked = mosaSettings.Multithreading;
+		TreeFilter.Text = mosaSettings.ExplorerFilter;
+		DebugDiagnostic.IsChecked = mosaSettings.DebugDiagnostic;
+		CodeSizeReduction.IsChecked = mosaSettings.ReduceCodeSize;
+
+		Platform.SelectedIndex = mosaSettings.Platform.ToLowerInvariant() switch
+		{
+			"x86" => 0,
+			"x64" => 1,
+			"arm32" => 2,
+			//"arm64" => 3,
+			_ => Platform.SelectedIndex
+		};
+
+		DisplayGraphviz.IsChecked = graphvizFound;
+		DisplayGraphviz.IsEnabled = graphvizFound;
+	}
+
+	private async void Open_OnClick(object _, RoutedEventArgs e)
+	{
+		var topLevel = GetTopLevel(this);
+		if (topLevel == null)
+			return;
+
+		var files = await topLevel.StorageProvider.OpenFilePickerAsync(Utils.LibraryOpenOptions);
+		if (files.Count != 1)
+			return;
+
+		lastOpenedFile = files[0].Path.LocalPath;
+		OpenFile();
+	}
+
+	private void Refresh_OnClick(object _, RoutedEventArgs e)
+	{
+		if (File.Exists(lastOpenedFile))
+			OpenFile();
+	}
+
+	private void Compile_OnClick(object _, RoutedEventArgs e)
+	{
+		if (compiler == null)
+			return;
+
+		compilerData.Stopwatch.Restart();
+		compiler.ScheduleAll();
+
+		MainPanel.IsEnabled = false;
+
+		ThreadPool.QueueUserWorkItem(_ =>
+		{
+			try
+			{
+				compiler.Compile();
+			}
+			finally
+			{
+				Dispatcher.UIThread.Post(CompileCompleted);
+			}
+		});
+	}
+
+	private void EnableAllOptimizations_OnClick(object _, RoutedEventArgs e) => ToggleOptimizations(true);
+
+	private void DisableAllOptimizations_OnClick(object _, RoutedEventArgs e) => ToggleOptimizations(false);
+
+	private void ToggleOptimizations(bool state)
+	{
+		StaticSingleAssignment.IsChecked = state;
+		BasicOptimizations.IsChecked = state;
+		ValueNumbering.IsChecked = state;
+		ConditionalConstantPropagation.IsChecked = state;
+		BinaryCodeGeneration.IsChecked = state;
+		Inline.IsChecked = state;
+		InlineExplicit.IsChecked = state;
+		LongExpansion.IsChecked = state;
+		TwoOptimizationPasses.IsChecked = state;
+		BitTracker.IsChecked = state;
+		LoopRangeTracker.IsChecked = state;
+		LoopInvariantCodeMotion.IsChecked = state;
+		PlatformOptimizations.IsChecked = state;
+		Devirtualization.IsChecked = state;
+		CodeSizeReduction.IsChecked = state;
+	}
+
+	private void CompileCompleted()
+	{
+		MainPanel.IsEnabled = true;
+
+		SetStatus("Compiled!");
+
+		compilerData.SortLog("Counters");
+
+		if (typeSystemTree != null)
+			typeSystemTree.Update();
+		else
+			CreateTree();
+	}
+
+	private void Quit_OnClick(object _, RoutedEventArgs e) => Close();
+
+	private void DisplayClick(object _, RoutedEventArgs e)
+	{
+		UpdateInstructions();
+		UpdateTransforms();
+	}
+
+	private void ShowSizes_OnClick(object _, RoutedEventArgs e)
+	{
+		CreateTree();
+		UpdateInstructions();
+		UpdateTransforms();
+	}
+
+	private async void DumpAllMethodStages_OnClick(object _, RoutedEventArgs e)
+	{
+		if (currentMethod == null)
+			return;
+
+		var topLevel = GetTopLevel(this);
+		if (topLevel == null)
+			return;
+
+		var folders = await topLevel.StorageProvider.OpenFolderPickerAsync(Utils.FolderOpenOptions);
+		if (folders.Count != 1)
+			return;
+
+		var path = folders[0].Path.LocalPath;
+
+		InstructionsStage.SelectedIndex = 0;
+
+		for (;;)
+		{
+			UpdateInstructionStageSelection();
+
+			var stage = InstructionsStage.SelectionBoxItem?.ToString()?
+				.Replace("\\", " - ")
+				.Replace("/", " - ");
+
+			await File.WriteAllTextAsync(Path.Combine(path, stage + "-stage.txt"), Instructions.Text);
+
+			if (InstructionsStage.Items.Count == InstructionsStage.SelectedIndex + 1)
+				break;
+
+			InstructionsStage.SelectedIndex++;
+		}
+
+		DebugStage.SelectedIndex = 0;
+
+		for (;;)
+		{
+			UpdateDebugResults();
+
+			var stage = DebugStage.SelectionBoxItem?.ToString()?
+				.Replace("\\", " - ")
+				.Replace("/", " - ");
+
+			await File.WriteAllTextAsync(Path.Combine(path, stage + "-debug.txt"), Debug.Text);
+
+			if (DebugStage.Items.Count == DebugStage.SelectedIndex + 1)
+				break;
+
+			DebugStage.SelectedIndex++;
+		}
+	}
+
+	private void Platform_OnSelectionChanged(object _, SelectionChangedEventArgs e)
+	{
+		if (TreeView != null)
+			ClearAll();
+	}
+
+	private void TreeFilter_OnTextChanged(object _, TextChangedEventArgs e) => CreateTree();
+
+	private void TreeView_OnSelectionChanged(object _, SelectionChangedEventArgs e)
+	{
+		currentMethod = GetCurrentMethod();
+		currentMethodData = GetCurrentMethodData();
+
+		if (compiler == null)
+			return;
+
+		Instructions.Clear();
+
+		if (currentMethod == null)
+			return;
+
+		compilerData.Stopwatch.Reset();
+		compiler.CompileSingleMethod(currentMethod);
+	}
+
+	private void InstructionsStage_OnSelectionChanged(object _, SelectionChangedEventArgs e) => UpdateInstructionStageSelection();
+
+	private void UpdateInstructionStageSelection()
+	{
+		var previousItemLabel = InstructionsBlock.SelectionBoxItem;
+
+		UpdateInstructionBlocks();
+
+		if (previousItemLabel != null && InstructionsBlock.Items.Contains(previousItemLabel))
+			InstructionsBlock.SelectedItem = previousItemLabel;
+		else
+			InstructionsBlock.SelectedIndex = 0;
+
+		UpdateInstructions();
+	}
+
+	private void UpdateInstructionBlocks()
+	{
+		var lines = GetCurrentInstructionLines();
+
+		InstructionsBlock.Items.Clear();
+		InstructionsBlock.Items.Add("All");
+
+		var labels = ExtractLabels(lines);
+		if (labels == null)
+			return;
+
+		foreach (var label in labels)
+			InstructionsBlock.Items.Add(label);
+	}
+
+	private static List<string> ExtractLabels(List<string> lines)
+	{
+		if (lines == null)
+			return null;
+
+		var labels = new List<string>();
+
+		foreach (var line in lines)
+		{
+			if (!line.StartsWith("Block #"))
+				continue;
+
+			labels.Add(line[line.IndexOf("L_", StringComparison.Ordinal)..]);
+		}
+
+		return labels;
+	}
+
+	private void InstructionsBlock_OnSelectionChanged(object _, SelectionChangedEventArgs e) => UpdateInstructions();
+
+	private void SaveA_OnClick(object _, RoutedEventArgs e)
+		=> File.WriteAllText(Path.Combine(mosaSettings.TemporaryFolder, "A.txt"), Instructions.Text);
+
+	private void SaveB_OnClick(object _, RoutedEventArgs e)
+		=> File.WriteAllText(Path.Combine(mosaSettings.TemporaryFolder, "B.txt"), Instructions.Text);
+
+	private void DebugStage_OnSelectionChanged(object _, SelectionChangedEventArgs e) => UpdateDebugResults();
+
+	private void DisplayGraphviz_OnIsCheckedChanged(object _, RoutedEventArgs e) => UpdateGraphviz();
+
+	private void TransformsStage_OnSelectionChanged(object _, SelectionChangedEventArgs e)
+	{
+		var previousItemLabel = TransformsBlock.SelectionBoxItem;
+
+		UpdateTransformLabels();
+
+		if (previousItemLabel != null && TransformsBlock.Items.Contains(previousItemLabel))
+			TransformsBlock.SelectedItem = previousItemLabel;
+		else
+			TransformsBlock.SelectedIndex = 0;
+
+		SetTransformationStep(0);
+		UpdateTransforms();
+		PopulateTransformList();
+	}
+
+	private void TransformsBlock_OnSelectionChanged(object _, SelectionChangedEventArgs e) => UpdateTransforms();
+
+	private void Save1_OnClick(object _, RoutedEventArgs e)
+		=> File.WriteAllText(Path.Combine(mosaSettings.TemporaryFolder, "1.txt"), Transforms.Text);
+
+	private void Save2_OnClick(object _, RoutedEventArgs e)
+		=> File.WriteAllText(Path.Combine(mosaSettings.TemporaryFolder, "2.txt"), Transforms.Text);
+
+	private void First_OnClick(object _, RoutedEventArgs e) => SetTransformationStep(0);
+
+	private void Previous_OnClick(object _, RoutedEventArgs e) => SetTransformationStep(transformStep - 1);
+
+	private void Next_OnClick(object _, RoutedEventArgs e) => SetTransformationStep(transformStep + 1);
+
+	private void Last_OnClick(object _, RoutedEventArgs e) => SetTransformationStep(int.MaxValue);
+
+
+	private void SetBlock_OnIsCheckedChanged(object _, RoutedEventArgs e)
+		=> TransformsGrid_OnSelectionChanged(null, null);
+
+	private void TransformsGrid_OnSelectionChanged(object _, SelectionChangedEventArgs e)
+	{
+		if (TransformsGrid.SelectedItem is not TransformEntry entry)
+			return;
+
+		if (SetBlock.IsChecked != null && SetBlock.IsChecked!.Value && !string.IsNullOrEmpty(entry.Block))
+			TransformsBlock.SelectedItem = entry.Block;
+
+		SetTransformationStep(entry.ID);
+	}
+
+	private void CountersGridFilter_OnTextChanged(object _, TextChangedEventArgs e) => UpdateCounters();
+
+	private void CompilerLogsSection_OnSelectionChanged(object _, SelectionChangedEventArgs e)
+	{
+		var formatted = CompilerLogsSection.SelectionBoxItem?.ToString();
+		if (formatted == null)
+			return;
+
+		currentLogSection = formatted[(formatted.IndexOf(' ') + 1)..];
+		compilerData.DirtyLog = true;
+
+		RefreshCompilerLog();
+	}
+
+	private void CompilerCountersGridFilter_OnTextChanged(object _, TextChangedEventArgs e) => UpdateCompilerCounters();
+
+	private void SetTransformationStep(int step)
+	{
+		if (step <= 0)
+			step = 0;
+
+		var max = GetTransformMaxSteps();
+
+		if (step > max - 1)
+			step = max - 1;
+
+		transformStep = step;
+
+		Current.Content = step;
+		Total.Content = max - 1;
+		TransformsGrid.SelectedIndex = step;
+
+		UpdateTransforms();
+	}
+
+	private int GetTransformMaxSteps()
+	{
+		if (currentMethodData == null)
+			return 0;
+
+		var stage = TransformsStage.SelectionBoxItem?.ToString();
+		if (stage == null)
+			return 0;
+
+		var logs = currentMethodData.TransformLogs[stage];
+		return logs.Count;
+	}
+
+	private void PopulateTransformList()
+	{
+		if (currentMethodData == null)
+			return;
+
+		var stage = TransformsStage.SelectionBoxItem?.ToString();
+		if (stage == null)
+			return;
+
+		if (!currentMethodData.DebugLogs.TryGetValue(stage, out var debug))
+			return;
+
+		if (debug.Contains("*** Pass"))
+			return;
+
+		var list = new List<TransformEntry> { new TransformEntry { ID = 0, Name = "***Start***" } };
+		var pass = 0;
+		TransformEntry entry = null;
+
+		foreach (var line in debug)
+		{
+			if (string.IsNullOrEmpty(line))
+				continue;
+
+			if (line.StartsWith("*** Pass"))
+			{
+				pass = Convert.ToInt32(line[10..]);
+				continue;
+			}
+
+			if (line.StartsWith("Merge Blocking: ") || line.StartsWith("Removed Unreachable Block:"))
+				continue;
+
+			var parts = line.Split('\t');
+			if (parts.Length != 2)
+				continue;
+
+			var part1 = parts[1][1..].Trim();
+
+			if (parts[0].StartsWith("L_") && entry != null)
+			{
+				entry.Block = parts[0].TrimEnd();
+				entry.Before = part1;
+				continue;
+			}
+
+			if (parts[0].StartsWith(' ') && entry != null)
+			{
+				entry.After = part1;
+				continue;
+			}
+
+			entry = new TransformEntry
+			{
+				ID = Convert.ToInt32(parts[0].Trim()) + 1,
+				Name = part1,
+				Pass = pass
+			};
+
+			list.Add(entry);
+		}
+
+		TransformsGrid.ItemsSource = list;
+	}
+
+	private void UpdateTransformLabels()
+	{
+		var lines = GetCurrentTransformLines();
+
+		TransformsBlock.Items.Clear();
+		TransformsBlock.Items.Add("All");
+
+		var labels = ExtractLabels(lines);
+		if (labels == null)
+			return;
+
+		foreach (var label in labels)
+			TransformsBlock.Items.Add(label);
+	}
+
+	private void UpdateDebugResults()
+	{
+		Debug.Clear();
+
+		var lines = GetCurrentDebugLines();
+		if (lines == null)
+			return;
+
+		Debug.Text = CreateText(lines);
+
+		UpdateGraphviz();
+	}
+
+	private List<string> GetCurrentDebugLines()
+	{
+		if (currentMethodData == null)
+			return null;
+
+		var stage = DebugStage.SelectionBoxItem?.ToString();
+		return stage == null ? null : currentMethodData.DebugLogs[stage];
+	}
+
+	private void UpdateGraphviz()
+	{
+		var graphviz = ShowGraphviz();
+
+		DebugPanel.IsVisible = graphviz;
+		Debug.IsVisible = !graphviz;
+	}
+
+	private bool ShowGraphviz()
+	{
+		DebugPanel.Children.Clear();
+
+		if (!graphvizFound)
+			return false;
+
+		if (DisplayGraphviz.IsChecked != null && !DisplayGraphviz.IsChecked.Value)
+			return false;
+
+		if (string.IsNullOrEmpty(Debug.Text) || !Debug.Text.Contains("digraph blocks"))
+			return false;
+
+		var dot = Path.GetTempFileName();
+		var bmp = Path.GetTempFileName();
+
+		try
+		{
+			File.WriteAllText(dot, Debug.Text);
+
+			var startInfo = new ProcessStartInfo
+			{
+				FileName = mosaSettings.GraphwizApp,
+				Arguments = $"dot -Tbmp -o \"{bmp}\" \"{dot}\"",
+				CreateNoWindow = true
+			};
+
+			var process = Process.Start(startInfo);
+			process?.WaitForExit();
+
+			var file = File.ReadAllBytes(bmp);
+
+			using var stream = new MemoryStream(file);
+
+			var bitmap = new Bitmap(stream);
+			var picture = new Image
+			{
+				Source = bitmap
+			};
+
+			DebugPanel.Children.Add(picture);
+		}
+		finally
+		{
+			File.Delete(dot);
+			File.Delete(bmp);
+		}
+
+		return true;
+	}
+
+	private void OpenFile()
+	{
+		UpdateSettings();
+		UpdateSettings(lastOpenedFile);
+		LoadAssembly();
+	}
+
+	private CompilerHooks CreateCompilerHooks() => new CompilerHooks
+	{
+		ExtendCompilerPipeline = ExtendCompilerPipeline,
+		ExtendMethodCompilerPipeline = ExtendMethodCompilerPipeline,
+
+		NotifyProgress = NotifyProgress,
+		NotifyEvent = NotifyEvent,
+		NotifyTraceLog = NotifyTraceLog,
+		NotifyMethodCompiled = NotifyMethodCompiled,
+		NotifyMethodInstructionTrace = NotifyMethodInstructionTrace,
+		NotifyMethodTranformTrace = NotifyMethodTransformTrace,
+		GetMethodTraceLevel = GetMethodTraceLevel
+	};
+
+	private static void ExtendCompilerPipeline(Pipeline<BaseCompilerStage> pipeline)
+		=> pipeline.InsertAfterFirst<TypeInitializerStage>(new ExplorerMethodCompileTimeStage());
+
+	private void ExtendMethodCompilerPipeline(Pipeline<BaseMethodCompilerStage> pipeline)
+	{
+		pipeline.Add(new DisassemblyStage());
+		pipeline.Add(new DebugInfoStage());
+
+		pipeline.InsertAfterLast<FastBlockOrderingStage>(new LoopAnalysisStage());
+		pipeline.InsertAfterLast<FastBlockOrderingStage>(new DominanceAnalysisStage());
+
+		if (Dispatcher.UIThread.Invoke(() => DebugDiagnostic.IsChecked))
+		{
+			for (var i = 1; i < pipeline.Count; i += 2)
+				pipeline.Insert(i, new GraphVizStage());
+		}
+		else
+		{
+			pipeline.InsertAfterLast<FastBlockOrderingStage>(new GraphVizStage());
+			pipeline.Add(new GraphVizStage());
+		}
+	}
+
+	private void NotifyProgress(int total, int completed)
+	{
+		totalMethods = total;
+		completedMethods = completed;
+	}
+
+	private void NotifyEvent(CompilerEvent compilerEvent, string message, int threadID)
+	{
+		if (compilerEvent != CompilerEvent.Counter)
+		{
+			var newStatus = compilerEvent.ToText();
+			if (!string.IsNullOrWhiteSpace(message))
+				newStatus += $": {message}";
+
+			lock (statusLock)
+				status = newStatus;
+		}
+
+		compilerData.AddTraceEvent(compilerEvent, message, threadID);
+
+		currentMethodData ??= GetCurrentMethodData();
+	}
+
+	private void NotifyTraceLog(TraceLog traceLog)
+	{
+		switch (traceLog.Type)
+		{
+			case TraceType.MethodDebug when traceLog.Lines.Count == 0: return;
+			case TraceType.MethodDebug:
+				{
+					var stageSection = traceLog.Stage;
+					if (traceLog.Section != null)
+						stageSection = $"{stageSection}-{traceLog.Section}";
+
+					methodStore.SetDebugStageInformation(traceLog.Method, stageSection, traceLog.Lines, traceLog.Version);
+					break;
+				}
+			case TraceType.MethodCounters:
+				{
+					methodStore.SetMethodCounterInformation(traceLog.Method, traceLog.Lines, traceLog.Version);
+					break;
+				}
+			case TraceType.MethodInstructions:
+				{
+					NotifyMethodInstructionTraceResponse(traceLog);
+					break;
+				}
+			case TraceType.GlobalDebug:
+				{
+					compilerData.UpdateLog(traceLog.Section, traceLog.Lines, traceLog.Section == currentLogSection);
+					break;
+				}
+		}
+	}
+
+	private void NotifyMethodCompiled(MosaMethod method)
+	{
+		if (method == currentMethod)
+			Dispatcher.UIThread.Post(UpdateMethodInformation);
+	}
+
+	private CompilerHooks.NotifyTraceLogHandler NotifyMethodInstructionTrace(MosaMethod method)
+	{
+		if (method != currentMethod)
+			return null;
+
+		return NotifyMethodInstructionTraceResponse;
+	}
+
+	private CompilerHooks.NotifyTraceLogHandler NotifyMethodTransformTrace(MosaMethod method)
+	{
+		if (method != currentMethod)
+			return null;
+
+		return NotifyMethodTransformTraceResponse;
+	}
+
+	private int? GetMethodTraceLevel(MosaMethod method) => method == currentMethod ? 10 : -1;
+
+	private void NotifyMethodTransformTraceResponse(TraceLog traceLog)
+		=> methodStore.SetTransformTraceInformation(traceLog.Method, traceLog.Stage, traceLog.Lines, traceLog.Version, traceLog.Step);
+
+	private void NotifyMethodInstructionTraceResponse(TraceLog traceLog)
+		=> methodStore.SetInstructionTraceInformation(traceLog.Method, traceLog.Stage, traceLog.Lines, traceLog.Version);
+
+	private void UpdateMethodInformation()
+	{
+		UpdateInstructionStages();
+		UpdateDebugStages();
+		UpdateCounters();
+		UpdateTransformStages();
+	}
+
+	private void UpdateInstructions()
+	{
+		Instructions.Clear();
+
+		if (currentMethod == null)
+			return;
+
+		var lines = GetCurrentInstructionLines();
+		var label = InstructionsBlock.SelectionBoxItem?.ToString();
+
+		SetStatus(currentMethod.FullName);
+
+		if (lines == null)
+			return;
+
+		if (string.IsNullOrWhiteSpace(label) || label == "All")
+			label = string.Empty;
+
+		Instructions.Text = methodStore.GetStageInstructions(lines, label, !ShowOperandTypes.IsChecked,
+			PadInstructions.IsChecked, RemoveIrNop.IsChecked);
+	}
+
+	private void UpdateTransforms()
+	{
+		Transforms.Clear();
+
+		if (currentMethod == null)
+			return;
+
+		var lines = GetCurrentTransformLines();
+		var label = TransformsBlock.SelectionBoxItem?.ToString();
+
+		if (lines == null)
+			return;
+
+		if (string.IsNullOrWhiteSpace(label) || label == "All")
+			label = string.Empty;
+
+		Transforms.Text = methodStore.GetStageInstructions(lines, label, !ShowOperandTypes.IsChecked,
+			PadInstructions.IsChecked, RemoveIrNop.IsChecked);
+	}
+
+	private List<string> GetCurrentTransformLines()
+	{
+		if (currentMethodData == null)
+			return null;
+
+		var stage = TransformsStage.SelectionBoxItem?.ToString();
+		if (stage == null)
+			return null;
+
+		var logs = currentMethodData.TransformLogs[stage];
+		logs.TryGetValue(transformStep, out var log);
+
+		return log;
+	}
+
+	private List<string> GetCurrentInstructionLines()
+	{
+		if (currentMethodData == null)
+			return null;
+
+		var stage = InstructionsStage.SelectionBoxItem?.ToString();
+		return stage == null ? null : currentMethodData.InstructionLogs[stage];
+
+	}
+
+	private void UpdateInstructionStages()
+	{
+		InstructionsStage.Items.Clear();
+
+		if (currentMethodData == null)
+			return;
+
+		foreach (var stage in currentMethodData.OrderedStageNames)
+			InstructionsStage.Items.Add(stage);
+
+		InstructionsStage.SelectedIndex = InstructionsStage.Items.Count == 0 ? -1 : 0;
+	}
+
+	private void UpdateDebugStages()
+	{
+		DebugStage.Items.Clear();
+
+		if (currentMethodData == null)
+			return;
+
+		foreach (var stage in currentMethodData.OrderedDebugStageNames)
+			DebugStage.Items.Add(stage);
+
+		if (DebugStage.Items.Count > 0)
+			DebugStage.SelectedIndex = 0;
+	}
+
+	private void UpdateCounters()
+	{
+		Counters.Clear();
+
+		if (currentMethodData == null)
+			return;
+
+		Counters.Text = CreateText(currentMethodData.Counters);
+
+		counterCollection.Clear();
+
+		var filter = CountersGridFilter.Text ?? string.Empty;
+
+		foreach (var line in currentMethodData.Counters)
+		{
+			if (!line.Contains(filter))
+				continue;
+
+			var entry = ExtractCounterData(line);
+			counterCollection.Add(entry);
+		}
+	}
+
+	private void UpdateTransformStages()
+	{
+		TransformsStage.Items.Clear();
+
+		if (currentMethodData == null)
+			return;
+
+		foreach (var stage in currentMethodData.OrderedTransformStageNames)
+			TransformsStage.Items.Add(stage);
+
+		if (TransformsStage.Items.Count > 0)
+			TransformsStage.SelectedIndex = 0;
+	}
+
+	private MosaMethod GetCurrentMethod() => ((TreeViewItem)TreeView.SelectedItem)?.Tag as MosaMethod;
+
+	private MethodData GetCurrentMethodData() => currentMethod == null ? null : methodStore.GetMethodData(currentMethod, false);
+
+	private void CreateTree()
+	{
+		if (compiler == null)
+			return;
+
+		if (compiler.TypeSystem == null || compiler.TypeLayout == null)
+		{
+			typeSystemTree = null;
+			TreeView.Items.Clear();
+			return;
+		}
+
+		var included = GetIncluded(TreeFilter.Text, out MosaUnit selected);
+
+		typeSystemTree = new TypeSystemTree(TreeView, compiler.TypeSystem, compiler.TypeLayout, ShowSizes.IsChecked, included);
+
+		Select(selected);
+	}
+
+	private HashSet<MosaUnit> GetIncluded(string value, out MosaUnit selected)
+	{
+		value = value.Trim();
+		selected = null;
+
+		if (string.IsNullOrWhiteSpace(value))
+			return null;
+
+		if (value.Length < 1)
+			return null;
+
+		var include = new HashSet<MosaUnit>();
+
+		MosaUnit typeSelected = null;
+		MosaUnit methodSelected = null;
+
+		foreach (var type in compiler.TypeSystem.AllTypes)
+		{
+			if (string.IsNullOrEmpty(type.FullName))
+				continue;
+
+			var typeIncluded = false;
+			var typeMatch = type.FullName.Contains(value);
+
+			if (typeMatch)
+			{
+				include.Add(type);
+				include.AddIfNew(type.Module);
+
+				typeSelected ??= type;
+			}
+
+			foreach (var method in type.Methods)
+			{
+				if (string.IsNullOrEmpty(method.FullName))
+					continue;
+
+				var methodMatch = method.FullName.Contains(value);
+				if (!typeMatch && !methodMatch)
+					continue;
+
+				include.Add(method);
+				include.AddIfNew(type);
+				include.AddIfNew(type.Module);
+
+				if (methodMatch && methodSelected == null)
+					methodSelected = method;
+			}
+
+			foreach (var property in type.Properties)
+			{
+				if (string.IsNullOrEmpty(property.FullName))
+					continue;
+
+				if (!typeIncluded && !property.FullName.Contains(value))
+					continue;
+
+				include.Add(property);
+				include.AddIfNew(type);
+				include.AddIfNew(type.Module);
+			}
+		}
+
+		selected = methodSelected ?? typeSelected;
+
+		return include;
+	}
+
+	private void Select(MosaUnit selected)
+	{
+		if (selected == null)
+			return;
+
+		foreach (TreeViewItem node in TreeView.Items)
+			if (Select(node, selected))
+				return;
+	}
+
+	private bool Select(TreeViewItem node, MosaUnit selected)
+	{
+		if (node == null)
+			return false;
+
+		if (node.Tag != null && node.Tag == selected)
+		{
+			TreeView.SelectedItem = node;
+			return true;
+		}
+
+		foreach (TreeViewItem children in node.Items)
+			if (Select(children, selected))
+				return true;
+
+		return false;
+	}
+
+	private void SetStatus(string newStatus)
+		=> Status.Content = $"{compilerData.Stopwatch.Elapsed.TotalSeconds:00.00} | {newStatus}";
+
+	private void UpdateSettings()
+	{
+		mosaSettings.MethodScanner = MethodScanner.IsChecked;
+		mosaSettings.EmitBinary = BinaryCodeGeneration.IsChecked;
+		mosaSettings.Platform = Platform.SelectionBoxItem?.ToString();
+		mosaSettings.Multithreading = MultiThreading.IsChecked;
+		mosaSettings.SSA = StaticSingleAssignment.IsChecked;
+		mosaSettings.BasicOptimizations = BasicOptimizations.IsChecked;
+		mosaSettings.ValueNumbering = ValueNumbering.IsChecked;
+		mosaSettings.SparseConditionalConstantPropagation = ConditionalConstantPropagation.IsChecked;
+		mosaSettings.Devirtualization = Devirtualization.IsChecked;
+		mosaSettings.BitTracker = BitTracker.IsChecked;
+		mosaSettings.LoopRangeTracker = LoopRangeTracker.IsChecked;
+		mosaSettings.LoopInvariantCodeMotion = LoopInvariantCodeMotion.IsChecked;
+		mosaSettings.LongExpansion = LongExpansion.IsChecked;
+		mosaSettings.TwoPassOptimization = TwoOptimizationPasses.IsChecked;
+		mosaSettings.PlatformOptimizations = PlatformOptimizations.IsChecked;
+		mosaSettings.InlineMethods = Inline.IsChecked;
+		mosaSettings.InlineExplicit = InlineExplicit.IsChecked;
+		mosaSettings.ReduceCodeSize = CodeSizeReduction.IsChecked;
+
+		mosaSettings.TraceLevel = 10;
+		//mosaSettings.InlineMaximum = 12;
+		//mosaSettings.InlineAggressiveMaximum = 24;
+		mosaSettings.MultibootVersion = "v2";
+	}
+
+	private void UpdateSettings(string path)
+	{
+		// Source Files
+		mosaSettings.ClearSourceFiles();
+		mosaSettings.AddSourceFile(path);
+
+		// Search Paths
+		mosaSettings.ClearSearchPaths();
+		mosaSettings.AddSearchPath(Path.GetDirectoryName(path));
+
+		mosaSettings.ResolveFileAndPathSettings();
+		mosaSettings.AddStandardPlugs();
+		mosaSettings.ExpandSearchPaths();
+	}
+
+	private void LoadAssembly()
+	{
+		ClearAll();
+		UpdateSettings();
+
+		compiler = new MosaCompiler(mosaSettings, CreateCompilerHooks(), new ClrModuleLoader(), new ClrTypeResolver());
+		compiler.Load();
+
+		CreateTree();
+		SetStatus("Assemblies Loaded!");
+	}
+
+	private void ClearAll()
+	{
+		compiler = null;
+		typeSystemTree = null;
+
+		TreeView.Items.Clear();
+		Instructions.Clear();
+		Debug.Clear();
+
+		methodStore.Clear();
+		counterCollection.Clear();
+		compilerCounterCollection.Clear();
+
+		ClearAllLogs();
+	}
+
+	private void ClearAllLogs()
+	{
+		compilerData.ClearAllLogs();
+		ClearSectionDropDown();
+		CompilerLogsSection.SelectedIndex = 0;
+	}
+
+	private void ClearSectionDropDown()
+	{
+		CompilerLogsSection.Items.Clear();
+
+		compilerData.DirtyLogSections = true;
+		compilerData.DirtyLog = true;
+
+		RefreshCompilerSelectionDropDown();
+		RefreshCompilerLog();
+	}
+
+	private void UpdateProgressBar()
+	{
+		ProgressBar.Maximum = totalMethods;
+		ProgressBar.Value = completedMethods;
+	}
+
+	private void RefreshCompilerSelectionDropDown()
+	{
+		if (!compilerData.DirtyLogSections)
+			return;
+
+		compilerData.DirtyLogSections = false;
+
+		lock (compilerData.Logs)
+			for (var i = CompilerLogsSection.Items.Count; i < compilerData.LogSections.Count; i++)
+				CompilerLogsSection.Items.Add($"[{i}] {compilerData.LogSections[i]}");
+	}
+
+	private void RefreshCompilerLog()
+	{
+		if (!compilerData.DirtyLog)
+			return;
+
+		switch (TabControl.SelectedIndex)
+		{
+			// Compiler Logs
+			case 4:
+				{
+					CompilerLogs.Text = CreateText(compilerData.GetLog(currentLogSection));
+					break;
+				}
+			// Compiler Counters
+			case 5:
+				{
+					UpdateCompilerCounters();
+					break;
+				}
+		}
+
+		compilerData.DirtyLog = false;
+	}
+
+	private void RefreshStatus()
+	{
+		lock (statusLock)
+		{
+			if (status == null)
+				return;
+
+			SetStatus(status);
+			status = null;
+		}
+	}
+
+	private static string CreateText(List<string> list)
+	{
+		if (list == null)
+			return string.Empty;
+
+		var sb = new StringBuilder();
+
+		lock (list)
+		{
+			foreach (var l in list)
+				sb.AppendLine(l);
+		}
+
+		return sb.ToString();
+	}
+
+	private void UpdateCompilerCounters()
+	{
+		compilerCounterCollection.Clear();
+
+		var lines = compilerData.GetLog("Counters");
+		if (lines == null)
+			return;
+
+		var filter = CompilerCountersGridFilter.Text ?? string.Empty;
+		foreach (var line in lines)
+		{
+			if (!line.Contains(filter))
+				continue;
+
+			var entry = ExtractCounterData(line);
+			compilerCounterCollection.Add(entry);
+		}
+
+		CompilerCounters.Text = CreateText(lines);
+	}
+
+	private static CounterEntry ExtractCounterData(string line)
+	{
+		var index = line.IndexOf(':');
+		var name = line[..index].Trim();
+		var value = int.Parse(line[(index + 1)..].Trim());
+		var entry = new CounterEntry(name, value);
+
+		return entry;
+	}
+}

--- a/Source/Mosa.Tool.Explorer.Avalonia/MethodData.cs
+++ b/Source/Mosa.Tool.Explorer.Avalonia/MethodData.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+namespace Mosa.Tool.Explorer.Avalonia;
+
+public class MethodData
+{
+	//public MosaMethod Method;
+
+	public int Version;
+
+	public readonly List<string> OrderedStageNames = new List<string>();
+	public readonly List<string> OrderedDebugStageNames = new List<string>();
+
+	public readonly List<string> OrderedTransformStageNames = new List<string>();
+
+	public readonly Dictionary<string, List<string>> InstructionLogs = new Dictionary<string, List<string>>();
+	public readonly Dictionary<string, List<string>> DebugLogs = new Dictionary<string, List<string>>();
+
+	public List<string> Counters = new List<string>();
+
+	public Dictionary<string, Dictionary<int, List<string>>> TransformLogs = new Dictionary<string, Dictionary<int, List<string>>>();
+}

--- a/Source/Mosa.Tool.Explorer.Avalonia/MethodStore.cs
+++ b/Source/Mosa.Tool.Explorer.Avalonia/MethodStore.cs
@@ -1,0 +1,236 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using System.Text;
+using Mosa.Compiler.Common;
+using Mosa.Compiler.MosaTypeSystem;
+
+namespace Mosa.Tool.Explorer.Avalonia;
+
+public class MethodStore
+{
+	private readonly Dictionary<MosaMethod, MethodData> methodDataStore = new Dictionary<MosaMethod, MethodData>();
+
+	public void Clear()
+	{
+		lock (methodDataStore)
+		{
+			methodDataStore.Clear();
+		}
+	}
+
+	private static void ClearMethodDataOnNewVersion(int version, MethodData methodData)
+	{
+		if (methodData.Version == version)
+			return;
+
+		methodData.InstructionLogs.Clear();
+		methodData.OrderedDebugStageNames.Clear();
+		methodData.OrderedStageNames.Clear();
+		methodData.OrderedTransformStageNames.Clear();
+		methodData.Counters.Clear();
+		methodData.DebugLogs.Clear();
+		methodData.TransformLogs.Clear();
+		methodData.Version = version;
+	}
+
+	public MethodData GetMethodData(MosaMethod method, bool create)
+	{
+		lock (methodDataStore)
+		{
+			if (methodDataStore.TryGetValue(method, out MethodData methodData) || !create)
+				return methodData;
+
+			methodData = new MethodData();
+			methodDataStore.Add(method, methodData);
+			return methodData;
+		}
+	}
+
+	public void SetInstructionTraceInformation(MosaMethod method, string stage, List<string> lines, int version)
+	{
+		var methodData = GetMethodData(method, true);
+
+		lock (methodData)
+		{
+			ClearMethodDataOnNewVersion(version, methodData);
+
+			methodData.OrderedStageNames.AddIfNew(stage);
+			methodData.InstructionLogs.Remove(stage);
+			methodData.InstructionLogs.Add(stage, lines);
+		}
+	}
+
+	public void SetTransformTraceInformation(MosaMethod method, string stage, List<string> lines, int version, int step)
+	{
+		var methodData = GetMethodData(method, true);
+
+		lock (methodData)
+		{
+			ClearMethodDataOnNewVersion(version, methodData);
+
+			methodData.OrderedTransformStageNames.AddIfNew(stage);
+
+			if (!methodData.TransformLogs.TryGetValue(stage, out var directionary))
+			{
+				directionary = new Dictionary<int, List<string>>();
+				methodData.TransformLogs.Add(stage, directionary);
+			}
+
+			directionary.Add(step, lines);
+		}
+	}
+
+	public void SetDebugStageInformation(MosaMethod method, string stage, List<string> lines, int version)
+	{
+		var methodData = GetMethodData(method, true);
+
+		lock (methodData)
+		{
+			ClearMethodDataOnNewVersion(version, methodData);
+
+			methodData.OrderedDebugStageNames.AddIfNew(stage);
+			methodData.DebugLogs.Remove(stage);
+			methodData.DebugLogs.Add(stage, lines);
+		}
+	}
+
+	public void SetMethodCounterInformation(MosaMethod method, List<string> lines, int version)
+	{
+		var methodData = GetMethodData(method, true);
+
+		lock (methodData)
+		{
+			ClearMethodDataOnNewVersion(version, methodData);
+
+			methodData.Counters = lines;
+		}
+	}
+
+	public string GetStageInstructions(List<string> lines, string blockLabel, bool strip, bool pad, bool removeNop)
+	{
+		var result = new StringBuilder();
+
+		if (lines == null)
+			return string.Empty;
+
+		if (string.IsNullOrWhiteSpace(blockLabel))
+		{
+			foreach (var l in lines)
+			{
+				var line = l;
+
+				if (line.Contains("IR.BlockStart") || line.Contains("IR.BlockEnd"))
+					continue;
+
+				if (removeNop && line.Contains("IR.Nop"))
+					continue;
+
+				if (strip)
+					line = StripBracketContents(line);
+
+				if (pad)
+					line = PadInstruction(line);
+
+				line = Simplify(line);
+
+				result.Append(line);
+				result.Append('\n');
+			}
+
+			return result.ToString();
+		}
+
+		var inBlock = false;
+
+		foreach (var l in lines)
+		{
+			var line = l;
+
+			if ((!inBlock) && line.StartsWith("Block #") && line.EndsWith(blockLabel))
+				inBlock = true;
+
+			if (!inBlock)
+				continue;
+
+			if (line.Contains("IR.BlockStart") || line.Contains("IR.BlockEnd"))
+				continue;
+
+			if (strip)
+				line = StripBracketContents(line);
+
+			if (pad)
+				line = PadInstruction(line);
+
+			line = Simplify(line);
+
+			result.Append(line);
+			result.Append('\n');
+
+			if (line.StartsWith("  Next:"))
+				return result.ToString();
+		}
+
+		return result.ToString();
+	}
+
+	private static string StripBracketContents(string s)
+	{
+		if (string.IsNullOrEmpty(s) || s.Length < 5)
+			return s;
+
+		if (!char.IsDigit(s[0]))
+			return s;
+
+		var at = 0;
+		while (true)
+		{
+			var open = s.IndexOf(" [", at, StringComparison.Ordinal);
+			if (open < 0)
+				return s;
+
+			var close = s.IndexOf(']', open);
+			if (close < 0)
+				return s;
+
+			var part = s.Substring(open + 2, close - open - 2);
+			if (part == "NULL" || char.IsSymbol(part[0]) || char.IsPunctuation(part[0]))
+			{
+				at = close;
+				continue;
+			}
+
+			s = s.Remove(open, close - open + 1);
+			at = open;
+		}
+	}
+
+	private static string PadInstruction(string s)
+	{
+		const int padding = 30;
+
+		if (string.IsNullOrEmpty(s) || s.Length < 5)
+			return s;
+
+		if (!char.IsDigit(s[0]))
+			return s;
+
+		var first = s.IndexOf(':');
+		if (first is < 0 or > 15)
+			return s;
+
+		var second = s.IndexOf(' ', first + 2);
+
+		switch (second)
+		{
+			case < 0: return s;
+			case > padding: return s;
+			default:
+				{
+					s = s.Insert(second, new string(' ', padding - second));
+					return s;
+				}
+		}
+	}
+
+	private static string Simplify(string s) => s.Replace("const=", string.Empty);
+}

--- a/Source/Mosa.Tool.Explorer.Avalonia/Mosa.Tool.Explorer.Avalonia.csproj
+++ b/Source/Mosa.Tool.Explorer.Avalonia/Mosa.Tool.Explorer.Avalonia.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>WinExe</OutputType>
+        <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+        <ApplicationManifest>app.manifest</ApplicationManifest>
+        <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    </PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Mosa.Compiler.Framework\Mosa.Compiler.Framework.csproj" />
+		<ProjectReference Include="..\Mosa.Compiler.MosaTypeSystem.CLR\Mosa.Compiler.MosaTypeSystem.CLR.csproj" />
+		<ProjectReference Include="..\Mosa.Compiler.ARM32\Mosa.Compiler.ARM32.csproj" />
+		<ProjectReference Include="..\Mosa.Compiler.x64\Mosa.Compiler.x64.csproj" />
+		<ProjectReference Include="..\Mosa.Compiler.x86\Mosa.Compiler.x86.csproj" />
+		<ProjectReference Include="..\Mosa.Utility.Configuration\Mosa.Utility.Configuration.csproj" />
+		<ProjectReference Include="..\Mosa.Utility.Disassembler\Mosa.Utility.Disassembler.csproj" />
+		<ProjectReference Include="..\Mosa.Utility.Launcher\Mosa.Utility.Launcher.csproj" />
+	</ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Avalonia" Version="11.1.0-beta1" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.1.0-beta1" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.0-beta1" />
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.0-beta1" />
+    </ItemGroup>
+
+</Project>

--- a/Source/Mosa.Tool.Explorer.Avalonia/Program.cs
+++ b/Source/Mosa.Tool.Explorer.Avalonia/Program.cs
@@ -1,0 +1,19 @@
+﻿using Avalonia;
+
+namespace Mosa.Tool.Explorer.Avalonia;
+
+public static class Program
+{
+	// Initialization code. Don't use any Avalonia, third-party APIs or any
+	// SynchronizationContext-reliant code before AppMain is called: things aren't initialized
+	// yet and stuff might break.
+	[STAThread]
+	public static void Main(string[] args) => BuildAvaloniaApp()
+		.StartWithClassicDesktopLifetime(args);
+
+	// Avalonia configuration, don't remove; also used by visual designer.
+	public static AppBuilder BuildAvaloniaApp()
+		=> AppBuilder.Configure<App>()
+			.UsePlatformDetect()
+			.LogToTrace();
+}

--- a/Source/Mosa.Tool.Explorer.Avalonia/Stages/DebugInfoStage.cs
+++ b/Source/Mosa.Tool.Explorer.Avalonia/Stages/DebugInfoStage.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using Mosa.Compiler.Framework;
+
+namespace Mosa.Tool.Explorer.Avalonia.Stages;
+
+public class DebugInfoStage : BaseMethodCompilerStage
+{
+	protected override void Run()
+	{
+		DumpByInstructions();
+		DumpRegions();
+		DumpSourceInfo();
+	}
+
+	protected void DumpByInstructions()
+	{
+		var trace = CreateTraceLog("Instructions");
+		if (trace == null)
+			return;
+
+		trace.Log("Label\tAddress\tLength\tStartLine\tEndLine\tStartColumn\tEndColumn\tInstruction\tDocument");
+
+		foreach (var block in BasicBlocks)
+		{
+			for (var node = block.First; !node.IsBlockEndInstruction; node = node.Next)
+			{
+				if (node.IsEmpty)
+					continue;
+
+				if (node.Instruction.IgnoreDuringCodeGeneration)
+					continue;
+
+				var label = node.Label;
+				var startLine = -1;
+				var endLine = 0;
+				var endColumn = 0;
+				var startColumn = 0;
+				var document = string.Empty;
+
+				//var offset = node.Offset;
+
+				var address = -1;
+				var length = 0;
+
+				foreach (var instruction in Method.Code)
+				{
+					if (instruction.Offset != label)
+						continue;
+
+					startLine = instruction.StartLine;
+					endLine = instruction.EndLine;
+					startColumn = instruction.StartColumn;
+					endColumn = instruction.EndColumn;
+					document = instruction.Document;
+
+					break;
+				}
+
+				if (startLine == -1)
+					continue;
+
+				foreach (var region in MethodData.LabelRegions)
+				{
+					if (region.Label != label)
+						continue;
+
+					address = region.Start;
+					length = region.Length;
+					break;
+				}
+
+				if (address == -1)
+					continue;
+
+				trace.Log($"{label:X5}\t{address}\t{length}\t{startLine}\t{endLine}\t{startColumn}\t{endColumn}\t{node}\t{document}");
+			}
+		}
+	}
+
+	protected void DumpRegions()
+	{
+		var trace = CreateTraceLog("Regions");
+
+		trace.Log("Label\tAddress\tLength");
+
+		foreach (var region in MethodData.LabelRegions)
+		{
+			trace.Log($"{region.Label:X5}\t{region.Start}\t{region.Length}");
+		}
+	}
+
+	protected void DumpSourceInfo()
+	{
+		var trace = CreateTraceLog("Source");
+
+		trace.Log("Label\tStartLine\tEndLine\tStartColumn\tEndColumn\tDocument");
+
+		foreach (var instruction in Method.Code)
+		{
+			trace.Log($"{instruction.Offset:X5}\t{instruction.StartLine}\t{instruction.EndLine}\t{instruction.StartColumn}\t{instruction.EndColumn}\t{instruction.Document}");
+		}
+	}
+}

--- a/Source/Mosa.Tool.Explorer.Avalonia/Stages/DisassemblyStage.cs
+++ b/Source/Mosa.Tool.Explorer.Avalonia/Stages/DisassemblyStage.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using Mosa.Compiler.Framework;
+using Mosa.Utility.Disassembler;
+
+namespace Mosa.Tool.Explorer.Avalonia.Stages;
+
+public class DisassemblyStage : BaseMethodCompilerStage
+{
+	protected override void Run()
+	{
+		if (!MosaSettings.EmitBinary)
+			return;
+
+		TraceDisassembly();
+		TracePatchRequests();
+	}
+
+	protected void TraceDisassembly()
+	{
+		var trace = CreateTraceLog();
+		if (trace == null)
+			return;
+
+		// Create a byte array from the symbol stream
+		var symbol = Linker.GetSymbol(Method.FullName);
+		var stream = symbol.Stream;
+		var oldPosition = stream.Position;
+		var length = (int)stream.Length;
+		var memory = new byte[length];
+
+		stream.Position = 0;
+		stream.Read(memory, 0, length);
+		stream.Position = oldPosition;
+
+		var disassembler = new Disassembler(Architecture.PlatformName);
+		disassembler.SetMemory(memory, 0);
+
+		var list = disassembler.Decode();
+
+		if (list != null)
+		{
+			foreach (var instr in list)
+				trace.Log(instr.Full);
+		}
+		else
+		{
+			PostEvent(CompilerEvent.Error, $"Failed disassembly for method {MethodCompiler.Method}");
+		}
+	}
+
+	protected void TracePatchRequests()
+	{
+		var trace = CreateTraceLog("Patch-Requests");
+		if (trace == null)
+			return;
+
+		var symbol = Linker.GetSymbol(Method.FullName);
+		foreach (var request in symbol.GetLinkRequests())
+			trace.Log($"{request.PatchOffset:x8} -> [{request.LinkType}] +{request.ReferenceOffset:x} [{request.ReferenceSymbol.SectionKind}] {request.ReferenceSymbol.Name}");
+	}
+}

--- a/Source/Mosa.Tool.Explorer.Avalonia/Stages/DominanceOutputStage.cs
+++ b/Source/Mosa.Tool.Explorer.Avalonia/Stages/DominanceOutputStage.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using System.Text;
+using Mosa.Compiler.Framework;
+using Mosa.Compiler.Framework.Analysis;
+
+namespace Mosa.Tool.Explorer.Avalonia.Stages;
+
+public class DominanceOutputStage : BaseMethodCompilerStage
+{
+	private const int TraceLevel = 5;
+
+	protected override void Run()
+	{
+		if (!IsTraceable(TraceLevel))
+			return;
+
+		OutputList();
+		OutputDiagram();
+		OutputDominanceBlock();
+	}
+
+	private void OutputList()
+	{
+		var trace = CreateTraceLog("List");
+		var sb = new StringBuilder();
+
+		foreach (var headBlock in BasicBlocks.HeadBlocks)
+		{
+			trace.Log($"Head: {headBlock}");
+
+			var dominance = new SimpleFastDominance(BasicBlocks, headBlock);
+			foreach (var block in BasicBlocks)
+			{
+				sb.Clear();
+				sb.Append($"  Block {block} : ");
+
+				var children = dominance.GetChildren(block);
+				if (children != null && children.Count != 0)
+				{
+					foreach (var child in children)
+					{
+						sb.Append(child);
+						sb.Append(", ");
+					}
+
+					sb.Length -= 2;
+				}
+
+				trace.Log(sb);
+			}
+
+			trace.Log();
+		}
+	}
+
+	private void OutputDiagram()
+	{
+		var trace = CreateTraceLog("Diagram");
+		trace.Log("digraph blocks {");
+
+		foreach (var headBlock in BasicBlocks.HeadBlocks)
+		{
+			var dominance = new SimpleFastDominance(BasicBlocks, headBlock);
+
+			foreach (var block in BasicBlocks)
+			{
+				var children = dominance.GetChildren(block);
+				if (children == null || children.Count == 0)
+					continue;
+
+				foreach (var child in children)
+					trace.Log($"\t{block} -> {child}");
+			}
+		}
+
+		trace.Log("}");
+	}
+
+	private void OutputDominanceBlock()
+	{
+		var trace = CreateTraceLog("DominanceBlock");
+		var sb = new StringBuilder();
+
+		foreach (var headBlock in BasicBlocks.HeadBlocks)
+		{
+			trace.Log($"Head: {headBlock}");
+			var dominance = new SimpleFastDominance(BasicBlocks, headBlock);
+
+			for (var i = 0; i < BasicBlocks.Count; i++)
+			{
+				var block = BasicBlocks[i];
+
+				sb.Clear();
+				sb.Append($"  Block {block} : ");
+
+				var dom = dominance.GetImmediateDominator(block);
+
+				sb.Append((dom != null) ? dom.ToString() : string.Empty);
+
+				trace.Log(sb);
+			}
+
+			trace.Log();
+		}
+	}
+}

--- a/Source/Mosa.Tool.Explorer.Avalonia/Stages/GraphVizStage.cs
+++ b/Source/Mosa.Tool.Explorer.Avalonia/Stages/GraphVizStage.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using Mosa.Compiler.Framework;
+
+namespace Mosa.Tool.Explorer.Avalonia.Stages;
+
+public class GraphVizStage : BaseMethodCompilerStage
+{
+	private const int TraceLevel = 6;
+
+	protected override void Run()
+	{
+		if (!IsTraceable(TraceLevel))
+			return;
+
+		var trace = CreateTraceLog();
+		trace.Log("digraph blocks {");
+
+		foreach (var block in BasicBlocks)
+		{
+			// trace.Log($"\t{block}");
+
+			foreach (var next in block.NextBlocks)
+				trace.Log($"\t{block} -> {next}");
+		}
+
+		trace.Log("}");
+	}
+}

--- a/Source/Mosa.Tool.Explorer.Avalonia/TransformEntry.cs
+++ b/Source/Mosa.Tool.Explorer.Avalonia/TransformEntry.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+namespace Mosa.Tool.Explorer.Avalonia;
+
+public class TransformEntry
+{
+	public int ID { get; set; }
+
+	public string Name { get; set; }
+
+	public string Before { get; set; }
+
+	public string After { get; set; }
+
+	public string Block { get; set; }
+
+	public int Pass { get; set; }
+}

--- a/Source/Mosa.Tool.Explorer.Avalonia/TypeSystemTree.cs
+++ b/Source/Mosa.Tool.Explorer.Avalonia/TypeSystemTree.cs
@@ -1,0 +1,394 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using Avalonia.Controls;
+using Mosa.Compiler.Framework;
+using Mosa.Compiler.MosaTypeSystem;
+
+namespace Mosa.Tool.Explorer.Avalonia;
+
+public class TypeSystemTree
+{
+	public TreeView TreeView { get; set; }
+	public readonly TypeSystem TypeSystem;
+	public readonly MosaTypeLayout TypeLayout;
+
+	private readonly bool showSizes;
+
+	private readonly Dictionary<object, TreeViewItem> map = new Dictionary<object, TreeViewItem>();
+	private readonly HashSet<object> contains = new HashSet<object>();
+	private readonly HashSet<MosaUnit> included;
+
+	public bool HasFilter => included != null && included.Count != 0;
+
+	public TypeSystemTree(TreeView treeView, TypeSystem typeSystem, MosaTypeLayout typeLayout, bool showSizesCheck = true, HashSet<MosaUnit> includedSet = null)
+	{
+		TreeView = treeView;
+
+		TypeSystem = typeSystem;
+		TypeLayout = typeLayout;
+		showSizes = showSizesCheck;
+		included = includedSet;
+
+		TreeView.Items.Clear();
+
+		CreateTreeBase();
+		CreateInitialTree();
+	}
+
+	public void Update()
+	{
+		foreach (var type in TypeSystem.AllTypes)
+		{
+			if (included != null && !included.Contains(type))
+				continue;
+
+			foreach (var method in type.Methods)
+				if (included == null || included.Contains(method))
+					GetOrCreateNode(method);
+		}
+	}
+
+	public void Update(MosaMethod method)
+	{
+		if (included == null || included.Contains(method))
+			GetOrCreateNode(method);
+	}
+
+	private void CreateTreeBase()
+	{
+		foreach (var module in TypeSystem.Modules)
+			if (included == null || included.Contains(module))
+				GetOrCreateNode(module);
+	}
+
+	private void CreateInitialTree()
+	{
+		var typeList = TypeSystem.AllTypes.OrderBy(o => o.FullName).ToList();
+
+		foreach (var type in typeList)
+			if (included == null || included.Contains(type))
+				GetOrCreateNode(type);
+	}
+
+	private void AddToTree(TreeViewItem node, TreeViewItem parent)
+	{
+		if (contains.Contains(node))
+			return;
+
+		if (parent == null)
+			TreeView.Items.Add(node);
+		else
+			parent.Items.Add(node);
+	}
+
+	private TreeViewItem GetOrCreateNode(MosaModule module)
+	{
+		if (map.TryGetValue(module, out TreeViewItem moduleNode))
+			return moduleNode;
+
+		moduleNode = new TreeViewItem { Header = module.Name, Tag = module };
+
+		map.Add(module, moduleNode);
+
+		AddToTree(moduleNode, null);
+
+		return moduleNode;
+	}
+
+	private TreeViewItem GetOrCreateNode(string name, MosaModule module)
+	{
+		name = (string.IsNullOrWhiteSpace(name)) ? "[No Namespace]" : name;
+
+		var index = module + ":" + name;
+
+		if (map.TryGetValue(index, out TreeViewItem namespaceNode))
+			return namespaceNode;
+
+		namespaceNode = new TreeViewItem { Header = name };
+
+		map.Add(index, namespaceNode);
+
+		var moduleNode = GetOrCreateNode(module);
+		AddToTree(namespaceNode, moduleNode);
+
+		return namespaceNode;
+	}
+
+	private TreeViewItem GetOrCreateNode(MosaType type)
+	{
+		if (map.TryGetValue(type, out TreeViewItem typeNode))
+			return typeNode;
+
+		typeNode = new TreeViewItem { Header = type.FullName, Tag = type };
+
+		map.Add(type, typeNode);
+
+		var namespaceNode = GetOrCreateNode(type.Namespace, type.Module);
+
+		AddToTree(typeNode, namespaceNode);
+
+		if (type.BaseType != null)
+		{
+			var baseTypeNode = new TreeViewItem { Header = $"Base Type: {type.BaseType.FullName}" };
+			typeNode.Items.Add(baseTypeNode);
+		}
+
+		if (type.DeclaringType != null)
+		{
+			var declaringTypeNode = new TreeViewItem { Header = $"Declaring Type: {type.DeclaringType.FullName}" };
+			typeNode.Items.Add(declaringTypeNode);
+		}
+
+		if (type.ElementType != null)
+		{
+			var elementTypeNode = new TreeViewItem { Header = $"Element Type: {type.ElementType.FullName}" };
+			typeNode.Items.Add(elementTypeNode);
+		}
+
+		if (type.Interfaces.Count != 0)
+		{
+			var interfacesNodes = new TreeViewItem { Header = "Interfaces" };
+			typeNode.Items.Add(interfacesNodes);
+
+			foreach (var interfaceType in type.Interfaces)
+			{
+				var interfaceNode = new TreeViewItem { Header = interfaceType.FullName };
+				interfacesNodes.Items.Add(interfaceNode);
+			}
+		}
+
+		if (type.Fields.Count != 0)
+		{
+			var fieldsNode = new TreeViewItem { Header = "Fields" };
+
+			if (showSizes && !type.HasOpenGenericParams)
+				fieldsNode.Header = fieldsNode.Header + " (Count: " + type.Fields.Count + " - Size: " + TypeLayout.GetTypeLayoutSize(type) + ")";
+
+			typeNode.Items.Add(fieldsNode);
+
+			foreach (var field in type.Fields)
+			{
+				var fieldNode = new TreeViewItem { Header = field.ShortName };
+				fieldsNode.Items.Add(fieldNode);
+
+				if (field.IsStatic)
+					fieldNode.Header += " [Static]";
+
+				if (!showSizes || field.HasOpenGenericParams)
+					continue;
+
+				fieldNode.Header = fieldNode.Header + " (Size: " + TypeLayout.GetFieldSize(field);
+
+				if (!field.IsStatic)
+					fieldNode.Header = fieldNode.Header + " - Offset: " + TypeLayout.GetFieldOffset(field);
+
+				fieldNode.Header += ")";
+			}
+		}
+
+		if (type.Properties.Count != 0)
+		{
+			var propertiesNode = new TreeViewItem { Header = "Properties" };
+
+			if (showSizes)
+				propertiesNode.Header = propertiesNode.Header + " (Count: " + type.Properties.Count + ")";
+
+			typeNode.Items.Add(propertiesNode);
+
+			foreach (var property in type.Properties)
+			{
+				if (included != null && !included.Contains(property))
+					continue;
+
+				var propertyNode = new TreeViewItem { Header = property.ShortName, Tag = property };
+				propertiesNode.Items.Add(propertyNode);
+
+				if (property.GetterMethod != null)
+				{
+					var getterNode = new TreeViewItem { Header = property.GetterMethod.ShortName, Tag = property.GetterMethod };
+
+					propertyNode.Items.Add(getterNode);
+
+					if (property.GetterMethod.IsStatic)
+						getterNode.Header += " [Static]";
+
+					if (property.GetterMethod.IsAbstract)
+						getterNode.Header += " [Abstract]";
+
+					if (property.GetterMethod.IsNewSlot)
+						getterNode.Header += " [NewSlot]";
+
+					if (property.GetterMethod.IsVirtual)
+						getterNode.Header += " [Virtual]";
+
+					if (property.GetterMethod.IsFinal)
+						getterNode.Header += " [Final]";
+
+					if (property.GetterMethod.IsSpecialName)
+						getterNode.Header += " [SpecialName]";
+
+					if (property.GetterMethod.IsRTSpecialName)
+						getterNode.Header += " [RTSpecialName]";
+
+					if (property.GetterMethod.GenericArguments.Count != 0)
+					{
+						var genericParameterNodes = new TreeViewItem { Header = "Generic Arguments Types" };
+						getterNode.Items.Add(genericParameterNodes);
+
+						foreach (var genericParameter in property.GetterMethod.GenericArguments)
+						{
+							var genericParameterNode = new TreeViewItem { Header = genericParameter.Name };
+							genericParameterNodes.Items.Add(genericParameterNode);
+						}
+					}
+				}
+
+				if (property.SetterMethod != null)
+				{
+					var setterNode = new TreeViewItem { Header = property.SetterMethod.ShortName, Tag = property.SetterMethod };
+					propertyNode.Items.Add(setterNode);
+
+					if (property.SetterMethod.IsStatic)
+						setterNode.Header += " [Static]";
+
+					if (property.SetterMethod.IsAbstract)
+						setterNode.Header += " [Abstract]";
+
+					if (property.SetterMethod.IsNewSlot)
+						setterNode.Header += " [NewSlot]";
+
+					if (property.SetterMethod.IsVirtual)
+						setterNode.Header += " [Virtual]";
+
+					if (property.SetterMethod.IsFinal)
+						setterNode.Header += " [Final]";
+
+					if (property.SetterMethod.IsSpecialName)
+						setterNode.Header += " [SpecialName]";
+
+					if (property.SetterMethod.IsRTSpecialName)
+						setterNode.Header += " [RTSpecialName]";
+
+					if (property.SetterMethod.GenericArguments.Count != 0)
+					{
+						var genericParameterNodes = new TreeViewItem { Header = "Generic Arguments Types" };
+						setterNode.Items.Add(genericParameterNodes);
+
+						foreach (var genericParameter in property.SetterMethod.GenericArguments)
+						{
+							var genericParameterNode = new TreeViewItem { Header = genericParameter.Name };
+							genericParameterNodes.Items.Add(genericParameterNode);
+						}
+					}
+				}
+			}
+		}
+
+		if (type.Methods.Count != 0)
+		{
+			typeNode.Items.Add(new TreeViewItem { Header = "Methods" });
+
+			var methodList = type.Methods.OrderBy(o => o.ShortName).ToList();
+
+			// Methods
+			foreach (var method in methodList)
+				if (included == null || included.Contains(method))
+					GetOrCreateNode(method);
+		}
+
+		//  Method Table
+		if (TypeLayout.GetMethodTable(type) != null)
+		{
+			var methodTableNode = new TreeViewItem { Header = "Method Table" };
+			typeNode.Items.Add(methodTableNode);
+
+			var methodList = TypeLayout.GetMethodTable(type).OrderBy(o => o.ShortName).ToList();
+
+			foreach (var method in methodList)
+			{
+				if (included == null || included.Contains(method))
+				{
+					var methodNode = new TreeViewItem { Header = method.ShortName, Tag = method };
+					methodTableNode.Items.Add(methodNode);
+				}
+			}
+		}
+
+		return typeNode;
+	}
+
+	private TreeViewItem GetOrCreateNode(MosaMethod method)
+	{
+		if (map.TryGetValue(method, out TreeViewItem methodNode))
+			return methodNode;
+
+		var type = method.DeclaringType;
+		if (type == null)
+			return null;
+
+		if (!map.TryGetValue(type, out TreeViewItem typeNode))
+			typeNode = GetOrCreateNode(type);
+
+		if (method.ShortName != null && (method.ShortName.StartsWith("set_") || method.ShortName.StartsWith("get_")))
+			return null;
+
+		// find "Methods" node
+		TreeViewItem methodsNode = null;
+
+		foreach (var node in typeNode.Items)
+		{
+			if ((string)((TreeViewItem)node).Header != "Methods")
+				continue;
+
+			methodsNode = (TreeViewItem)node;
+			break;
+		}
+
+		if (methodsNode == null)
+		{
+			methodsNode = new TreeViewItem { Header = "Methods" };
+			typeNode.Items.Add(methodsNode);
+		}
+
+		methodNode = new TreeViewItem { Header = method.ShortName, Tag = method };
+
+		map.Add(method, methodNode);
+
+		AddToTree(methodNode, methodsNode);
+
+		if (method.IsStatic)
+			methodNode.Header += " [Static]";
+
+		if (method.IsAbstract)
+			methodNode.Header += " [Abstract]";
+
+		if (method.IsNewSlot)
+			methodNode.Header += " [NewSlot]";
+
+		if (method.IsVirtual)
+			methodNode.Header += " [Virtual]";
+
+		if (method.IsFinal)
+			methodNode.Header += " [Final]";
+
+		if (method.IsSpecialName)
+			methodNode.Header += " [SpecialName]";
+
+		if (method.IsRTSpecialName)
+			methodNode.Header += " [RTSpecialName]";
+
+		if (method.GenericArguments.Count == 0)
+			return methodNode;
+
+		var genericParameterNodes = new TreeViewItem { Header = "Generic Arguments Types" };
+		methodNode.Items.Add(genericParameterNodes);
+
+		foreach (var genericParameter in method.GenericArguments)
+		{
+			var genericParameterNode = new TreeViewItem { Header = genericParameter.Name };
+			genericParameterNodes.Items.Add(genericParameterNode);
+		}
+
+		return methodNode;
+	}
+}

--- a/Source/Mosa.Tool.Explorer.Avalonia/Utils.cs
+++ b/Source/Mosa.Tool.Explorer.Avalonia/Utils.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+using Avalonia.Platform.Storage;
+
+namespace Mosa.Tool.Explorer.Avalonia;
+
+public static class Utils
+{
+	public static readonly FilePickerFileType LibraryFileType = new FilePickerFileType("Library")
+	{
+		Patterns = new List<string> { "*.dll" }
+	};
+
+	public static readonly FilePickerOpenOptions LibraryOpenOptions = new FilePickerOpenOptions
+	{
+		FileTypeFilter = new List<FilePickerFileType> { LibraryFileType }
+	};
+
+	public static readonly FolderPickerOpenOptions FolderOpenOptions = new FolderPickerOpenOptions();
+}

--- a/Source/Mosa.Tool.Explorer.Avalonia/app.manifest
+++ b/Source/Mosa.Tool.Explorer.Avalonia/app.manifest
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <!-- This manifest is used on Windows only.
+       Don't remove it as it might cause problems with window transparency and embedded controls.
+       For more details visit https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
+  <assemblyIdentity version="1.0.0.0" name="Mosa.Tool.Launcher.Avalonia.Desktop"/>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>

--- a/Source/Mosa.sln
+++ b/Source/Mosa.sln
@@ -252,6 +252,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Template", "Template", "{A1
 		TemplateLibrary.txt = TemplateLibrary.txt
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mosa.Tool.Explorer.Avalonia", "Mosa.Tool.Explorer.Avalonia\Mosa.Tool.Explorer.Avalonia.csproj", "{95FD51DF-AFE1-4762-89A7-91F99437E807}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1436,6 +1438,24 @@ Global
 		{26667157-E909-4F7A-9130-F8B5C15A1E4E}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{26667157-E909-4F7A-9130-F8B5C15A1E4E}.Release|x86.ActiveCfg = Release|Any CPU
 		{26667157-E909-4F7A-9130-F8B5C15A1E4E}.Release|x86.Build.0 = Release|Any CPU
+		{95FD51DF-AFE1-4762-89A7-91F99437E807}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{95FD51DF-AFE1-4762-89A7-91F99437E807}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{95FD51DF-AFE1-4762-89A7-91F99437E807}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{95FD51DF-AFE1-4762-89A7-91F99437E807}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{95FD51DF-AFE1-4762-89A7-91F99437E807}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{95FD51DF-AFE1-4762-89A7-91F99437E807}.Debug|x86.Build.0 = Debug|Any CPU
+		{95FD51DF-AFE1-4762-89A7-91F99437E807}.Description|Any CPU.ActiveCfg = Debug|Any CPU
+		{95FD51DF-AFE1-4762-89A7-91F99437E807}.Description|Any CPU.Build.0 = Debug|Any CPU
+		{95FD51DF-AFE1-4762-89A7-91F99437E807}.Description|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{95FD51DF-AFE1-4762-89A7-91F99437E807}.Description|Mixed Platforms.Build.0 = Debug|Any CPU
+		{95FD51DF-AFE1-4762-89A7-91F99437E807}.Description|x86.ActiveCfg = Debug|Any CPU
+		{95FD51DF-AFE1-4762-89A7-91F99437E807}.Description|x86.Build.0 = Debug|Any CPU
+		{95FD51DF-AFE1-4762-89A7-91F99437E807}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{95FD51DF-AFE1-4762-89A7-91F99437E807}.Release|Any CPU.Build.0 = Release|Any CPU
+		{95FD51DF-AFE1-4762-89A7-91F99437E807}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{95FD51DF-AFE1-4762-89A7-91F99437E807}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{95FD51DF-AFE1-4762-89A7-91F99437E807}.Release|x86.ActiveCfg = Release|Any CPU
+		{95FD51DF-AFE1-4762-89A7-91F99437E807}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1512,6 +1532,7 @@ Global
 		{E94607AB-584E-4D15-B0FA-68E086FE9E70} = {75BB6B40-C122-422F-8B40-F50A70A08E0D}
 		{26667157-E909-4F7A-9130-F8B5C15A1E4E} = {3A538FDC-0226-4971-A3C0-31570CDA340D}
 		{A1660856-2153-477F-BAAC-39E8BEB75971} = {F0EFF742-92D5-4219-939A-8F6F8DAB24E5}
+		{95FD51DF-AFE1-4762-89A7-91F99437E807} = {D032B24A-CE3A-4881-BACE-CC4FE0AFD69D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C22A5C94-6B05-4B1B-845A-A2EA7615E093}


### PR DESCRIPTION
This PR ports the Explorer tool to Avalonia. Currently, both the Windows Forms and the Avalonia versions coexist as the Avalonia version needs some more polish (most notably visual fixes, and the fact that it uses a pre-release version of Avalonia), but functionality is complete. Once it's been polished, the old tool will be removed and the `.Avalonia` suffix will be removed from the project.