### PR TITLE
Mosa.Utility.Launcher: Code style changes

### DIFF
--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -45,7 +45,6 @@ resharper_csharp_allow_comment_after_lbrace = true
 resharper_csharp_blank_lines_around_field = 0
 resharper_csharp_blank_lines_around_invocable = 0
 resharper_csharp_blank_lines_around_region = 0
-resharper_csharp_case_block_braces = next_line_shifted_2
 resharper_csharp_indent_statement_pars = outside
 resharper_csharp_max_line_length = 15750
 resharper_csharp_remove_blank_lines_near_braces_in_code = false

--- a/Source/Mosa.Utility.Launcher/BaseLauncher.cs
+++ b/Source/Mosa.Utility.Launcher/BaseLauncher.cs
@@ -30,24 +30,19 @@ public class BaseLauncher
 
 	protected void OutputStatus(string status)
 	{
-		if (string.IsNullOrEmpty(status)) return;
+		if (string.IsNullOrEmpty(status))
+			return;
 
 		OutputEvent(status);
 	}
 
-	protected virtual void OutputEvent(string status)
-	{
-		CompilerHooks.NotifyStatus?.Invoke(status);
-	}
+	protected virtual void OutputEvent(string status) => CompilerHooks.NotifyStatus?.Invoke(status);
 
-	protected static byte[] GetResource(string path, string name)
-	{
-		return GetResource($"{path
-			.Replace(".", "._")
-			.Replace(@"\", "._")
-			.Replace("/", "._")
-			.Replace("-", "_")}.{name}");
-	}
+	protected static byte[] GetResource(string path, string name) => GetResource($"{path
+		.Replace(".", "._")
+		.Replace(@"\", "._")
+		.Replace("/", "._")
+		.Replace("-", "_")}.{name}");
 
 	protected Process CreateApplicationProcess(string app, string args)
 	{

--- a/Source/Mosa.Utility.Launcher/Starter.cs
+++ b/Source/Mosa.Utility.Launcher/Starter.cs
@@ -22,15 +22,10 @@ public class Starter : BaseLauncher
 	private readonly object lockObject = new object();
 
 	public Starter(MosaSettings mosaSettings, CompilerHooks compilerHooks)
-		: base(mosaSettings, compilerHooks)
-	{
-	}
+		: base(mosaSettings, compilerHooks) {}
 
 	public Starter(MosaSettings mosaSettings, CompilerHooks compilerHooks, MosaLinker linker)
-		: base(mosaSettings, compilerHooks)
-	{
-		Linker = linker;
-	}
+		: base(mosaSettings, compilerHooks) => Linker = linker;
 
 	public bool Launch(bool waitForExit = false)
 	{
@@ -56,18 +51,9 @@ public class Starter : BaseLauncher
 			Process.Start();
 
 			if (MosaSettings.LaunchDebugger)
-			{
 				LaunchDebugger();
-			}
 			else if (MosaSettings.LaunchGDB)
-			{
 				LaunchGDB();
-			}
-
-			if (!MosaSettings.LauncherExit)
-			{
-				//Output(process.Output);
-			}
 
 			IsSuccessful = true;
 		}
@@ -96,7 +82,6 @@ public class Starter : BaseLauncher
 		var watchDog = new WatchDog(MosaSettings.EmulatorMaxRuntime * 1000);
 
 		client.OnStatusUpdate = OutputStatus;
-
 		client.OnDataAvailable = () =>
 		{
 			while (client.HasLine)
@@ -104,9 +89,7 @@ public class Starter : BaseLauncher
 				var line = client.GetLine();
 
 				lock (lockObject)
-				{
 					OutputStatus(line);
-				}
 
 				if (line.Contains(successText))
 					success = true;
@@ -146,21 +129,14 @@ public class Starter : BaseLauncher
 		}
 
 		OutputStatus("========================");
-
 		if (kill)
 			OutputStatus("Kill command received");
 
 		OutputStatus($"VM Exit Code: {process.ExitCode}");
-
-		if (success)
-			OutputStatus("Test Result: PASSED");
-		else
-			OutputStatus("Test Result: FAILED");
+		OutputStatus(success ? "Test Result: PASSED" : "Test Result: FAILED");
 
 		if (MosaSettings.LauncherExit)
-		{
 			Environment.Exit(success ? 0 : 1);
-		}
 
 		return success;
 	}
@@ -174,7 +150,6 @@ public class Starter : BaseLauncher
 		var watchDog = new WatchDog(MosaSettings.EmulatorMaxRuntime * 1000);
 
 		client.OnStatusUpdate = OutputStatus;
-
 		client.OnDataAvailable = () =>
 		{
 			while (client.HasLine)
@@ -182,9 +157,7 @@ public class Starter : BaseLauncher
 				var line = client.GetLine();
 
 				lock (lockObject)
-				{
 					OutputStatus(line);
-				}
 
 				if (line == "##KILL##")
 					kill = true;
@@ -221,16 +194,13 @@ public class Starter : BaseLauncher
 		}
 
 		OutputStatus("========================");
-
 		if (kill)
 			OutputStatus("Kill command received");
 
 		OutputStatus($"VM Exit Code: {process.ExitCode}");
 
 		if (MosaSettings.LauncherExit)
-		{
 			Environment.Exit(0);
-		}
 
 		return success;
 	}
@@ -274,33 +244,33 @@ public class Starter : BaseLauncher
 		switch (MosaSettings.Platform.ToLowerInvariant())
 		{
 			case "x86":
-				{
-					qemuApp = MosaSettings.QemuX86App;
-					qemuUefi = MosaSettings.QemuEdk2X86;
-					sb.Append(" -cpu qemu32,+sse4.1,abm,bmi1,bmi2,popcnt");
-					break;
-				}
+			{
+				qemuApp = MosaSettings.QemuX86App;
+				qemuUefi = MosaSettings.QemuEdk2X86;
+				sb.Append(" -cpu qemu32,+sse4.1,abm,bmi1,bmi2,popcnt");
+				break;
+			}
 			case "x64":
-				{
-					qemuApp = MosaSettings.QemuX64App;
-					qemuUefi = MosaSettings.QemuEdk2X64;
-					sb.Append(" -cpu qemu64,+sse4.1,abm,bmi1,bmi2,popcnt");
-					break;
-				}
+			{
+				qemuApp = MosaSettings.QemuX64App;
+				qemuUefi = MosaSettings.QemuEdk2X64;
+				sb.Append(" -cpu qemu64,+sse4.1,abm,bmi1,bmi2,popcnt");
+				break;
+			}
 			case "arm32":
-				{
-					qemuApp = MosaSettings.QemuARM32App;
-					qemuUefi = MosaSettings.QemuEdk2ARM32;
-					sb.Append(" -cpu arm1176");
-					break;
-				}
+			{
+				qemuApp = MosaSettings.QemuARM32App;
+				qemuUefi = MosaSettings.QemuEdk2ARM32;
+				sb.Append(" -cpu arm1176");
+				break;
+			}
 			case "arm64":
-				{
-					qemuApp = MosaSettings.QemuARM64App;
-					qemuUefi = MosaSettings.QemuEdk2ARM64;
-					sb.Append(" -cpu cortex-a7");
-					break;
-				}
+			{
+				qemuApp = MosaSettings.QemuARM64App;
+				qemuUefi = MosaSettings.QemuEdk2ARM64;
+				sb.Append(" -cpu cortex-a7");
+				break;
+			}
 			default: throw new CompilerException($"Unknown platform: {MosaSettings.Platform}");
 		}
 
@@ -313,50 +283,47 @@ public class Starter : BaseLauncher
 		}
 
 		if (!MosaSettings.EmulatorDisplay || MosaSettings.LauncherTest)
-		{
 			sb.Append(" -display none");
-		}
 		else
-		{
 			sb.Append(RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? " -display cocoa" : " -display sdl");
-		}
 
 		var serial = MosaSettings.EmulatorSerial;
 
-		if (MosaSettings.LauncherSerial || MosaSettings.LauncherTest) serial = "tcpserver";
+		if (MosaSettings.LauncherSerial || MosaSettings.LauncherTest)
+			serial = "tcpserver";
 
 		switch (serial)
 		{
 			case "pipe":
-				{
-					sb.Append(" -serial pipe:\"");
-					sb.Append(MosaSettings.EmulatorSerialPipe);
-					sb.Append('"');
-					break;
-				}
+			{
+				sb.Append(" -serial pipe:\"");
+				sb.Append(MosaSettings.EmulatorSerialPipe);
+				sb.Append('"');
+				break;
+			}
 			case "tcpserver":
-				{
-					sb.Append(" -serial tcp:");
-					sb.Append(MosaSettings.EmulatorSerialHost);
-					sb.Append(':');
-					sb.Append(MosaSettings.EmulatorSerialPort);
-					sb.Append(",server,nowait");
-					break;
-				}
+			{
+				sb.Append(" -serial tcp:");
+				sb.Append(MosaSettings.EmulatorSerialHost);
+				sb.Append(':');
+				sb.Append(MosaSettings.EmulatorSerialPort);
+				sb.Append(",server,nowait");
+				break;
+			}
 			case "tcpclient":
-				{
-					sb.Append(" -serial tcp:");
-					sb.Append(MosaSettings.EmulatorSerialHost);
-					sb.Append(':');
-					sb.Append(MosaSettings.EmulatorSerialPort);
-					sb.Append(",client,nowait");
-					break;
-				}
+			{
+				sb.Append(" -serial tcp:");
+				sb.Append(MosaSettings.EmulatorSerialHost);
+				sb.Append(':');
+				sb.Append(MosaSettings.EmulatorSerialPort);
+				sb.Append(",client,nowait");
+				break;
+			}
 			default:
-				{
-					sb.Append(" -serial null");
-					break;
-				}
+			{
+				sb.Append(" -serial null");
+				break;
+			}
 		}
 
 		if (MosaSettings.EmulatorGDB)
@@ -368,37 +335,37 @@ public class Starter : BaseLauncher
 		switch (MosaSettings.ImageFormat)
 		{
 			case "bin":
-				{
-					sb.Append(" -kernel \"");
-					sb.Append(MosaSettings.ImageFile);
-					sb.Append('"');
-					break;
-				}
+			{
+				sb.Append(" -kernel \"");
+				sb.Append(MosaSettings.ImageFile);
+				sb.Append('"');
+				break;
+			}
 			default:
-				{
-					sb.Append(" -drive format=raw,file=\"");
-					sb.Append(MosaSettings.ImageFile);
-					sb.Append('"');
-					break;
-				}
+			{
+				sb.Append(" -drive format=raw,file=\"");
+				sb.Append(MosaSettings.ImageFile);
+				sb.Append('"');
+				break;
+			}
 		}
 
 		switch (MosaSettings.ImageFirmware)
 		{
 			case "bios":
-				{
-					sb.Append(" -L \"");
-					sb.Append(MosaSettings.QemuBIOS);
-					sb.Append('"');
-					break;
-				}
+			{
+				sb.Append(" -L \"");
+				sb.Append(MosaSettings.QemuBIOS);
+				sb.Append('"');
+				break;
+			}
 			case "uefi":
-				{
-					sb.Append(" -drive if=pflash,format=raw,readonly=on,file=\"");
-					sb.Append(qemuUefi);
-					sb.Append('"');
-					break;
-				}
+			{
+				sb.Append(" -drive if=pflash,format=raw,readonly=on,file=\"");
+				sb.Append(qemuUefi);
+				sb.Append('"');
+				break;
+			}
 		}
 
 		return CreateApplicationProcess(qemuApp, sb.ToString());
@@ -448,28 +415,28 @@ public class Starter : BaseLauncher
 		switch (MosaSettings.EmulatorSerial)
 		{
 			case "pipe":
-				{
-					sb.Append("com1: enabled=1, mode=pipe-server, dev=\"\\\\.\\pipe\\");
-					sb.Append(MosaSettings.EmulatorSerialPipe);
-					sb.AppendLine("\"");
-					break;
-				}
+			{
+				sb.Append("com1: enabled=1, mode=pipe-server, dev=\"\\\\.\\pipe\\");
+				sb.Append(MosaSettings.EmulatorSerialPipe);
+				sb.AppendLine("\"");
+				break;
+			}
 			case "tcpserver":
-				{
-					sb.Append("com1: enabled=1, mode=socket-server, dev=");
-					sb.Append(MosaSettings.EmulatorSerialHost);
-					sb.Append(':');
-					sb.AppendLine(MosaSettings.EmulatorSerialPort.ToString());
-					break;
-				}
+			{
+				sb.Append("com1: enabled=1, mode=socket-server, dev=");
+				sb.Append(MosaSettings.EmulatorSerialHost);
+				sb.Append(':');
+				sb.AppendLine(MosaSettings.EmulatorSerialPort.ToString());
+				break;
+			}
 			case "tcpclient":
-				{
-					sb.Append("com1: enabled=1, mode=socket-client, dev=");
-					sb.Append(MosaSettings.EmulatorSerialHost);
-					sb.Append(':');
-					sb.AppendLine(MosaSettings.EmulatorSerialPort.ToString());
-					break;
-				}
+			{
+				sb.Append("com1: enabled=1, mode=socket-client, dev=");
+				sb.Append(MosaSettings.EmulatorSerialHost);
+				sb.Append(':');
+				sb.AppendLine(MosaSettings.EmulatorSerialPort.ToString());
+				break;
+			}
 		}
 
 		if (MosaSettings.EmulatorGDB)
@@ -552,9 +519,7 @@ public class Starter : BaseLauncher
 		var args = $"\"{configFile}\" -x -q";
 
 		if (!string.IsNullOrWhiteSpace(MosaSettings.VmwareWorkstationApp))
-		{
 			return CreateApplicationProcess(MosaSettings.VmwareWorkstationApp, args);
-		}
 
 		return !string.IsNullOrWhiteSpace(MosaSettings.VmwarePlayerApp)
 			? CreateApplicationProcess(MosaSettings.VmwarePlayerApp, args)
@@ -569,7 +534,7 @@ public class Starter : BaseLauncher
 		{
 			var newFile = Path.ChangeExtension(MosaSettings.ImageFile, "bak");
 
-			// Janky method to keep the image file
+			// Janky way of keeping the image file
 			File.Move(MosaSettings.ImageFile, newFile);
 
 			// Delete the VM first


### PR DESCRIPTION
Hello! This PR makes code style changes throughout the Mosa.Utility.Launcher project in order to improve consistency with other projects. The following changes were done:

- The space shift when putting braces after a `case` statement has now been removed as a ReSharper rule
- Code after a statement (like `if`) was put on a separate line if not already the case
- Method bodies were transformed into expression bodies whenever possible
- Null-coalescing operators were used whenever possible
- Braces around statements were removed if the containing block had only 1 line of code
- Commented code was removed
- Variables whose name didn't give any more useful insight into what it is were inlined (e.g. `var arg = "convert -f raw [...]";`)
- Strings that were too long (like in `Builder.GetLimineCFG()`) were transformed into multi-line strings
- Using blocks were transformed into using statements whenever possible
- If statements were transformed into 1 switch statement whenever it made sense (when there are more than 2 if statements)
- Private fields were moved after public fields
- Patterns were used in comparisons whenever possible
- Ternary operators were used whenever it made sense for cleaner code