### PR TITLE
Improve Reko disassembly speed

### DIFF
--- a/Source/Mosa.Tool.Debugger/Views/InstructionView.cs
+++ b/Source/Mosa.Tool.Debugger/Views/InstructionView.cs
@@ -57,19 +57,20 @@ public partial class InstructionView : DebugDockContent
 	{
 		instructions.Clear();
 
-		var disassembler = new Disassembler("x86");
-		disassembler.SetMemory(memory, address);
+		var disassembler = new Disassembler("x86", memory, address);
+		var instruction = disassembler.DecodeNext();
 
-		foreach (var instruction in disassembler.Decode())
+		while (instruction != null)
 		{
 			var entry = new InstructionEntry()
 			{
 				IP = instruction.Address,
-				Length = instruction.Length,
+				Length = (int)instruction.Length,
 				Instruction = instruction.Instruction.ToString()
 			};
 
 			instructions.Add(entry);
+			instruction = disassembler.DecodeNext();
 		}
 	}
 

--- a/Source/Mosa.Tool.Debugger/Views/MethodView.cs
+++ b/Source/Mosa.Tool.Debugger/Views/MethodView.cs
@@ -160,7 +160,7 @@ public partial class MethodView : DebugDockContent
 			var entry = new MethodInstructionEntry()
 			{
 				IP = instruction.Address,   // Offset?
-				Length = instruction.Length,
+				Length = (int)instruction.Length,
 				Instruction = instruction.Instruction,
 				Info = info
 			};

--- a/Source/Mosa.Tool.Debugger/Views/MethodView.cs
+++ b/Source/Mosa.Tool.Debugger/Views/MethodView.cs
@@ -148,10 +148,10 @@ public partial class MethodView : DebugDockContent
 	{
 		instructions.Clear();
 
-		var disassembler = new Disassembler("x86");
-		disassembler.SetMemory(memory, address);
+		var disassembler = new Disassembler("x86", memory, address);
+		var instruction = disassembler.DecodeNext();
 
-		foreach (var instruction in disassembler.Decode())
+		while (instruction != null)
 		{
 			var addr = MainForm.ParseAddress(instruction.Instruction);
 
@@ -166,6 +166,7 @@ public partial class MethodView : DebugDockContent
 			};
 
 			instructions.Add(entry);
+			instruction = disassembler.DecodeNext();
 		}
 	}
 

--- a/Source/Mosa.Tool.Debugger/Views/StatusView.cs
+++ b/Source/Mosa.Tool.Debugger/Views/StatusView.cs
@@ -44,15 +44,15 @@ public partial class StatusView : DebugDockContent
 		if (address != InstructionPointer)
 			return;
 
-		var disassembler = new Disassembler("x86");
-		disassembler.SetMemory(memory, address);
+		var disassembler = new Disassembler("x86", memory, address);
 
 		tbInstruction.Text = "Unable to decode!";
 
-		foreach (var instruction in disassembler.Decode())
+		var instruction = disassembler.DecodeNext();
+		while (instruction != null)
 		{
 			tbInstruction.Text = instruction.Instruction;
-			break;
+			instruction = disassembler.DecodeNext();
 		}
 	}
 }

--- a/Source/Mosa.Tool.Debugger/Views/TraceView.cs
+++ b/Source/Mosa.Tool.Debugger/Views/TraceView.cs
@@ -68,13 +68,13 @@ public partial class TraceView : DebugDockContent
 
 		if (address == InstructionPointer)
 		{
-			var disassembler = new Disassembler("x86");
-			disassembler.SetMemory(memory, address);
+			var disassembler = new Disassembler("x86", memory, address);
+			var instruction = disassembler.DecodeNext();
 
-			foreach (var instruction in disassembler.Decode())
+			while (instruction != null)
 			{
 				opinstruction = instruction.Instruction;
-				break;
+				instruction = disassembler.DecodeNext();
 			}
 		}
 

--- a/Source/Mosa.Tool.Explorer.Avalonia/Stages/DisassemblyStage.cs
+++ b/Source/Mosa.Tool.Explorer.Avalonia/Stages/DisassemblyStage.cs
@@ -33,19 +33,13 @@ public class DisassemblyStage : BaseMethodCompilerStage
 		stream.Read(memory, 0, length);
 		stream.Position = oldPosition;
 
-		var disassembler = new Disassembler(Architecture.PlatformName);
-		disassembler.SetMemory(memory, 0);
+		var disassembler = new Disassembler(Architecture.PlatformName, memory, 0);
+		var instruction = disassembler.DecodeNext();
 
-		var list = disassembler.Decode();
-
-		if (list != null)
+		while (instruction != null)
 		{
-			foreach (var instr in list)
-				trace.Log(instr.Full);
-		}
-		else
-		{
-			PostEvent(CompilerEvent.Error, $"Failed disassembly for method {MethodCompiler.Method}");
+			trace.Log(instruction.Full);
+			instruction = disassembler.DecodeNext();
 		}
 	}
 

--- a/Source/Mosa.Tool.Explorer/Stages/DisassemblyStage.cs
+++ b/Source/Mosa.Tool.Explorer/Stages/DisassemblyStage.cs
@@ -34,21 +34,13 @@ public class DisassemblyStage : BaseMethodCompilerStage
 		stream.Read(memory, 0, length);
 		stream.Position = oldPosition;
 
-		var disassembler = new Disassembler(Architecture.PlatformName);
-		disassembler.SetMemory(memory, 0);
+		var disassembler = new Disassembler(Architecture.PlatformName, memory, 0);
+		var instruction = disassembler.DecodeNext();
 
-		var list = disassembler.Decode();
-
-		if (list != null)
+		while (instruction != null)
 		{
-			foreach (var instr in list)
-			{
-				trace.Log(instr.Full);
-			}
-		}
-		else
-		{
-			PostEvent(CompilerEvent.Error, $"Failed disassembly for method {MethodCompiler.Method}");
+			trace.Log(instruction.Full);
+			instruction = disassembler.DecodeNext();
 		}
 	}
 

--- a/Source/Mosa.Utility.Disassembler/DecodedInstruction.cs
+++ b/Source/Mosa.Utility.Disassembler/DecodedInstruction.cs
@@ -2,13 +2,13 @@
 
 namespace Mosa.Utility.Disassembler;
 
-public partial class DecodedInstruction
+public class DecodedInstruction
 {
-	public ulong Address { get; set; }
+	public ulong Address { get; init; }
 
-	public int Length { get; set; }
+	public uint Length { get; init; }
 
-	public string Instruction { get; set; }
+	public string Instruction { get; init; }
 
-	public string Full { get; set; }
+	public string Full { get; init; }
 }

--- a/Source/Mosa.Utility.Disassembler/Disassembler.cs
+++ b/Source/Mosa.Utility.Disassembler/Disassembler.cs
@@ -50,23 +50,20 @@ public class Disassembler
 		var address = machineInstruction.Address.Offset;
 		var instruction = machineInstruction.ToString()
 			.Replace('\t', ' ')
-			.Replace(",", ", ")
-			.Replace("+", " + ")
-			.Replace("-", " - ")
-			.Replace("*", " * ");
+			.Replace(",", ", ");
 
 		// FIXME
 		//instruction = ChangeHex(instruction);
 
-		sb.Append(address.ToString("X8"));
+		sb.Append(address.ToString("x8"));
 		sb.Append(' ');
 		for (var i = 0U; i < length; i++)
 		{
 			var b = memory[i + Offset];
-			sb.Append(b.ToString("X2"));
+			sb.Append(b.ToString("x2"));
 			sb.Append(' ');
 		}
-		for (var i = 0; i < 41 - sb.Length; i++)
+		for (var i = sb.Length; i < 41; i++)
 			sb.Append(' ');
 		sb.Append(instruction);
 

--- a/Source/Mosa.Utility.Launcher/Builder.cs
+++ b/Source/Mosa.Utility.Launcher/Builder.cs
@@ -241,12 +241,12 @@ public class Builder : BaseLauncher
 		for (ulong i = fileOffset; i < (ulong)code2.Length; i++)
 			code[i - fileOffset] = code2[i];
 
-		var disassembler = new Disassembler.Disassembler(MosaSettings.Platform);
-		disassembler.SetMemory(code, startingAddress);
+		var disassembler = new Disassembler.Disassembler(MosaSettings.Platform, code, startingAddress);
 
 		using var dest = File.CreateText(MosaSettings.AsmFile);
 
-		foreach (var instruction in disassembler.Decode())
+		var instruction = disassembler.DecodeNext();
+		while (instruction != null)
 		{
 			if (map.TryGetValue(instruction.Address, out List<string> list))
 				foreach (var entry in list)
@@ -256,6 +256,8 @@ public class Builder : BaseLauncher
 
 			if (instruction.Address > startingAddress + length)
 				break;
+
+			instruction = disassembler.DecodeNext();
 		}
 	}
 


### PR DESCRIPTION
This PR drastically improves the disassembly speed when using Reko (a.k.a. the `-output-asm` CLI argument). The main problem was that the MOSA `Disassembler` class would:
- Read every disassembled instruction from the list created by the Reko library
- Create a whole new list with a few modifications in the string representation
- Read every instruction from that newly created list, the most common scenario being to write them into a file

This is indeed much slower, so this PR fixes it by simply having a `DecodeNext()` method in the `Disassembler` class, which makes it act like an enumerator.