### PR TITLE
Improve template & fix settings bug

### DIFF
--- a/Source/Mosa.Templates/templates/.template.config/dotnetcli.host.json
+++ b/Source/Mosa.Templates/templates/.template.config/dotnetcli.host.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "http://json.schemastore.org/dotnetcli.host",
+	"symbolInfo": {
+		"BundleQemuWindows": {
+			"longName": "bundle-qemu-windows"
+		}
+	},
+	"usageExamples": [
+		""
+	]
+}

--- a/Source/Mosa.Templates/templates/.template.config/ide.host.json
+++ b/Source/Mosa.Templates/templates/.template.config/ide.host.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "http://json.schemastore.org/ide.host",
+	"symbolInfo": [
+		{
+			"id": "BundleQemuWindows",
+			"name": {
+				"text": "Bundle QEMU for Windows"
+			},
+			"isVisible": true
+		}
+	]
+}

--- a/Source/Mosa.Templates/templates/.template.config/template.json
+++ b/Source/Mosa.Templates/templates/.template.config/template.json
@@ -4,11 +4,21 @@
 	"classifications": [ "Common", "OS", "Kernel" ],
 	"identity": "Mosa.Starter",
 	"sourceName": "Mosa.Starter",
+	"defaultName": "MosaKernel",
 	"name": "MOSA Kernel",
 	"shortName": "mosakrnl",
 	"preferNameDirectory": true,
 	"tags": {
 		"language": "C#",
 		"type": "solution"
+	},
+	"symbols": {
+		"BundleQemuWindows": {
+			"type": "parameter",
+			"description": "Defines if QEMU for Windows should be bundled by default in the project.",
+			"datatype": "bool",
+			"displayName": "Bundle QEMU for Windows",
+			"defaultValue": "true"
+		}
 	}
 }

--- a/Source/Mosa.Templates/templates/Mosa.Starter/Mosa.Starter.csproj
+++ b/Source/Mosa.Templates/templates/Mosa.Starter/Mosa.Starter.csproj
@@ -16,7 +16,11 @@
 	<ItemGroup>
 		<PackageReference Include="Mosa.Platform" Version="*" />
 		<PackageReference Include="Mosa.DeviceSystem" Version="*" />
+		<!--#if (BundleQemuWindows) -->
 		<PackageReference Include="Mosa.Tools.Package.Qemu" Version="*" />
+		<!--#else -->
+		<PackageReference Include="Mosa.Tools.Package" Version="*" />
+		<!--#endif -->
 	</ItemGroup>
 
 </Project>

--- a/Source/Mosa.Tool.Bootstrap/Mosa.Tool.Bootstrap.csproj
+++ b/Source/Mosa.Tool.Bootstrap/Mosa.Tool.Bootstrap.csproj
@@ -8,9 +8,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia.Desktop" Version="11.0.10" />
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.10" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.10" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.1.3" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.3" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.3" />
 	</ItemGroup>
 
 </Project>

--- a/Source/Mosa.Tool.Explorer.Avalonia/Mosa.Tool.Explorer.Avalonia.csproj
+++ b/Source/Mosa.Tool.Explorer.Avalonia/Mosa.Tool.Explorer.Avalonia.csproj
@@ -19,10 +19,9 @@
 	</ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.1.0-beta2" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.1.0-beta2" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.0-beta2" />
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.0-beta2" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.1.3" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.3" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.3" />
     </ItemGroup>
 
 </Project>

--- a/Source/Mosa.Tool.Launcher/Mosa.Tool.Launcher.csproj
+++ b/Source/Mosa.Tool.Launcher/Mosa.Tool.Launcher.csproj
@@ -13,9 +13,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia.Desktop" Version="11.0.10" />
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.10" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.10" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.1.3" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.3" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.3" />
 	</ItemGroup>
 
 </Project>

--- a/Source/Mosa.Utility.Configuration/MOSASettings.cs
+++ b/Source/Mosa.Utility.Configuration/MOSASettings.cs
@@ -1039,9 +1039,9 @@ public partial class MosaSettings
 			try
 			{
 				return (string)Registry.CurrentUser
-						.OpenSubKey(WindowsRegistry.Software)
-						.OpenSubKey(WindowsRegistry.MosaApp)
-						.GetValue(name, defaultValue);
+						.OpenSubKey(WindowsRegistry.Software)?
+						.OpenSubKey(WindowsRegistry.MosaApp)?
+						.GetValue(name, defaultValue) ?? defaultValue;
 			}
 			catch
 			{


### PR DESCRIPTION
- Updated Avalonia to 11.1.3
- Fixed a settings bug using the Windows registry where the application would crash if the setting wasn't found
- Added a new "Bundle QEMU for Windows" option in the template, which uses Mosa.Tools.Package.Qemu instead of Mosa.Tools.Package