### PR TITLE
Mosa.TinyCoreLib: Implement small classes

### DIFF
--- a/Source/Mosa.TinyCoreLib/Internal/Impl.cs
+++ b/Source/Mosa.TinyCoreLib/Internal/Impl.cs
@@ -1,0 +1,85 @@
+// Copyright (c) MOSA Project. Licensed under the New BSD License.
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Internal;
+
+internal static class Impl
+{
+	public static class Debug
+	{
+		public const string NoMessage = "No message";
+		public const string NoDetails = "No details";
+		public const string NoCategory = "No category";
+		public const string NoValue = "No value";
+		public const string FailText = "{0}\nDetails: {1}"; // {0} = Message, {1} = Details
+		public const string WriteText = "DEBUG ({0}): {1}"; // {0} = Category, {1} = Value/Message
+	}
+
+	public static class ConstructorInfo
+	{
+		public const string ConstructorName = ".ctor";
+		public const string TypeConstructorName = ".cctor";
+	}
+
+	public static class RuntimeHelpers
+	{
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		public static extern void InitializeArray(Array array, RuntimeFieldHandle fldHandle);
+
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		public static extern int GetHashCode(object o);
+
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		public new static extern bool Equals(object o1, object o2);
+
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		public static extern T UnsafeCast<T>(object o) where T : class;
+
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		public static extern IEnumerable<Assembly> GetAssemblies();
+
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		public static extern object CreateInstance(Type type, params object[] args);
+
+		// The body of this function will be replaced by the EE with unsafe code
+		// See getILIntrinsicImplementation for how this happens.
+		[Intrinsic]
+		public static bool EnumEquals<T>(T x, T y) where T : Enum => x.Equals(y);
+
+		[Intrinsic]
+		public static bool IsReferenceOrContainsReferences<T>() => throw new InvalidOperationException();
+	}
+
+	public static class Bmi1
+	{
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		public static extern uint ResetLowestSetBit(uint value);
+
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		public static extern uint TrailingZeroCount(uint value);
+	}
+
+	public static class Lzcnt
+	{
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		public static extern uint LeadingZeroCount(uint value);
+	}
+
+	public static class Popcnt
+	{
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		public static extern uint PopCount(uint value);
+	}
+
+	public static class Object
+	{
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		public static extern Type GetType(object obj);
+
+		[MethodImpl(MethodImplOptions.InternalCall)]
+		public static extern Type MemberwiseClone(object obj);
+	}
+}

--- a/Source/Mosa.TinyCoreLib/Internal/IntrinsicAttribute.cs
+++ b/Source/Mosa.TinyCoreLib/Internal/IntrinsicAttribute.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) MOSA Project. Licensed under the New BSD License.
+
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Reserved by the compiler for tracking intrinsics.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Field, Inherited = false)]
+internal sealed class IntrinsicAttribute : Attribute;

--- a/Source/Mosa.TinyCoreLib/System.Buffers/MemoryHandle.cs
+++ b/Source/Mosa.TinyCoreLib/System.Buffers/MemoryHandle.cs
@@ -4,26 +4,33 @@ namespace System.Buffers;
 
 public struct MemoryHandle : IDisposable
 {
-	private object _dummy;
+	private unsafe void* pointer;
+	private GCHandle handle;
+	private IPinnable? pinnable;
 
-	private int _dummyPrimitive;
-
-	[CLSCompliant(false)]
-	public unsafe void* Pointer
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	[CLSCompliant(false)] public unsafe void* Pointer => pointer;
 
 	[CLSCompliant(false)]
-	public unsafe MemoryHandle(void* pointer, GCHandle handle = default(GCHandle), IPinnable? pinnable = null)
+	public unsafe MemoryHandle(void* pointer, GCHandle handle = default, IPinnable? pinnable = null)
 	{
-		throw null;
+		this.pointer = pointer;
+		this.handle = handle;
+		this.pinnable = pinnable;
 	}
 
 	public void Dispose()
 	{
+		handle.Free();
+		
+		if (pinnable != null)
+		{
+			pinnable.Unpin();
+			pinnable = null;
+		}
+
+		unsafe
+		{
+			pointer = null;
+		}
 	}
 }

--- a/Source/Mosa.TinyCoreLib/System.Diagnostics/Debug.cs
+++ b/Source/Mosa.TinyCoreLib/System.Diagnostics/Debug.cs
@@ -10,324 +10,240 @@ public static class Debug
 	[InterpolatedStringHandler]
 	public struct AssertInterpolatedStringHandler
 	{
-		private object _dummy;
-
-		private int _dummyPrimitive;
-
 		public AssertInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, out bool shouldAppend)
-		{
-			throw null;
-		}
+			=> throw new NotImplementedException();
 
 		public void AppendFormatted(object? value, int alignment = 0, string? format = null)
-		{
-		}
+			=> throw new NotImplementedException();
 
-		public void AppendFormatted(ReadOnlySpan<char> value)
-		{
-		}
+		public void AppendFormatted(ReadOnlySpan<char> value) => throw new NotImplementedException();
 
 		public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null)
-		{
-		}
+			=> throw new NotImplementedException();
 
-		public void AppendFormatted(string? value)
-		{
-		}
+		public void AppendFormatted(string? value) => throw new NotImplementedException();
 
 		public void AppendFormatted(string? value, int alignment = 0, string? format = null)
-		{
-		}
+			=> throw new NotImplementedException();
 
-		public void AppendFormatted<T>(T value)
-		{
-		}
+		public void AppendFormatted<T>(T value) => throw new NotImplementedException();
 
-		public void AppendFormatted<T>(T value, int alignment)
-		{
-		}
+		public void AppendFormatted<T>(T value, int alignment) => throw new NotImplementedException();
 
-		public void AppendFormatted<T>(T value, int alignment, string? format)
-		{
-		}
+		public void AppendFormatted<T>(T value, int alignment, string? format) => throw new NotImplementedException();
 
-		public void AppendFormatted<T>(T value, string? format)
-		{
-		}
+		public void AppendFormatted<T>(T value, string? format) => throw new NotImplementedException();
 
-		public void AppendLiteral(string value)
-		{
-		}
+		public void AppendLiteral(string value) => throw new NotImplementedException();
 	}
 
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	[InterpolatedStringHandler]
 	public struct WriteIfInterpolatedStringHandler
 	{
-		private object _dummy;
-
-		private int _dummyPrimitive;
-
 		public WriteIfInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, out bool shouldAppend)
-		{
-			throw null;
-		}
+			=> throw new NotImplementedException();
 
 		public void AppendFormatted(object? value, int alignment = 0, string? format = null)
-		{
-		}
+			=> throw new NotImplementedException();
 
-		public void AppendFormatted(ReadOnlySpan<char> value)
-		{
-		}
+		public void AppendFormatted(ReadOnlySpan<char> value) => throw new NotImplementedException();
 
 		public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null)
-		{
-		}
+			=> throw new NotImplementedException();
 
-		public void AppendFormatted(string? value)
-		{
-		}
+		public void AppendFormatted(string? value) => throw new NotImplementedException();
 
 		public void AppendFormatted(string? value, int alignment = 0, string? format = null)
-		{
-		}
+			=> throw new NotImplementedException();
 
-		public void AppendFormatted<T>(T value)
-		{
-		}
+		public void AppendFormatted<T>(T value) => throw new NotImplementedException();
 
-		public void AppendFormatted<T>(T value, int alignment)
-		{
-		}
+		public void AppendFormatted<T>(T value, int alignment) => throw new NotImplementedException();
 
-		public void AppendFormatted<T>(T value, int alignment, string? format)
-		{
-		}
+		public void AppendFormatted<T>(T value, int alignment, string? format) => throw new NotImplementedException();
 
-		public void AppendFormatted<T>(T value, string? format)
-		{
-		}
+		public void AppendFormatted<T>(T value, string? format) => throw new NotImplementedException();
 
-		public void AppendLiteral(string value)
-		{
-		}
+		public void AppendLiteral(string value) => throw new NotImplementedException();
 	}
 
-	public static bool AutoFlush
-	{
-		get
-		{
-			throw null;
-		}
-		set
-		{
-		}
-	}
+	public static bool AutoFlush { get; set; }
 
-	public static int IndentLevel
-	{
-		get
-		{
-			throw null;
-		}
-		set
-		{
-		}
-	}
+	public static int IndentLevel { get; set; }
 
-	public static int IndentSize
-	{
-		get
-		{
-			throw null;
-		}
-		set
-		{
-		}
-	}
+	public static int IndentSize { get; set; } = 2;
 
-	public static DebugProvider SetProvider(DebugProvider provider)
-	{
-		throw null;
-	}
+	public static DebugProvider SetProvider(DebugProvider provider) => throw new NotImplementedException();
 
 	[Conditional("DEBUG")]
 	public static void Assert([DoesNotReturnIf(false)] bool condition)
-	{
-	}
+		=> Assert(condition, null, null);
 
 	[Conditional("DEBUG")]
 	public static void Assert([DoesNotReturnIf(false)] bool condition, [InterpolatedStringHandlerArgument("condition")] ref AssertInterpolatedStringHandler message)
-	{
-	}
+		=> throw new NotImplementedException();
 
 	[Conditional("DEBUG")]
 	public static void Assert([DoesNotReturnIf(false)] bool condition, [InterpolatedStringHandlerArgument("condition")] ref AssertInterpolatedStringHandler message, [InterpolatedStringHandlerArgument("condition")] ref AssertInterpolatedStringHandler detailMessage)
-	{
-	}
+		=> throw new NotImplementedException();
 
 	[Conditional("DEBUG")]
 	public static void Assert([DoesNotReturnIf(false)] bool condition, string? message)
-	{
-	}
+		=> Assert(condition, message, null);
 
 	[Conditional("DEBUG")]
 	public static void Assert([DoesNotReturnIf(false)] bool condition, string? message, string? detailMessage)
 	{
+		if (!condition)
+			Fail(message, detailMessage);
 	}
 
 	[Conditional("DEBUG")]
 	public static void Assert([DoesNotReturnIf(false)] bool condition, string? message, [StringSyntax("CompositeFormat")] string detailMessageFormat, params object?[] args)
-	{
-	}
+		=> throw new NotImplementedException();
 
 	[Conditional("DEBUG")]
-	public static void Close()
-	{
-	}
+	public static void Close() => throw new NotImplementedException();
 
 	[DoesNotReturn]
 	[Conditional("DEBUG")]
-	public static void Fail(string? message)
-	{
-		throw null;
-	}
+	public static void Fail(string? message) => Fail(message, null);
 
 	[DoesNotReturn]
 	[Conditional("DEBUG")]
 	public static void Fail(string? message, string? detailMessage)
-	{
-		throw null;
-	}
+		=> Environment.FailFast(string.Format(
+			Internal.Impl.Debug.FailText,
+			message ?? Internal.Impl.Debug.NoMessage,
+			detailMessage ?? Internal.Impl.Debug.NoDetails));
 
 	[Conditional("DEBUG")]
-	public static void Flush()
-	{
-	}
+	public static void Flush() => throw new NotImplementedException();
 
 	[Conditional("DEBUG")]
-	public static void Indent()
-	{
-	}
+	public static void Indent() => IndentLevel++;
 
 	[Conditional("DEBUG")]
-	public static void Print(string? message)
-	{
-	}
+	public static void Print(string? message) => Write(message);
 
 	[Conditional("DEBUG")]
 	public static void Print([StringSyntax("CompositeFormat")] string format, params object?[] args)
-	{
-	}
+		=> throw new NotImplementedException();
 
 	[Conditional("DEBUG")]
 	public static void Unindent()
-	{
-	}
+		=> IndentLevel--;
 
 	[Conditional("DEBUG")]
-	public static void Write(object? value)
-	{
-	}
+	public static void Write(object? value) => Write(value, string.Empty);
 
 	[Conditional("DEBUG")]
 	public static void Write(object? value, string? category)
-	{
-	}
+		=> Write(string.Format(Internal.Impl.Debug.WriteText,
+			category ?? Internal.Impl.Debug.NoCategory,
+			value ?? Internal.Impl.Debug.NoValue));
 
 	[Conditional("DEBUG")]
-	public static void Write(string? message)
-	{
-	}
+	public static void Write(string? message) => Write(message, "");
 
 	[Conditional("DEBUG")]
 	public static void Write(string? message, string? category)
-	{
-	}
+		=> Write(string.Format(Internal.Impl.Debug.WriteText,
+			category ?? Internal.Impl.Debug.NoCategory,
+			message ?? Internal.Impl.Debug.NoMessage));
 
 	[Conditional("DEBUG")]
 	public static void WriteIf(bool condition, [InterpolatedStringHandlerArgument("condition")] ref WriteIfInterpolatedStringHandler message)
-	{
-	}
+		=> throw new NotImplementedException();
 
 	[Conditional("DEBUG")]
 	public static void WriteIf(bool condition, [InterpolatedStringHandlerArgument("condition")] ref WriteIfInterpolatedStringHandler message, string? category)
-	{
-	}
+		=> throw new NotImplementedException();
 
 	[Conditional("DEBUG")]
 	public static void WriteIf(bool condition, object? value)
 	{
+		if (condition)
+			Write(value, null);
 	}
 
 	[Conditional("DEBUG")]
 	public static void WriteIf(bool condition, object? value, string? category)
 	{
+		if (condition)
+			Write(value, category);
 	}
 
 	[Conditional("DEBUG")]
 	public static void WriteIf(bool condition, string? message)
 	{
+		if (condition)
+			Write(message, null);
 	}
 
 	[Conditional("DEBUG")]
 	public static void WriteIf(bool condition, string? message, string? category)
 	{
+		if (condition)
+			Write(message, category);
 	}
 
 	[Conditional("DEBUG")]
-	public static void WriteLine(object? value)
-	{
-	}
+	public static void WriteLine(object? value) => throw new NotImplementedException();
 
 	[Conditional("DEBUG")]
 	public static void WriteLine(object? value, string? category)
-	{
-	}
+		=> WriteLine(Internal.Impl.Debug.WriteText,
+			category ?? Internal.Impl.Debug.NoCategory,
+			value ?? Internal.Impl.Debug.NoValue);
 
 	[Conditional("DEBUG")]
-	public static void WriteLine(string? message)
-	{
-	}
+	public static void WriteLine(string? message) => throw new NotImplementedException();
 
 	[Conditional("DEBUG")]
 	public static void WriteLine([StringSyntax("CompositeFormat")] string format, params object?[] args)
-	{
-	}
+		=> throw new NotImplementedException();
 
 	[Conditional("DEBUG")]
 	public static void WriteLine(string? message, string? category)
-	{
-	}
+		=> WriteLine(Internal.Impl.Debug.WriteText,
+			category ?? Internal.Impl.Debug.NoCategory,
+			message ?? Internal.Impl.Debug.NoMessage);
 
 	[Conditional("DEBUG")]
-	public static void WriteLineIf(bool condition, [InterpolatedStringHandlerArgument("condition")] ref WriteIfInterpolatedStringHandler message)
-	{
-	}
+	public static void WriteLineIf(bool condition, [InterpolatedStringHandlerArgument("condition")] ref WriteIfInterpolatedStringHandler message) =>
+		throw new NotImplementedException();
 
 	[Conditional("DEBUG")]
 	public static void WriteLineIf(bool condition, [InterpolatedStringHandlerArgument("condition")] ref WriteIfInterpolatedStringHandler message, string? category)
-	{
-	}
+		=> throw new NotImplementedException();
 
 	[Conditional("DEBUG")]
 	public static void WriteLineIf(bool condition, object? value)
 	{
+		if (condition)
+			WriteLine(value);
 	}
 
 	[Conditional("DEBUG")]
 	public static void WriteLineIf(bool condition, object? value, string? category)
 	{
+		if (condition)
+			WriteLine(value, category);
 	}
 
 	[Conditional("DEBUG")]
 	public static void WriteLineIf(bool condition, string? message)
 	{
+		if (condition)
+			WriteLine(message);
 	}
 
 	[Conditional("DEBUG")]
 	public static void WriteLineIf(bool condition, string? message, string? category)
 	{
+		if (condition)
+			WriteLine(message, category);
 	}
 }

--- a/Source/Mosa.TinyCoreLib/System.Reflection/ConstructorInfo.cs
+++ b/Source/Mosa.TinyCoreLib/System.Reflection/ConstructorInfo.cs
@@ -4,9 +4,9 @@ namespace System.Reflection;
 
 public abstract class ConstructorInfo : MethodBase
 {
-	public static readonly string ConstructorName;
+	public static readonly string ConstructorName = Internal.Impl.ConstructorInfo.ConstructorName;
 
-	public static readonly string TypeConstructorName;
+	public static readonly string TypeConstructorName = Internal.Impl.ConstructorInfo.TypeConstructorName;
 
 	public override MemberTypes MemberType
 	{

--- a/Source/Mosa.TinyCoreLib/System.Reflection/CustomAttributeData.cs
+++ b/Source/Mosa.TinyCoreLib/System.Reflection/CustomAttributeData.cs
@@ -4,13 +4,7 @@ namespace System.Reflection;
 
 public class CustomAttributeData
 {
-	public virtual Type AttributeType
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public virtual Type AttributeType { get; }
 
 	public virtual ConstructorInfo Constructor
 	{
@@ -20,21 +14,9 @@ public class CustomAttributeData
 		}
 	}
 
-	public virtual IList<CustomAttributeTypedArgument> ConstructorArguments
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public virtual IList<CustomAttributeTypedArgument> ConstructorArguments { get; }
 
-	public virtual IList<CustomAttributeNamedArgument> NamedArguments
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public virtual IList<CustomAttributeNamedArgument> NamedArguments { get; }
 
 	protected CustomAttributeData()
 	{

--- a/Source/Mosa.TinyCoreLib/System.Reflection/FieldInfo.cs
+++ b/Source/Mosa.TinyCoreLib/System.Reflection/FieldInfo.cs
@@ -10,86 +10,26 @@ public abstract class FieldInfo : MemberInfo
 
 	public abstract Type FieldType { get; }
 
-	public bool IsAssembly
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsAssembly => (Attributes & FieldAttributes.FieldAccessMask) == FieldAttributes.Assembly;
 
-	public bool IsFamily
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsFamily => (Attributes & FieldAttributes.FieldAccessMask) == FieldAttributes.Family;
 
-	public bool IsFamilyAndAssembly
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsFamilyAndAssembly => (Attributes & FieldAttributes.FieldAccessMask) == FieldAttributes.FamANDAssem;
 
-	public bool IsFamilyOrAssembly
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsFamilyOrAssembly => (Attributes & FieldAttributes.FieldAccessMask) == FieldAttributes.FamORAssem;
 
-	public bool IsInitOnly
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsInitOnly => (Attributes & FieldAttributes.InitOnly) == FieldAttributes.InitOnly;
 
-	public bool IsLiteral
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsLiteral => (Attributes & FieldAttributes.Literal) == FieldAttributes.Literal;
 
 	[Obsolete("Formatter-based serialization is obsolete and should not be used.", DiagnosticId = "SYSLIB0050", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
-	public bool IsNotSerialized
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsNotSerialized => (Attributes & FieldAttributes.NotSerialized) == FieldAttributes.NotSerialized;
 
-	public bool IsPinvokeImpl
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsPinvokeImpl => (Attributes & FieldAttributes.PinvokeImpl) == FieldAttributes.PinvokeImpl;
 
-	public bool IsPrivate
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsPrivate => (Attributes & FieldAttributes.FieldAccessMask) == FieldAttributes.Private;
 
-	public bool IsPublic
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsPublic => (Attributes & FieldAttributes.FieldAccessMask) == FieldAttributes.Public;
 
 	public virtual bool IsSecurityCritical
 	{
@@ -115,21 +55,9 @@ public abstract class FieldInfo : MemberInfo
 		}
 	}
 
-	public bool IsSpecialName
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsSpecialName => (Attributes & FieldAttributes.SpecialName) == FieldAttributes.SpecialName;
 
-	public bool IsStatic
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsStatic => (Attributes & FieldAttributes.Static) == FieldAttributes.Static;
 
 	public override MemberTypes MemberType
 	{

--- a/Source/Mosa.TinyCoreLib/System.Reflection/IntrospectionExtensions.cs
+++ b/Source/Mosa.TinyCoreLib/System.Reflection/IntrospectionExtensions.cs
@@ -6,8 +6,5 @@ namespace System.Reflection;
 public static class IntrospectionExtensions
 {
 	[EditorBrowsable(EditorBrowsableState.Never)]
-	public static TypeInfo GetTypeInfo(this Type type)
-	{
-		throw null;
-	}
+	public static TypeInfo GetTypeInfo(this Type type) => throw new NotImplementedException();
 }

--- a/Source/Mosa.TinyCoreLib/System.Reflection/MethodBase.cs
+++ b/Source/Mosa.TinyCoreLib/System.Reflection/MethodBase.cs
@@ -23,21 +23,9 @@ public abstract class MethodBase : MemberInfo
 		}
 	}
 
-	public bool IsAbstract
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsAbstract => (Attributes & MethodAttributes.Abstract) == MethodAttributes.Abstract;
 
-	public bool IsAssembly
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsAssembly => (Attributes & MethodAttributes.MemberAccessMask) == MethodAttributes.Assembly;
 
 	public virtual bool IsConstructedGenericMethod
 	{
@@ -47,45 +35,16 @@ public abstract class MethodBase : MemberInfo
 		}
 	}
 
-	public bool IsConstructor
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsConstructor => this is ConstructorInfo && !IsStatic && (Attributes & MethodAttributes.RTSpecialName)
+		== MethodAttributes.RTSpecialName;
 
-	public bool IsFamily
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsFamily => (Attributes & MethodAttributes.MemberAccessMask) == MethodAttributes.Family;
 
-	public bool IsFamilyAndAssembly
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsFamilyAndAssembly => (Attributes & MethodAttributes.MemberAccessMask) == MethodAttributes.FamANDAssem;
 
-	public bool IsFamilyOrAssembly
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsFamilyOrAssembly => (Attributes & MethodAttributes.MemberAccessMask) == MethodAttributes.FamORAssem;
 
-	public bool IsFinal
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsFinal => (Attributes & MethodAttributes.Final) == MethodAttributes.Final;
 
 	public virtual bool IsGenericMethod
 	{
@@ -103,29 +62,11 @@ public abstract class MethodBase : MemberInfo
 		}
 	}
 
-	public bool IsHideBySig
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsHideBySig => (Attributes & MethodAttributes.HideBySig) == MethodAttributes.HideBySig;
 
-	public bool IsPrivate
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsPrivate => (Attributes & MethodAttributes.MemberAccessMask) == MethodAttributes.Private;
 
-	public bool IsPublic
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsPublic => (Attributes & MethodAttributes.MemberAccessMask) == MethodAttributes.Public;
 
 	public virtual bool IsSecurityCritical
 	{
@@ -151,29 +92,11 @@ public abstract class MethodBase : MemberInfo
 		}
 	}
 
-	public bool IsSpecialName
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsSpecialName => (Attributes & MethodAttributes.SpecialName) == MethodAttributes.SpecialName;
 
-	public bool IsStatic
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsStatic => (Attributes & MethodAttributes.Static) == MethodAttributes.Static;
 
-	public bool IsVirtual
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsVirtual => (Attributes & MethodAttributes.Virtual) == MethodAttributes.Virtual;
 
 	public abstract RuntimeMethodHandle MethodHandle { get; }
 

--- a/Source/Mosa.TinyCoreLib/System.Reflection/ParameterInfo.cs
+++ b/Source/Mosa.TinyCoreLib/System.Reflection/ParameterInfo.cs
@@ -42,53 +42,17 @@ public class ParameterInfo : ICustomAttributeProvider, IObjectReference
 		}
 	}
 
-	public virtual bool HasDefaultValue
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public virtual bool HasDefaultValue => (Attributes & ParameterAttributes.HasDefault) == ParameterAttributes.HasDefault;
 
-	public bool IsIn
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsIn => (Attributes & ParameterAttributes.In) == ParameterAttributes.In;
 
-	public bool IsLcid
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsLcid => (Attributes & ParameterAttributes.Lcid) == ParameterAttributes.Lcid;
 
-	public bool IsOptional
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsOptional => (Attributes & ParameterAttributes.Optional) == ParameterAttributes.Optional;
 
-	public bool IsOut
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsOut => (Attributes & ParameterAttributes.Out) == ParameterAttributes.Out;
 
-	public bool IsRetval
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsRetval => (Attributes & ParameterAttributes.Retval) == ParameterAttributes.Retval;
 
 	public virtual MemberInfo Member
 	{

--- a/Source/Mosa.TinyCoreLib/System.Reflection/PropertyInfo.cs
+++ b/Source/Mosa.TinyCoreLib/System.Reflection/PropertyInfo.cs
@@ -18,13 +18,7 @@ public abstract class PropertyInfo : MemberInfo
 		}
 	}
 
-	public bool IsSpecialName
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public bool IsSpecialName => (Attributes & PropertyAttributes.SpecialName) == PropertyAttributes.SpecialName;
 
 	public override MemberTypes MemberType
 	{

--- a/Source/Mosa.TinyCoreLib/System.Runtime.CompilerServices/RuntimeHelpers.cs
+++ b/Source/Mosa.TinyCoreLib/System.Runtime.CompilerServices/RuntimeHelpers.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Internal;
 
 namespace System.Runtime.CompilerServices;
 
@@ -31,20 +32,14 @@ public static class RuntimeHelpers
 	{
 	}
 
-	public new static bool Equals(object? o1, object? o2)
-	{
-		throw null;
-	}
+	public new static bool Equals(object? o1, object? o2) => Impl.RuntimeHelpers.Equals(o1, o2);
 
 	[Obsolete("The Constrained Execution Region (CER) feature is not supported.", DiagnosticId = "SYSLIB0004", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 	public static void ExecuteCodeWithGuaranteedCleanup(TryCode code, CleanupCode backoutCode, object? userData)
 	{
 	}
 
-	public static int GetHashCode(object? o)
-	{
-		throw null;
-	}
+	public static int GetHashCode(object? o) => Impl.RuntimeHelpers.GetHashCode(o);
 
 	[return: NotNullIfNotNull("obj")]
 	public static object? GetObjectValue(object? obj)
@@ -63,13 +58,9 @@ public static class RuntimeHelpers
 	}
 
 	public static void InitializeArray(Array array, RuntimeFieldHandle fldHandle)
-	{
-	}
+		=> Impl.RuntimeHelpers.InitializeArray(array, fldHandle);
 
-	public static bool IsReferenceOrContainsReferences<T>()
-	{
-		throw null;
-	}
+	public static bool IsReferenceOrContainsReferences<T>() => Impl.RuntimeHelpers.IsReferenceOrContainsReferences<T>();
 
 	[Obsolete("The Constrained Execution Region (CER) feature is not supported.", DiagnosticId = "SYSLIB0004", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 	public static void PrepareConstrainedRegions()

--- a/Source/Mosa.TinyCoreLib/System.Runtime.Intrinsics.X86/Bmi1.cs
+++ b/Source/Mosa.TinyCoreLib/System.Runtime.Intrinsics.X86/Bmi1.cs
@@ -1,3 +1,5 @@
+using Internal;
+
 namespace System.Runtime.Intrinsics.X86;
 
 [CLSCompliant(false)]
@@ -5,98 +7,44 @@ public abstract class Bmi1 : X86Base
 {
 	public new abstract class X64 : X86Base.X64
 	{
-		public new static bool IsSupported
-		{
-			get
-			{
-				throw null;
-			}
-		}
+		public new static bool IsSupported => throw new NotImplementedException();
 
 		internal X64()
 		{
 		}
 
-		public static ulong AndNot(ulong left, ulong right)
-		{
-			throw null;
-		}
+		public static ulong AndNot(ulong left, ulong right) => throw new NotImplementedException();
 
-		public static ulong BitFieldExtract(ulong value, byte start, byte length)
-		{
-			throw null;
-		}
+		public static ulong BitFieldExtract(ulong value, byte start, byte length) => throw new NotImplementedException();
 
-		public static ulong BitFieldExtract(ulong value, ushort control)
-		{
-			throw null;
-		}
+		public static ulong BitFieldExtract(ulong value, ushort control) => throw new NotImplementedException();
 
-		public static ulong ExtractLowestSetBit(ulong value)
-		{
-			throw null;
-		}
+		public static ulong ExtractLowestSetBit(ulong value) => throw new NotImplementedException();
 
-		public static ulong GetMaskUpToLowestSetBit(ulong value)
-		{
-			throw null;
-		}
+		public static ulong GetMaskUpToLowestSetBit(ulong value) => throw new NotImplementedException();
 
-		public static ulong ResetLowestSetBit(ulong value)
-		{
-			throw null;
-		}
+		public static ulong ResetLowestSetBit(ulong value) => throw new NotImplementedException();
 
-		public static ulong TrailingZeroCount(ulong value)
-		{
-			throw null;
-		}
+		public static ulong TrailingZeroCount(ulong value) => throw new NotImplementedException();
 	}
 
-	public new static bool IsSupported
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public new static bool IsSupported => throw new NotImplementedException();
 
 	internal Bmi1()
 	{
 	}
 
-	public static uint AndNot(uint left, uint right)
-	{
-		throw null;
-	}
+	public static uint AndNot(uint left, uint right) => throw new NotImplementedException();
 
-	public static uint BitFieldExtract(uint value, byte start, byte length)
-	{
-		throw null;
-	}
+	public static uint BitFieldExtract(uint value, byte start, byte length) => throw new NotImplementedException();
 
-	public static uint BitFieldExtract(uint value, ushort control)
-	{
-		throw null;
-	}
+	public static uint BitFieldExtract(uint value, ushort control) => throw new NotImplementedException();
 
-	public static uint ExtractLowestSetBit(uint value)
-	{
-		throw null;
-	}
+	public static uint ExtractLowestSetBit(uint value) => throw new NotImplementedException();
 
-	public static uint GetMaskUpToLowestSetBit(uint value)
-	{
-		throw null;
-	}
+	public static uint GetMaskUpToLowestSetBit(uint value) => throw new NotImplementedException();
 
-	public static uint ResetLowestSetBit(uint value)
-	{
-		throw null;
-	}
+	public static uint ResetLowestSetBit(uint value) => Impl.Bmi1.ResetLowestSetBit(value);
 
-	public static uint TrailingZeroCount(uint value)
-	{
-		throw null;
-	}
+	public static uint TrailingZeroCount(uint value) => Impl.Bmi1.TrailingZeroCount(value);
 }

--- a/Source/Mosa.TinyCoreLib/System.Runtime.Intrinsics.X86/Lzcnt.cs
+++ b/Source/Mosa.TinyCoreLib/System.Runtime.Intrinsics.X86/Lzcnt.cs
@@ -1,3 +1,5 @@
+using Internal;
+
 namespace System.Runtime.Intrinsics.X86;
 
 [CLSCompliant(false)]
@@ -5,38 +7,20 @@ public abstract class Lzcnt : X86Base
 {
 	public new abstract class X64 : X86Base.X64
 	{
-		public new static bool IsSupported
-		{
-			get
-			{
-				throw null;
-			}
-		}
+		public new static bool IsSupported => throw new NotImplementedException();
 
 		internal X64()
 		{
 		}
 
-		public static ulong LeadingZeroCount(ulong value)
-		{
-			throw null;
-		}
+		public static ulong LeadingZeroCount(ulong value) => throw new NotImplementedException();
 	}
 
-	public new static bool IsSupported
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public new static bool IsSupported => throw new NotImplementedException();
 
 	internal Lzcnt()
 	{
 	}
 
-	public static uint LeadingZeroCount(uint value)
-	{
-		throw null;
-	}
+	public static uint LeadingZeroCount(uint value) => Impl.Lzcnt.LeadingZeroCount(value);
 }

--- a/Source/Mosa.TinyCoreLib/System.Runtime.Intrinsics.X86/Popcnt.cs
+++ b/Source/Mosa.TinyCoreLib/System.Runtime.Intrinsics.X86/Popcnt.cs
@@ -1,3 +1,5 @@
+using Internal;
+
 namespace System.Runtime.Intrinsics.X86;
 
 [CLSCompliant(false)]
@@ -5,38 +7,20 @@ public abstract class Popcnt : Sse42
 {
 	public new abstract class X64 : Sse42.X64
 	{
-		public new static bool IsSupported
-		{
-			get
-			{
-				throw null;
-			}
-		}
+		public new static bool IsSupported => throw new NotImplementedException();
 
 		internal X64()
 		{
 		}
 
-		public static ulong PopCount(ulong value)
-		{
-			throw null;
-		}
+		public static ulong PopCount(ulong value) => throw new NotImplementedException();
 	}
 
-	public new static bool IsSupported
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public new static bool IsSupported => throw new NotImplementedException();
 
 	internal Popcnt()
 	{
 	}
 
-	public static uint PopCount(uint value)
-	{
-		throw null;
-	}
+	public static uint PopCount(uint value) => Impl.Popcnt.PopCount(value);
 }

--- a/Source/Mosa.TinyCoreLib/System/ConsoleKeyInfo.cs
+++ b/Source/Mosa.TinyCoreLib/System/ConsoleKeyInfo.cs
@@ -4,59 +4,31 @@ namespace System;
 
 public readonly struct ConsoleKeyInfo : IEquatable<ConsoleKeyInfo>
 {
-	private readonly int _dummyPrimitive;
+	public ConsoleKey Key { get; }
 
-	public ConsoleKey Key
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public char KeyChar { get; }
 
-	public char KeyChar
-	{
-		get
-		{
-			throw null;
-		}
-	}
-
-	public ConsoleModifiers Modifiers
-	{
-		get
-		{
-			throw null;
-		}
-	}
+	public ConsoleModifiers Modifiers { get; }
 
 	public ConsoleKeyInfo(char keyChar, ConsoleKey key, bool shift, bool alt, bool control)
 	{
-		throw null;
+		var modifiers = ConsoleModifiers.None;
+		if (shift) modifiers |= ConsoleModifiers.Shift;
+		if (alt) modifiers |= ConsoleModifiers.Alt;
+		if (control) modifiers |= ConsoleModifiers.Control;
+
+		KeyChar = keyChar;
+		Key = key;
+		Modifiers = modifiers;
 	}
 
-	public bool Equals(ConsoleKeyInfo obj)
-	{
-		throw null;
-	}
+	public bool Equals(ConsoleKeyInfo obj) => KeyChar == obj.KeyChar && Key == obj.Key && Modifiers == obj.Modifiers;
 
-	public override bool Equals([NotNullWhen(true)] object? value)
-	{
-		throw null;
-	}
+	public override bool Equals([NotNullWhen(true)] object? value) => value is ConsoleKeyInfo key && Equals(key);
 
-	public override int GetHashCode()
-	{
-		throw null;
-	}
+	public override int GetHashCode() => HashCode.Combine(KeyChar, Key, Modifiers);
 
-	public static bool operator ==(ConsoleKeyInfo a, ConsoleKeyInfo b)
-	{
-		throw null;
-	}
+	public static bool operator ==(ConsoleKeyInfo a, ConsoleKeyInfo b) => a.Equals(b);
 
-	public static bool operator !=(ConsoleKeyInfo a, ConsoleKeyInfo b)
-	{
-		throw null;
-	}
+	public static bool operator !=(ConsoleKeyInfo a, ConsoleKeyInfo b) => !a.Equals(b);
 }

--- a/Source/Mosa.TinyCoreLib/System/HashCode.cs
+++ b/Source/Mosa.TinyCoreLib/System/HashCode.cs
@@ -36,7 +36,7 @@ public struct HashCode
 
 	public static int Combine<T1, T2, T3, T4>(T1 value1, T2 value2, T3 value3, T4 value4)
 	{
-		throw null;
+		throw new NotImplementedException();
 	}
 
 	public static int Combine<T1, T2, T3, T4, T5>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5)

--- a/Source/Mosa.TinyCoreLib/System/Object.cs
+++ b/Source/Mosa.TinyCoreLib/System/Object.cs
@@ -2,42 +2,25 @@ namespace System;
 
 public class Object
 {
-	public virtual bool Equals(object? obj)
-	{
-		throw null;
-	}
+	public virtual bool Equals(object? obj) => Internal.Impl.RuntimeHelpers.Equals(this, obj);
 
-	public static bool Equals(object? objA, object? objB)
-	{
-		throw null;
-	}
+	public static bool Equals(object? objA, object? objB) => ReferenceEquals(objA, objB) || objA.Equals(objB);
 
-	~Object()
-	{
-	}
+	~Object() {}
 
-	public virtual int GetHashCode()
-	{
-		throw null;
-	}
+	public virtual int GetHashCode() => Internal.Impl.RuntimeHelpers.GetHashCode(this);
 
-	public Type GetType()
-	{
-		throw null;
-	}
+	public Type GetType() => Internal.Impl.Object.GetType(this);
 
-	protected object MemberwiseClone()
-	{
-		throw null;
-	}
+	protected object MemberwiseClone() => Internal.Impl.Object.MemberwiseClone(this);
 
 	public static bool ReferenceEquals(object? objA, object? objB)
 	{
-		throw null;
+		if (objA is null || objB is null)
+			return false;
+
+		return objA == objB;
 	}
 
-	public virtual string? ToString()
-	{
-		throw null;
-	}
+	public virtual string? ToString() => GetType().ToString();
 }

--- a/Source/Mosa.TinyCoreLib/System/Void.cs
+++ b/Source/Mosa.TinyCoreLib/System/Void.cs
@@ -3,6 +3,4 @@ using System.Runtime.InteropServices;
 namespace System;
 
 [StructLayout(LayoutKind.Sequential, Size = 1)]
-public struct Void
-{
-}
+public struct Void;


### PR DESCRIPTION
Hello! This PR implements various small methods, fields, etc. that were implemented in Mosa.Korlib. Namely, it implements them in the following classes:

**Internal**
- Impl (for platform-specific methods)
- IntrinsicAttribute (for the compiler)

**System**
- ConsoleKeyInfo
- HashCode
- Object
- Void

**System.Buffers**
- MemoryHandle

**System.Diagnostics**
- Debug

**System.Reflection**
- ConstructorInfo
- CustomAttributeData
- FieldInfo
- IntrospectionExtensions
- MethodBase
- ParameterInfo
- PropertyInfo

**System.Runtime.CompilerServices**
- RuntimeHelpers

**System.Runtime.Intrinsics.X86**
- Bmi1
- Lzcnt
- Popcnt